### PR TITLE
Add docker-watchdog script for automatic container health monitoring

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -231,7 +231,18 @@ There's no catch. The author built this to solve their own job search problem an
 
 ### I closed my laptop / computer went to sleep. Is Kestrel still running?
 
-Maybe. Docker containers usually survive sleep/wake on Mac. Open http://localhost:8101 - if it loads, you're fine. If not, open Terminal and run `docker compose up -d` from your Kestrel folder. Your data is never lost - it's saved in a file on your computer, not in Docker's memory.
+Docker containers sometimes stop working after macOS sleep/wake. Open http://localhost:8101 — if it loads, you're fine. If not, open Terminal and run:
+
+```
+cd ~/Downloads/kestrel-main
+docker compose up -d
+```
+
+If that doesn't work, make sure Docker Desktop is running (whale icon in the menu bar), then try `docker compose down && docker compose up -d`.
+
+Kestrel also includes a watchdog script that checks and restarts containers automatically: `bash scripts/docker-watchdog.sh`. See the [troubleshooting guide](HELP.md#my-mac-went-to-sleep-and-kestrel-stopped-working) for details.
+
+Your data is never lost — it's saved in a file on your computer, not in Docker's memory.
 
 ---
 

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -81,6 +81,41 @@ Docker might have stopped. Check:
 2. Open Terminal and type: `docker compose up -d`
 3. Wait 30 seconds, then try http://localhost:8101 again
 
+### "My Mac went to sleep and Kestrel stopped working"
+
+This is a known macOS issue. Docker containers sometimes fail to recover after sleep/wake.
+
+**Quick fix (works most of the time):**
+```
+cd ~/Downloads/kestrel-main
+docker compose up -d
+```
+
+**If that didn't work:**
+
+1. Check if Docker Desktop is running (whale icon in menu bar). If not, open it and wait 30 seconds.
+2. Then run:
+   ```
+   docker compose down
+   docker compose up -d
+   ```
+3. Wait 30 seconds, then open http://localhost:8101
+
+**Automatic monitoring (optional):**
+
+Kestrel includes a watchdog script that checks and restarts containers for you:
+
+```
+bash scripts/docker-watchdog.sh
+```
+
+To run it continuously in the background:
+```
+bash scripts/docker-watchdog.sh --watch
+```
+
+Your data is never lost during sleep/wake — it's saved in a database file on your computer, not in Docker's memory.
+
 ---
 
 ## Dashboard issues
@@ -169,4 +204,5 @@ Someone will help you.
 | See what's happening | `docker compose logs backend` |
 | Check if it's running | `curl http://localhost:8100/health` |
 | Start completely fresh | `docker compose down -v && bash setup.sh` |
+| Check & fix containers after sleep | `bash scripts/docker-watchdog.sh` |
 | Open the settings file | `open .env` (Mac) or `notepad .env` (Windows) |

--- a/scripts/docker-watchdog.sh
+++ b/scripts/docker-watchdog.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# docker-watchdog.sh — Check Kestrel containers and restart if unhealthy
+#
+# Usage:
+#   bash scripts/docker-watchdog.sh              # one-shot check & fix
+#   bash scripts/docker-watchdog.sh --watch      # continuous monitoring
+#   bash scripts/docker-watchdog.sh -f docker-compose.prod.yml  # production
+#
+# Exit codes: 0 = healthy, 1 = recovery failed, 2 = Docker unavailable
+
+COMPOSE_FILE=""
+WATCH_MODE=false
+CHECK_INTERVAL=30
+DOCKER_WAIT_TIMEOUT=60
+HEALTH_URL="http://localhost:8100/health"
+
+usage() {
+    echo "Usage: bash scripts/docker-watchdog.sh [OPTIONS]"
+    echo ""
+    echo "Check Kestrel Docker containers and restart them if unhealthy."
+    echo ""
+    echo "Options:"
+    echo "  -f FILE        Docker Compose file (default: docker-compose.yml)"
+    echo "  --watch        Run continuously instead of one-shot"
+    echo "  --interval N   Seconds between checks in watch mode (default: 30)"
+    echo "  -h, --help     Show this help message"
+    exit 0
+}
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f)           COMPOSE_FILE="$2"; shift 2 ;;
+        --watch)      WATCH_MODE=true; shift ;;
+        --interval)   CHECK_INTERVAL="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *)            echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# Default compose file
+if [ -z "$COMPOSE_FILE" ]; then
+    COMPOSE_FILE="docker-compose.yml"
+fi
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Compose file not found: $COMPOSE_FILE"
+    echo "Run this script from the Kestrel project folder."
+    exit 1
+fi
+
+COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+
+wait_for_docker() {
+    local elapsed=0
+    while ! docker info &>/dev/null 2>&1; do
+        if [ "$elapsed" -ge "$DOCKER_WAIT_TIMEOUT" ]; then
+            log "Docker did not respond within ${DOCKER_WAIT_TIMEOUT}s"
+            return 1
+        fi
+        if [ "$elapsed" -eq 0 ]; then
+            log "Waiting for Docker to start..."
+            # Try to launch Docker Desktop on macOS
+            if [[ "$(uname 2>/dev/null)" == "Darwin" ]]; then
+                open -a Docker 2>/dev/null || true
+            fi
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 0
+}
+
+check_health() {
+    # Check if containers are running
+    local running
+    running=$($COMPOSE_CMD ps --status running -q 2>/dev/null | wc -l | tr -d ' ')
+    local expected
+    expected=$($COMPOSE_CMD config --services 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$running" -lt "$expected" ]; then
+        log "Only $running of $expected containers running"
+        return 1
+    fi
+
+    # Check the health endpoint directly
+    if ! curl -sf --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
+        log "Health endpoint not responding"
+        return 1
+    fi
+
+    return 0
+}
+
+recover() {
+    log "Restarting containers..."
+    $COMPOSE_CMD up -d 2>&1 | tail -5
+
+    # Wait for health (same pattern as setup.sh)
+    log "Waiting for health check..."
+    local i
+    for i in $(seq 1 30); do
+        if curl -sf --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
+            log "Kestrel is healthy again"
+            return 0
+        fi
+        sleep 2
+    done
+
+    log "Recovery failed — containers did not become healthy within 60s"
+    log "Try: $COMPOSE_CMD logs backend"
+    return 1
+}
+
+run_check() {
+    if ! wait_for_docker; then
+        return 2
+    fi
+
+    if check_health; then
+        log "All containers healthy"
+        return 0
+    fi
+
+    recover
+}
+
+# Main
+if [ "$WATCH_MODE" = true ]; then
+    log "Watching Kestrel containers (every ${CHECK_INTERVAL}s, Ctrl+C to stop)"
+    while true; do
+        run_check || true
+        sleep "$CHECK_INTERVAL"
+    done
+else
+    run_check
+fi


### PR DESCRIPTION
## Summary
This PR adds a new watchdog script that monitors Kestrel Docker containers and automatically restarts them if they become unhealthy. This addresses a known issue where containers sometimes fail to recover after macOS sleep/wake cycles.

## Key Changes
- **New script: `scripts/docker-watchdog.sh`** — Monitors container health and automatically restarts them
  - Supports one-shot checks (`bash scripts/docker-watchdog.sh`) and continuous monitoring (`--watch` mode)
  - Configurable check intervals and Docker Compose file selection
  - Waits for Docker to start (with automatic Docker Desktop launch on macOS)
  - Checks both container status and health endpoint (`/health`)
  - Provides clear logging with timestamps and helpful error messages
  - Exit codes: 0 (healthy), 1 (recovery failed), 2 (Docker unavailable)

- **Updated `docs/HELP.md`** — Added comprehensive troubleshooting section for macOS sleep/wake issues
  - Quick fix instructions for common scenarios
  - Introduction to the watchdog script with usage examples
  - Clarification that user data is never lost during sleep/wake

- **Updated `docs/FAQ.md`** — Expanded answer about container persistence after sleep
  - More detailed troubleshooting steps
  - Reference to the new watchdog script
  - Link to the full troubleshooting guide

## Implementation Details
- The watchdog script uses `docker compose` commands to check running containers and service count
- Health checks use `curl` with a 5-second timeout to the `/health` endpoint
- Recovery process mirrors the setup.sh pattern: restart containers and wait up to 60 seconds for health
- Watch mode runs indefinitely with configurable intervals (default 30 seconds)
- Robust error handling with proper exit codes and informative logging

https://claude.ai/code/session_01BvonoE9uwNaFmVKZz2t2um