### PR TITLE
Add visual previews to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Free with a GitHub account. Your own instance in 2 minutes. Nothing installed on
 
 ---
 
+## Preview
+
+<p align="center">
+  <strong>Pipeline — drag applications across stages</strong><br><br>
+  <img src="docs/images/preview-pipeline.svg" alt="Kanban board showing job applications across pipeline stages" width="820">
+</p>
+
+<p align="center">
+  <strong>Discovery — AI-scored job matches</strong><br><br>
+  <img src="docs/images/preview-discovery.svg" alt="Discovery page showing scored job listings from multiple boards" width="820">
+</p>
+
+<p align="center">
+  <strong>Settings — connect your integrations</strong><br><br>
+  <img src="docs/images/preview-settings.svg" alt="Settings page showing integration configuration" width="820">
+</p>
+
+---
+
 ## What it does
 
 - **Discovers jobs** from multiple boards automatically (Indeed, LinkedIn, Glassdoor, Arbeitsagentur)

--- a/docs/images/preview-discovery.svg
+++ b/docs/images/preview-discovery.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="920" height="520" rx="12" fill="#f8fafc"/>
+  <rect width="920" height="520" rx="12" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Top Nav Bar -->
+  <rect width="920" height="48" rx="12" fill="#ffffff"/>
+  <rect y="40" width="920" height="8" fill="#ffffff"/>
+  <line x1="0" y1="48" x2="920" y2="48" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="20" y="30" font-size="15" font-weight="700" fill="#0f172a">Kestrel</text>
+  <text x="95" y="30" font-size="11" fill="#64748b">Pipeline</text>
+  <rect x="155" y="12" width="72" height="26" rx="6" fill="#f1f5f9"/>
+  <text x="168" y="30" font-size="11" font-weight="600" fill="#3b82f6">Discovery</text>
+  <text x="242" y="30" font-size="11" fill="#64748b">Follow-Ups</text>
+  <text x="319" y="30" font-size="11" fill="#64748b">Contacts</text>
+  <text x="385" y="30" font-size="11" fill="#64748b">Analytics</text>
+  <text x="452" y="30" font-size="11" fill="#64748b">Settings</text>
+
+  <!-- Page Header -->
+  <text x="24" y="78" font-size="18" font-weight="700" fill="#0f172a">Discovered Jobs</text>
+  <text x="168" y="78" font-size="14" fill="#94a3b8">(23)</text>
+
+  <!-- Search Bar -->
+  <rect x="24" y="90" width="580" height="34" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="44" y="112" font-size="12" fill="#94a3b8">Search jobs by title, company, description...</text>
+  <!-- Search icon -->
+  <circle cx="35" cy="107" r="5" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+  <line x1="39" y1="111" x2="42" y2="114" stroke="#94a3b8" stroke-width="1.5"/>
+
+  <!-- Sort & Filter Controls -->
+  <rect x="614" y="90" width="100" height="34" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="630" y="112" font-size="11" fill="#64748b">Sort: Score</text>
+  <rect x="722" y="90" width="80" height="34" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="738" y="112" font-size="11" fill="#64748b">Filters</text>
+  <rect x="810" y="90" width="90" height="34" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="822" y="112" font-size="11" font-weight="500" fill="#3b82f6">Save Search</text>
+
+  <!-- Job Card 1 -->
+  <rect x="24" y="136" width="876" height="88" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="40" y="162" font-size="14" font-weight="600" fill="#0f172a">Senior Backend Engineer</text>
+  <text x="40" y="180" font-size="11" fill="#64748b">Stripe</text>
+  <text x="90" y="180" font-size="11" fill="#64748b">San Francisco, CA</text>
+  <rect x="215" y="169" width="52" height="16" rx="4" fill="#dcfce7"/>
+  <text x="223" y="180" font-size="9" font-weight="500" fill="#16a34a">Remote</text>
+  <text x="40" y="198" font-size="10" fill="#94a3b8">Build and scale payment infrastructure serving millions of businesses worldwide. Design distributed systems...</text>
+  <rect x="40" y="206" width="80" height="16" rx="4" fill="#eff6ff"/>
+  <text x="48" y="217" font-size="9" fill="#3b82f6">$190k - $250k</text>
+  <rect x="126" y="206" width="52" height="16" rx="4" fill="#f1f5f9"/>
+  <text x="134" y="217" font-size="9" fill="#64748b">LinkedIn</text>
+  <rect x="184" y="206" width="44" height="16" rx="4" fill="#f1f5f9"/>
+  <text x="192" y="217" font-size="9" fill="#64748b">Indeed</text>
+  <!-- Score -->
+  <text x="830" y="160" font-size="20" font-weight="700" fill="#16a34a">9.2</text>
+  <text x="860" y="160" font-size="11" fill="#16a34a">★</text>
+  <rect x="818" y="168" width="62" height="18" rx="4" fill="#dcfce7"/>
+  <text x="826" y="181" font-size="10" font-weight="500" fill="#16a34a">88% ready</text>
+  <text x="840" y="200" font-size="9" fill="#94a3b8">2 days ago</text>
+
+  <!-- Job Card 2 -->
+  <rect x="24" y="232" width="876" height="88" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="40" y="258" font-size="14" font-weight="600" fill="#0f172a">Staff Software Engineer</text>
+  <text x="40" y="276" font-size="11" fill="#64748b">GitHub</text>
+  <text x="88" y="276" font-size="11" fill="#64748b">Remote - US</text>
+  <rect x="170" y="265" width="52" height="16" rx="4" fill="#dcfce7"/>
+  <text x="178" y="276" font-size="9" font-weight="500" fill="#16a34a">Remote</text>
+  <text x="40" y="294" font-size="10" fill="#94a3b8">Lead architecture for developer collaboration features. Work across teams on real-time systems and APIs...</text>
+  <rect x="40" y="302" width="80" height="16" rx="4" fill="#eff6ff"/>
+  <text x="48" y="313" font-size="9" fill="#3b82f6">$200k - $280k</text>
+  <rect x="126" y="302" width="52" height="16" rx="4" fill="#f1f5f9"/>
+  <text x="134" y="313" font-size="9" fill="#64748b">LinkedIn</text>
+  <!-- Score -->
+  <text x="830" y="256" font-size="20" font-weight="700" fill="#16a34a">8.7</text>
+  <text x="860" y="256" font-size="11" fill="#16a34a">★</text>
+  <rect x="818" y="264" width="62" height="18" rx="4" fill="#dcfce7"/>
+  <text x="826" y="277" font-size="10" font-weight="500" fill="#16a34a">82% ready</text>
+  <text x="840" y="296" font-size="9" fill="#94a3b8">3 days ago</text>
+
+  <!-- Job Card 3 -->
+  <rect x="24" y="328" width="876" height="88" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="40" y="354" font-size="14" font-weight="600" fill="#0f172a">Platform Engineer</text>
+  <text x="40" y="372" font-size="11" fill="#64748b">Datadog</text>
+  <text x="96" y="372" font-size="11" fill="#64748b">New York, NY</text>
+  <text x="40" y="390" font-size="10" fill="#94a3b8">Design and maintain cloud-native observability infrastructure. Kubernetes, Terraform, CI/CD pipelines...</text>
+  <rect x="40" y="398" width="80" height="16" rx="4" fill="#eff6ff"/>
+  <text x="48" y="409" font-size="9" fill="#3b82f6">$170k - $230k</text>
+  <rect x="126" y="398" width="60" height="16" rx="4" fill="#f1f5f9"/>
+  <text x="134" y="409" font-size="9" fill="#64748b">Glassdoor</text>
+  <!-- Score -->
+  <text x="830" y="352" font-size="20" font-weight="700" fill="#ca8a04">6.8</text>
+  <text x="860" y="352" font-size="11" fill="#ca8a04">★</text>
+  <rect x="818" y="360" width="62" height="18" rx="4" fill="#fef9c3"/>
+  <text x="826" y="373" font-size="10" font-weight="500" fill="#ca8a04">61% ready</text>
+  <text x="840" y="392" font-size="9" fill="#94a3b8">5 days ago</text>
+
+  <!-- Job Card 4 -->
+  <rect x="24" y="424" width="876" height="62" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="40" y="452" font-size="14" font-weight="600" fill="#0f172a">DevOps Lead</text>
+  <text x="40" y="470" font-size="11" fill="#64748b">Cloudflare</text>
+  <text x="106" y="470" font-size="11" fill="#64748b">Austin, TX</text>
+  <rect x="176" y="459" width="52" height="16" rx="4" fill="#dcfce7"/>
+  <text x="184" y="470" font-size="9" font-weight="500" fill="#16a34a">Remote</text>
+  <!-- Score -->
+  <text x="830" y="448" font-size="20" font-weight="700" fill="#16a34a">8.1</text>
+  <text x="860" y="448" font-size="11" fill="#16a34a">★</text>
+  <rect x="818" y="456" width="62" height="18" rx="4" fill="#dbeafe"/>
+  <text x="826" y="469" font-size="10" font-weight="500" fill="#2563eb">75% ready</text>
+
+  <!-- Pagination -->
+  <text x="370" y="510" font-size="11" fill="#64748b">Showing 1-20 of 23 jobs</text>
+  <rect x="480" y="496" width="28" height="20" rx="4" fill="#3b82f6"/>
+  <text x="489" y="510" font-size="10" font-weight="600" fill="#ffffff">1</text>
+  <rect x="512" y="496" width="28" height="20" rx="4" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="521" y="510" font-size="10" fill="#64748b">2</text>
+</svg>

