### PR TITLE
Handle AI credits exhaustion gracefully across scoring flows

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -976,9 +976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,9 +993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,9 +1010,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1027,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,9 +1044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,9 +1061,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,9 +1284,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1320,9 +1299,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1340,9 +1316,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,9 +1331,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3376,9 +3346,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3398,9 +3365,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3422,9 +3386,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3444,9 +3405,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/frontend/src/api/scoring.ts
+++ b/frontend/src/api/scoring.ts
@@ -1,0 +1,48 @@
+/**
+ * API client functions for AI scoring.
+ */
+
+const SCORE_API = "/api/score";
+
+export interface BatchScoreRequest {
+  profile_id: number;
+  discovered_job_ids?: number[];
+  rescore_stale?: boolean;
+}
+
+export interface BatchScoreResponse {
+  scored_count: number;
+  total_time_seconds: number;
+  credits_exhausted: boolean;
+  errors: Array<{ discovered_job_id: string; error: string }>;
+}
+
+/**
+ * Batch score discovered jobs. Returns partial results if credits run out.
+ */
+export async function batchScore(
+  params: BatchScoreRequest,
+): Promise<BatchScoreResponse> {
+  const resp = await fetch(`${SCORE_API}/batch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+
+  if (resp.status === 402) {
+    sessionStorage.setItem("credits_exhausted", "true");
+    throw new Error(
+      "AI scoring credits exhausted. Add credits at openrouter.ai",
+    );
+  }
+
+  if (!resp.ok) throw new Error(`Batch scoring failed: ${resp.status}`);
+
+  const data: BatchScoreResponse = await resp.json();
+
+  if (data.credits_exhausted) {
+    sessionStorage.setItem("credits_exhausted", "true");
+  }
+
+  return data;
+}

--- a/frontend/src/pages/Discovery.tsx
+++ b/frontend/src/pages/Discovery.tsx
@@ -32,6 +32,7 @@ import {
   X,
   Trash2,
   SlidersHorizontal,
+  AlertTriangle,
 } from "lucide-react";
 
 // ---------------------------------------------------------------------------
@@ -507,6 +508,9 @@ export function Discovery() {
   const [page, setPage] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [creditsExhausted, setCreditsExhausted] = useState(
+    () => sessionStorage.getItem("credits_exhausted") === "true",
+  );
 
   // Debounce search input
   const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
@@ -733,6 +737,43 @@ export function Discovery() {
           onFiltersChange={handleFiltersChange}
           onClear={clearFilters}
         />
+      )}
+
+      {/* Credits exhausted banner */}
+      {creditsExhausted && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-start justify-between">
+            <div className="flex gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+              <div>
+                <h3 className="text-sm font-semibold text-amber-800">
+                  AI Scoring Stopped
+                </h3>
+                <p className="mt-1 text-sm text-amber-700">
+                  OpenRouter credits have been exhausted. Some jobs may not have
+                  scores.{" "}
+                  <a
+                    href="https://openrouter.ai"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium underline hover:text-amber-900"
+                  >
+                    Add credits at openrouter.ai
+                  </a>
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                setCreditsExhausted(false);
+                sessionStorage.removeItem("credits_exhausted");
+              }}
+              className="ml-4 text-amber-400 hover:text-amber-600"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
       )}
 
       {/* Loading state */}

--- a/src/career_os/ai/__init__.py
+++ b/src/career_os/ai/__init__.py
@@ -3,10 +3,11 @@
 from career_os.ai.base import AIProvider
 from career_os.ai.factory import UnsupportedProviderError, get_ai_provider
 from career_os.ai.mock_provider import MockProvider
-from career_os.ai.openrouter_provider import OpenRouterProvider
+from career_os.ai.openrouter_provider import CreditsExhaustedError, OpenRouterProvider
 
 __all__ = [
     "AIProvider",
+    "CreditsExhaustedError",
     "MockProvider",
     "OpenRouterProvider",
     "UnsupportedProviderError",

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -30,6 +30,20 @@ OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "anthropic/claude-sonnet-4"
 
 
+class CreditsExhaustedError(Exception):
+    """Raised when OpenRouter returns 402 or 429 indicating credits/quota exhaustion."""
+
+    def __init__(self, status_code: int, detail: str = "") -> None:
+        self.status_code = status_code
+        message = (
+            f"OpenRouter credits exhausted (HTTP {status_code}). "
+            "Add credits at https://openrouter.ai"
+        )
+        if detail:
+            message += f": {detail}"
+        super().__init__(message)
+
+
 class OpenRouterProvider(AIProvider):
     """AI provider backed by OpenRouter API."""
 
@@ -81,6 +95,16 @@ class OpenRouterProvider(AIProvider):
                 },
                 json=payload,
             )
+            if response.status_code in (402, 429):
+                detail = ""
+                try:
+                    body = response.json()
+                    detail = body.get("error", {}).get("message", "")
+                except Exception:
+                    pass
+                raise CreditsExhaustedError(
+                    status_code=response.status_code, detail=detail
+                )
             response.raise_for_status()
             data = response.json()
 

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -1,8 +1,11 @@
 """Scoring API routes — AI-powered job scoring engine."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.ai.openrouter_provider import CreditsExhaustedError
 from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
@@ -12,6 +15,7 @@ from career_os.schemas.scoring import (
     ScoringWeightsResponse,
     ScoringWeightsUpdate,
 )
+from career_os.services.pushover import send_credits_exhausted_alert
 from career_os.services.scoring import (
     JobNotFoundError,
     ProfileNotFoundError,
@@ -24,6 +28,8 @@ from career_os.services.scoring import (
     score_job,
     update_weights,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["scoring"])
 
@@ -59,6 +65,11 @@ async def score_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except JobNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CreditsExhaustedError as exc:
+        raise HTTPException(
+            status_code=402,
+            detail="AI scoring credits exhausted. Add credits at https://openrouter.ai",
+        ) from exc
     except ScoringError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except Exception as exc:
@@ -134,11 +145,25 @@ async def batch_score_endpoint(
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Batch scoring error: {exc}") from exc
 
+    credits_exhausted = result.get("credits_exhausted", False)
+
+    if credits_exhausted:
+        try:
+            send_credits_exhausted_alert(
+                db,
+                profile_id=payload.profile_id,
+                scored_count=result["scored_count"],
+                total_count=result["scored_count"] + len(result.get("errors", [])),
+            )
+        except Exception:
+            logger.warning("Could not send Pushover notification for credits exhausted")
+
     return BatchScoreResponse(
         scored_count=result["scored_count"],
         total_time_seconds=result["total_time_seconds"],
         scores=[ScoreResponse.model_validate(s) for s in result["scores"]],
         errors=result["errors"],
+        credits_exhausted=credits_exhausted,
     )
 
 

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -154,3 +154,7 @@ class BatchScoreResponse(BaseModel):
     errors: list[dict[str, str]] = Field(
         default_factory=list, description="Scoring errors for individual jobs"
     )
+    credits_exhausted: bool = Field(
+        default=False,
+        description="True if scoring stopped due to AI provider credits being exhausted",
+    )

--- a/src/career_os/services/pushover.py
+++ b/src/career_os/services/pushover.py
@@ -804,6 +804,45 @@ def send_test_notification(
 
 
 # ---------------------------------------------------------------------------
+# Alert: AI credits exhausted
+# ---------------------------------------------------------------------------
+
+
+def send_credits_exhausted_alert(
+    db: Session,
+    *,
+    profile_id: int,
+    scored_count: int,
+    total_count: int,
+) -> dict:
+    """Send a high-priority notification when AI credits are exhausted mid-scoring.
+
+    Gracefully no-ops when Pushover is not configured.
+    """
+    try:
+        client = _get_pushover_client(db)
+    except PushoverNotConfiguredError:
+        return {"status": "skipped", "reason": "pushover not configured"}
+
+    title = "AI Scoring Stopped"
+    message = (
+        f"OpenRouter credits exhausted during batch scoring. "
+        f"{scored_count} of {total_count} jobs were scored before credits ran out.\n\n"
+        f"Add credits at https://openrouter.ai"
+    )
+
+    return _send_and_log(
+        db,
+        client,
+        profile_id=profile_id,
+        category="scoring",
+        title=title,
+        message=message,
+        priority=PRIORITY_HIGH,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test Pushover connection (with actual API call)
 # ---------------------------------------------------------------------------
 

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -14,6 +14,7 @@ import time
 from sqlalchemy.orm import Session
 
 from career_os.ai.factory import get_ai_provider
+from career_os.ai.openrouter_provider import CreditsExhaustedError
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
 from career_os.models.scoring import ScoredJob, ScoringWeights
@@ -492,6 +493,7 @@ async def batch_score_discovery(
 
     scores: list[ScoredJob] = []
     errors: list[dict[str, str]] = []
+    credits_exhausted = False
 
     for job in jobs:
         try:
@@ -507,6 +509,14 @@ async def batch_score_discovery(
                 application_id=job.application_id,
             )
             scores.append(scored)
+        except CreditsExhaustedError:
+            logger.warning(
+                "AI credits exhausted after scoring %d/%d jobs — stopping batch",
+                len(scores),
+                len(jobs),
+            )
+            credits_exhausted = True
+            break
         except Exception as exc:
             logger.warning("Failed to score job %d: %s", job.id, exc)
             errors.append(
@@ -523,6 +533,7 @@ async def batch_score_discovery(
         "total_time_seconds": round(total_time, 2),
         "scores": scores,
         "errors": errors,
+        "credits_exhausted": credits_exhausted,
     }
 
 

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -198,6 +198,31 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
             job["review_reason"] = result.get("review_reason", "")
 
         except Exception as e:
+            status_code = getattr(e, "status_code", None)
+            error_str = str(e)
+
+            if status_code in (402, 429) or "insufficient_quota" in error_str.lower():
+                logger.error(
+                    f"AI credits exhausted after scoring {len(scored)}/{total} jobs — stopping. "
+                    "Add credits at https://openrouter.ai"
+                )
+                job["fit_score"] = 0
+                job["fit_reasoning"] = "Not scored: AI credits exhausted"
+                job["estimated_salary"] = "unknown"
+                job["effort_flag"] = "unknown"
+                job["prep_level"] = 0
+                job["prep_notes"] = ""
+                scored.append(job)
+                for remaining_job in jobs[i + 1 :]:
+                    remaining_job["fit_score"] = 0
+                    remaining_job["fit_reasoning"] = "Not scored: AI credits exhausted"
+                    remaining_job["estimated_salary"] = "unknown"
+                    remaining_job["effort_flag"] = "unknown"
+                    remaining_job["prep_level"] = 0
+                    remaining_job["prep_notes"] = ""
+                    scored.append(remaining_job)
+                break
+
             logger.warning(f"Scoring failed for {title} @ {company}: {e}")
             job["fit_score"] = 2  # Default to 2, not 5 -- unknown jobs shouldn't pass
             job["fit_reasoning"] = f"Scoring error: {e}"


### PR DESCRIPTION
## Summary
This PR adds comprehensive handling for AI provider credit exhaustion across the scoring system. When OpenRouter credits run out during batch scoring operations, the system now gracefully stops scoring, notifies the user, sends alerts, and allows the pipeline to continue with partial results.

## Key Changes

- **New `CreditsExhaustedError` exception** in `openrouter_provider.py` to explicitly handle 402/429 HTTP responses from OpenRouter API
- **Frontend API client** (`frontend/src/api/scoring.ts`) for batch scoring with `credits_exhausted` flag in response
- **Credits exhaustion banner** in Discovery page that displays when credits run out, with link to add credits and dismissible UI
- **Backend batch scoring** now catches `CreditsExhaustedError`, stops processing remaining jobs, and returns partial results with `credits_exhausted=true`
- **Pushover notifications** via new `send_credits_exhausted_alert()` function to notify users when credits are exhausted mid-batch
- **Daily pipeline resilience** (`tools/daily_pipeline.py`) to gracefully handle credit exhaustion by marking remaining jobs as unscored and continuing execution
- **Schema updates** to include `credits_exhausted` flag in `BatchScoreResponse`

## Implementation Details

- HTTP 402 (Payment Required) and 429 (Too Many Requests) responses from OpenRouter trigger the new exception
- Session storage flag (`credits_exhausted`) persists the state across page reloads
- Batch scoring returns all successfully scored jobs before stopping, enabling partial result processing
- Pipeline continues execution with remaining jobs marked as "Not scored: AI credits exhausted" rather than failing completely
- Pushover alerts include scored count vs. total count for visibility into partial completion

https://claude.ai/code/session_012uGi51ndafU1M3PuGoD9hx