### PR TITLE
fix: block scoring on incomplete profile (#27)

### DIFF
--- a/frontend/src/api/scoring.ts
+++ b/frontend/src/api/scoring.ts
@@ -36,6 +36,12 @@ export async function batchScore(
     );
   }
 
+  if (resp.status === 422) {
+    const body = await resp.json();
+    sessionStorage.setItem("profile_incomplete", body.detail || "true");
+    throw new Error(body.detail || "Profile incomplete for scoring");
+  }
+
   if (!resp.ok) throw new Error(`Batch scoring failed: ${resp.status}`);
 
   const data: BatchScoreResponse = await resp.json();

--- a/frontend/src/pages/Discovery.tsx
+++ b/frontend/src/pages/Discovery.tsx
@@ -511,6 +511,9 @@ export function Discovery() {
   const [creditsExhausted, setCreditsExhausted] = useState(
     () => sessionStorage.getItem("credits_exhausted") === "true",
   );
+  const [profileIncomplete, setProfileIncomplete] = useState(
+    () => sessionStorage.getItem("profile_incomplete") !== null,
+  );
 
   // Debounce search input
   const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
@@ -769,6 +772,41 @@ export function Discovery() {
                 sessionStorage.removeItem("credits_exhausted");
               }}
               className="ml-4 text-amber-400 hover:text-amber-600"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Profile incomplete banner */}
+      {profileIncomplete && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <div className="flex items-start justify-between">
+            <div className="flex gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600" />
+              <div>
+                <h3 className="text-sm font-semibold text-blue-800">
+                  Profile Incomplete
+                </h3>
+                <p className="mt-1 text-sm text-blue-700">
+                  Fill in your profile (target roles and location) for
+                  personalized AI scores.{" "}
+                  <a
+                    href="/settings"
+                    className="font-medium underline hover:text-blue-900"
+                  >
+                    Go to Settings
+                  </a>
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                setProfileIncomplete(false);
+                sessionStorage.removeItem("profile_incomplete");
+              }}
+              className="ml-4 text-blue-400 hover:text-blue-600"
             >
               <X className="h-4 w-4" />
             </button>

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -18,6 +18,7 @@ from career_os.schemas.scoring import (
 from career_os.services.pushover import send_credits_exhausted_alert
 from career_os.services.scoring import (
     JobNotFoundError,
+    ProfileIncompleteError,
     ProfileNotFoundError,
     ScoringError,
     batch_score_discovery,
@@ -63,6 +64,8 @@ async def score_endpoint(
         )
     except ProfileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProfileIncompleteError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except JobNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except CreditsExhaustedError as exc:
@@ -142,6 +145,8 @@ async def batch_score_endpoint(
         )
     except ProfileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProfileIncompleteError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Batch scoring error: {exc}") from exc
 

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -37,6 +37,10 @@ class JobNotFoundError(Exception):
     """Raised when a discovered job or application is not found."""
 
 
+class ProfileIncompleteError(Exception):
+    """Raised when profile lacks required fields for meaningful scoring."""
+
+
 class ScoringError(Exception):
     """Raised when scoring fails."""
 
@@ -274,6 +278,17 @@ async def score_job(
     if not profile:
         raise ProfileNotFoundError(f"Profile {profile_id} not found")
 
+    # Guard: profile must have target roles and location for meaningful scores
+    if not profile.job_family or not profile.location:
+        missing = []
+        if not profile.job_family:
+            missing.append("target roles")
+        if not profile.location:
+            missing.append("location")
+        raise ProfileIncompleteError(
+            f"Fill in your profile ({', '.join(missing)}) for personalized scores"
+        )
+
     # Validate discovered_job_id if provided
     if discovered_job_id is not None:
         dj = (
@@ -447,6 +462,17 @@ async def batch_score_discovery(
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
     if not profile:
         raise ProfileNotFoundError(f"Profile {profile_id} not found")
+
+    # Guard: profile must have target roles and location for meaningful scores
+    if not profile.job_family or not profile.location:
+        missing = []
+        if not profile.job_family:
+            missing.append("target roles")
+        if not profile.location:
+            missing.append("location")
+        raise ProfileIncompleteError(
+            f"Fill in your profile ({', '.join(missing)}) for personalized scores"
+        )
 
     start_time = time.monotonic()
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -301,6 +301,38 @@ class TestScoreEndpoint:
         )
         assert resp.status_code == 422
 
+    def test_score_incomplete_profile_no_job_family_returns_422(self, client, db_session):
+        """Scoring with profile missing job_family returns 422."""
+        profile = db_session.query(Profile).filter(Profile.id == 1).first()
+        profile.job_family = None
+        db_session.commit()
+
+        resp = client.post(
+            "/api/score",
+            json={
+                "profile_id": 1,
+                "job_description": JOB_DESCRIPTION_A,
+            },
+        )
+        assert resp.status_code == 422
+        assert "target roles" in resp.json()["detail"]
+
+    def test_score_incomplete_profile_no_location_returns_422(self, client, db_session):
+        """Scoring with profile missing location returns 422."""
+        profile = db_session.query(Profile).filter(Profile.id == 1).first()
+        profile.location = None
+        db_session.commit()
+
+        resp = client.post(
+            "/api/score",
+            json={
+                "profile_id": 1,
+                "job_description": JOB_DESCRIPTION_A,
+            },
+        )
+        assert resp.status_code == 422
+        assert "location" in resp.json()["detail"]
+
     def test_score_with_discovered_job_id(self, client, db_session):
         """Score linked to a discovered job updates its fit_score."""
         job_ids = _seed_discovered_jobs(db_session)
@@ -778,6 +810,16 @@ class TestBatchScoring:
         """Batch scoring with non-existent profile returns 404."""
         resp = client.post("/api/score/batch", json={"profile_id": 999})
         assert resp.status_code == 404
+
+    def test_batch_score_incomplete_profile_returns_422(self, client, db_session):
+        """Batch scoring with incomplete profile returns 422."""
+        profile = db_session.query(Profile).filter(Profile.id == 1).first()
+        profile.job_family = None
+        db_session.commit()
+
+        resp = client.post("/api/score/batch", json={"profile_id": 1})
+        assert resp.status_code == 422
+        assert "target roles" in resp.json()["detail"]
 
     def test_batch_score_completes_within_60s(self, client, db_session):
         """Batch scoring completes within 60 seconds."""


### PR DESCRIPTION
## Summary
- Add `ProfileIncompleteError` guard in scoring service — requires `job_family` and `location` before scoring
- API returns HTTP 422 with descriptive message listing missing fields
- Frontend catches 422 in scoring API client, shows blue info banner in Discovery page linking to Settings
- 3 new test cases covering single score + batch with incomplete profile

Closes #27

## Test plan
- [ ] Backend: `pytest tests/test_scoring.py -x` — verify 422 for missing job_family, missing location, and batch with incomplete profile
- [ ] Frontend: `npx vitest run` — 223/223 tests pass
- [ ] Lint: `ruff check src/career_os/api/scoring.py src/career_os/services/scoring.py` clean
- [ ] ESLint: `npx eslint src/pages/Discovery.tsx src/api/scoring.ts` clean

https://claude.ai/code/session_01MWtYRtVZF1NZMBuB6GJb4A