--- a/docs/images/preview-pipeline.svg
+++ b/docs/images/preview-pipeline.svg
@@ -1,0 +1,156 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+    <filter id="shadow2" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="920" height="520" rx="12" fill="#f8fafc"/>
+  <rect width="920" height="520" rx="12" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Top Nav Bar -->
+  <rect width="920" height="48" rx="12" fill="#ffffff"/>
+  <rect y="40" width="920" height="8" fill="#ffffff"/>
+  <line x1="0" y1="48" x2="920" y2="48" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="20" y="30" font-size="15" font-weight="700" fill="#0f172a">Kestrel</text>
+  <rect x="90" y="12" width="68" height="26" rx="6" fill="#f1f5f9"/>
+  <text x="103" y="30" font-size="11" font-weight="600" fill="#3b82f6">Pipeline</text>
+  <text x="172" y="30" font-size="11" fill="#64748b">Discovery</text>
+  <text x="245" y="30" font-size="11" fill="#64748b">Follow-Ups</text>
+  <text x="322" y="30" font-size="11" fill="#64748b">Contacts</text>
+  <text x="388" y="30" font-size="11" fill="#64748b">Analytics</text>
+  <text x="455" y="30" font-size="11" fill="#64748b">Settings</text>
+
+  <!-- Page Header -->
+  <text x="24" y="78" font-size="18" font-weight="700" fill="#0f172a">Pipeline</text>
+  <rect x="86" y="64" width="85" height="22" rx="11" fill="#eff6ff"/>
+  <text x="94" y="79" font-size="11" fill="#3b82f6">14 applications</text>
+
+  <!-- Add Button -->
+  <rect x="836" y="60" width="65" height="28" rx="6" fill="#3b82f6" filter="url(#shadow1)"/>
+  <text x="852" y="79" font-size="12" font-weight="500" fill="#ffffff">+ Add</text>
+
+  <!-- Column: Discovered -->
+  <rect x="12" y="96" width="175" height="412" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="0.5"/>
+  <text x="24" y="118" font-size="12" font-weight="600" fill="#475569">Discovered</text>
+  <rect x="130" y="106" width="22" height="18" rx="9" fill="#e2e8f0"/>
+  <text x="136" y="119" font-size="10" font-weight="600" fill="#64748b">5</text>
+
+  <!-- Card D1 -->
+  <rect x="20" y="130" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="30" y="150" font-size="12" font-weight="600" fill="#0f172a">Stripe</text>
+  <text x="30" y="165" font-size="10" fill="#94a3b8">Backend Engineer</text>
+  <rect x="30" y="174" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="36" y="185" font-size="9" font-weight="600" fill="#16a34a">9.1</text>
+  <rect x="66" y="174" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="72" y="185" font-size="9" font-weight="500" fill="#2563eb">85% ready</text>
+
+  <!-- Card D2 -->
+  <rect x="20" y="220" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="30" y="240" font-size="12" font-weight="600" fill="#0f172a">Vercel</text>
+  <text x="30" y="255" font-size="10" fill="#94a3b8">Full-Stack Developer</text>
+  <rect x="30" y="264" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="36" y="275" font-size="9" font-weight="600" fill="#16a34a">8.4</text>
+  <rect x="66" y="264" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="72" y="275" font-size="9" font-weight="500" fill="#2563eb">72% ready</text>
+
+  <!-- Card D3 -->
+  <rect x="20" y="310" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="30" y="330" font-size="12" font-weight="600" fill="#0f172a">Datadog</text>
+  <text x="30" y="345" font-size="10" fill="#94a3b8">Platform Engineer</text>
+  <rect x="30" y="354" width="30" height="16" rx="4" fill="#fef9c3"/>
+  <text x="36" y="365" font-size="9" font-weight="600" fill="#ca8a04">6.7</text>
+  <rect x="66" y="354" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="72" y="365" font-size="9" font-weight="500" fill="#2563eb">60% ready</text>
+
+  <!-- Column: Interested -->
+  <rect x="194" y="96" width="175" height="412" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="206" y="118" font-size="12" font-weight="600" fill="#2563eb">Interested</text>
+  <rect x="312" y="106" width="22" height="18" rx="9" fill="#bfdbfe"/>
+  <text x="318" y="119" font-size="10" font-weight="600" fill="#2563eb">3</text>
+
+  <!-- Card I1 -->
+  <rect x="202" y="130" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="212" y="150" font-size="12" font-weight="600" fill="#0f172a">Figma</text>
+  <text x="212" y="165" font-size="10" fill="#94a3b8">Senior Engineer</text>
+  <rect x="212" y="174" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="218" y="185" font-size="9" font-weight="600" fill="#16a34a">8.8</text>
+  <rect x="248" y="174" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="254" y="185" font-size="9" font-weight="500" fill="#2563eb">90% ready</text>
+
+  <!-- Card I2 -->
+  <rect x="202" y="220" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="212" y="240" font-size="12" font-weight="600" fill="#0f172a">Linear</text>
+  <text x="212" y="255" font-size="10" fill="#94a3b8">Product Engineer</text>
+  <rect x="212" y="264" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="218" y="275" font-size="9" font-weight="600" fill="#16a34a">8.2</text>
+  <rect x="248" y="264" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="254" y="275" font-size="9" font-weight="500" fill="#2563eb">78% ready</text>
+
+  <!-- Column: Applied -->
+  <rect x="376" y="96" width="175" height="412" rx="8" fill="#eef2ff" stroke="#c7d2fe" stroke-width="0.5"/>
+  <text x="388" y="118" font-size="12" font-weight="600" fill="#4f46e5">Applied</text>
+  <rect x="494" y="106" width="22" height="18" rx="9" fill="#c7d2fe"/>
+  <text x="500" y="119" font-size="10" font-weight="600" fill="#4f46e5">3</text>
+
+  <!-- Card A1 -->
+  <rect x="384" y="130" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="394" y="150" font-size="12" font-weight="600" fill="#0f172a">GitHub</text>
+  <text x="394" y="165" font-size="10" fill="#94a3b8">Staff Engineer</text>
+  <rect x="394" y="174" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="400" y="185" font-size="9" font-weight="600" fill="#16a34a">9.5</text>
+  <rect x="430" y="174" width="50" height="16" rx="4" fill="#dcfce7"/>
+  <text x="436" y="185" font-size="9" font-weight="500" fill="#16a34a">92% ready</text>
+
+  <!-- Card A2 -->
+  <rect x="384" y="220" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="394" y="240" font-size="12" font-weight="600" fill="#0f172a">Notion</text>
+  <text x="394" y="255" font-size="10" fill="#94a3b8">Frontend Developer</text>
+  <rect x="394" y="264" width="30" height="16" rx="4" fill="#fef9c3"/>
+  <text x="400" y="275" font-size="9" font-weight="600" fill="#ca8a04">7.3</text>
+  <rect x="430" y="264" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="436" y="275" font-size="9" font-weight="500" fill="#2563eb">68% ready</text>
+
+  <!-- Column: Interviewing -->
+  <rect x="558" y="96" width="175" height="412" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="570" y="118" font-size="12" font-weight="600" fill="#d97706">Interviewing</text>
+  <rect x="676" y="106" width="22" height="18" rx="9" fill="#fde68a"/>
+  <text x="682" y="119" font-size="10" font-weight="600" fill="#d97706">2</text>
+
+  <!-- Card IV1 -->
+  <rect x="566" y="130" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="576" y="150" font-size="12" font-weight="600" fill="#0f172a">Shopify</text>
+  <text x="576" y="165" font-size="10" fill="#94a3b8">Senior Developer</text>
+  <rect x="576" y="174" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="582" y="185" font-size="9" font-weight="600" fill="#16a34a">8.9</text>
+  <rect x="612" y="174" width="50" height="16" rx="4" fill="#dcfce7"/>
+  <text x="618" y="185" font-size="9" font-weight="500" fill="#16a34a">95% ready</text>
+
+  <!-- Card IV2 -->
+  <rect x="566" y="220" width="159" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="576" y="240" font-size="12" font-weight="600" fill="#0f172a">Atlassian</text>
+  <text x="576" y="255" font-size="10" fill="#94a3b8">Cloud Engineer</text>
+  <rect x="576" y="264" width="30" height="16" rx="4" fill="#fef9c3"/>
+  <text x="582" y="275" font-size="9" font-weight="600" fill="#ca8a04">7.6</text>
+  <rect x="612" y="264" width="50" height="16" rx="4" fill="#dbeafe"/>
+  <text x="618" y="275" font-size="9" font-weight="500" fill="#2563eb">82% ready</text>
+
+  <!-- Column: Offer -->
+  <rect x="740" y="96" width="168" height="412" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="752" y="118" font-size="12" font-weight="600" fill="#059669">Offer</text>
+  <rect x="860" y="106" width="22" height="18" rx="9" fill="#a7f3d0"/>
+  <text x="866" y="119" font-size="10" font-weight="600" fill="#059669">1</text>
+
+  <!-- Card O1 -->
+  <rect x="748" y="130" width="152" height="82" rx="6" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="758" y="150" font-size="12" font-weight="600" fill="#0f172a">Cloudflare</text>
+  <text x="758" y="165" font-size="10" fill="#94a3b8">Systems Engineer</text>
+  <rect x="758" y="174" width="30" height="16" rx="4" fill="#dcfce7"/>
+  <text x="764" y="185" font-size="9" font-weight="600" fill="#16a34a">9.3</text>
+  <rect x="794" y="174" width="50" height="16" rx="4" fill="#dcfce7"/>
+  <text x="800" y="185" font-size="9" font-weight="500" fill="#16a34a">98% ready</text>
+</svg>

--- a/docs/images/preview-settings.svg
+++ b/docs/images/preview-settings.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="920" height="520" rx="12" fill="#f8fafc"/>
+  <rect width="920" height="520" rx="12" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Top Nav Bar -->
+  <rect width="920" height="48" rx="12" fill="#ffffff"/>
+  <rect y="40" width="920" height="8" fill="#ffffff"/>
+  <line x1="0" y1="48" x2="920" y2="48" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="20" y="30" font-size="15" font-weight="700" fill="#0f172a">Kestrel</text>
+  <text x="95" y="30" font-size="11" fill="#64748b">Pipeline</text>
+  <text x="155" y="30" font-size="11" fill="#64748b">Discovery</text>
+  <text x="228" y="30" font-size="11" fill="#64748b">Follow-Ups</text>
+  <text x="305" y="30" font-size="11" fill="#64748b">Contacts</text>
+  <text x="371" y="30" font-size="11" fill="#64748b">Analytics</text>
+  <rect x="435" y="12" width="62" height="26" rx="6" fill="#f1f5f9"/>
+  <text x="448" y="30" font-size="11" font-weight="600" fill="#3b82f6">Settings</text>
+
+  <!-- Page Header -->
+  <text x="24" y="78" font-size="18" font-weight="700" fill="#0f172a">Settings</text>
+
+  <!-- Tabs -->
+  <rect x="24" y="90" width="110" height="32" rx="0" fill="none"/>
+  <text x="40" y="111" font-size="12" font-weight="600" fill="#3b82f6">Integrations</text>
+  <line x1="24" y1="122" x2="134" y2="122" stroke="#3b82f6" stroke-width="2"/>
+  <text x="160" y="111" font-size="12" fill="#64748b">Profiles</text>
+  <line x1="24" y1="123" x2="896" y2="123" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Intro text -->
+  <text x="24" y="146" font-size="11" fill="#64748b">Configure external integrations. Enable an integration, enter your credentials, and test the connection.</text>
+
+  <!-- Integration Panel 1: OpenRouter (Connected) -->
+  <rect x="24" y="162" width="872" height="148" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="44" y="188" font-size="14" font-weight="600" fill="#0f172a">OpenRouter</text>
+  <text x="44" y="204" font-size="11" fill="#94a3b8">AI provider for job scoring and interview prep</text>
+  <!-- Connected badge -->
+  <rect x="780" y="174" width="86" height="22" rx="11" fill="#dcfce7"/>
+  <text x="800" y="189" font-size="10" font-weight="600" fill="#16a34a">Connected</text>
+  <!-- Toggle ON -->
+  <rect x="44" y="218" width="36" height="20" rx="10" fill="#3b82f6"/>
+  <circle cx="68" cy="228" r="7" fill="#ffffff"/>
+  <text x="88" y="232" font-size="11" fill="#0f172a">Enabled</text>
+  <!-- API Key field -->
+  <text x="44" y="258" font-size="10" font-weight="500" fill="#475569">API Key</text>
+  <rect x="44" y="264" width="400" height="30" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="56" y="284" font-size="11" fill="#94a3b8">sk-or-••••••••••••••••</text>
+  <!-- Eye icon placeholder -->
+  <rect x="416" y="272" width="14" height="14" rx="2" fill="none" stroke="#94a3b8" stroke-width="1"/>
+  <!-- Test & Save buttons -->
+  <rect x="470" y="266" width="110" height="28" rx="6" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="486" y="284" font-size="11" fill="#64748b">Test Connection</text>
+  <rect x="588" y="266" width="60" height="28" rx="6" fill="#3b82f6"/>
+  <text x="603" y="284" font-size="11" font-weight="500" fill="#ffffff">Save</text>
+
+  <!-- Integration Panel 2: LinkedIn (Not Configured) -->
+  <rect x="24" y="320" width="872" height="148" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="44" y="346" font-size="14" font-weight="600" fill="#0f172a">LinkedIn</text>
+  <text x="44" y="362" font-size="11" fill="#94a3b8">Import jobs from LinkedIn job search</text>
+  <!-- Not Configured badge -->
+  <rect x="760" y="332" width="106" height="22" rx="11" fill="#fef9c3"/>
+  <text x="776" y="347" font-size="10" font-weight="600" fill="#ca8a04">Not Configured</text>
+  <!-- Toggle OFF -->
+  <rect x="44" y="376" width="36" height="20" rx="10" fill="#e2e8f0"/>
+  <circle cx="56" cy="386" r="7" fill="#ffffff"/>
+  <text x="88" y="390" font-size="11" fill="#94a3b8">Disabled</text>
+  <!-- Cookie field -->
+  <text x="44" y="416" font-size="10" font-weight="500" fill="#475569">Session Cookie</text>
+  <rect x="44" y="422" width="400" height="30" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="56" y="442" font-size="11" fill="#cbd5e1">Paste your li_at cookie value</text>
+  <!-- Test & Save buttons (disabled state) -->
+  <rect x="470" y="424" width="110" height="28" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="486" y="442" font-size="11" fill="#cbd5e1">Test Connection</text>
+  <rect x="588" y="424" width="60" height="28" rx="6" fill="#94a3b8"/>
+  <text x="603" y="442" font-size="11" font-weight="500" fill="#ffffff">Save</text>
+
+  <!-- Integration Panel 3: Indeed (partial, clipped) -->
+  <rect x="24" y="478" width="872" height="40" rx="8" fill="#ffffff" filter="url(#shadow1)"/>
+  <text x="44" y="504" font-size="14" font-weight="600" fill="#0f172a">Indeed</text>
+  <rect x="780" y="488" width="86" height="22" rx="11" fill="#dcfce7"/>
+  <text x="800" y="503" font-size="10" font-weight="600" fill="#16a34a">Connected</text>
+</svg>


### PR DESCRIPTION
## Summary
Added three SVG preview images to the README to showcase the main features of the Kestrel application. These visual previews provide users with an immediate understanding of the application's interface and capabilities before diving into the documentation.

## Changes
- **preview-pipeline.svg**: Kanban-style board showing job applications across pipeline stages (Discovered, Interested, Applied, Interviewing, Offer) with candidate cards displaying scores and readiness percentages
- **preview-discovery.svg**: Job discovery interface with AI-scored job listings from multiple boards, search functionality, and filtering options
- **preview-settings.svg**: Settings page demonstrating integration configuration for external services (OpenRouter, LinkedIn, Indeed)
- **README.md**: Added new "Preview" section with three centered image blocks showcasing each major feature

## Implementation Details
- All SVG images use a consistent design system with Tailwind-inspired color palette and typography
- Images include drop shadows and proper spacing for visual hierarchy
- Preview section is positioned prominently in the README after the quick start section
- Images are responsive and set to 820px width for optimal viewing

https://claude.ai/code/session_01RHKdHVyEwgkZ9eSDupwBhn