### PR TITLE
fix: resolve SonarCloud issues across 6 batches (S8410, S8415, S1192, S108, S3776, S3358)

### DIFF
--- a/frontend/src/__tests__/scoreColor.test.ts
+++ b/frontend/src/__tests__/scoreColor.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for scoreColor helper extracted from KanbanCard.
+ *
+ * Verifies the three-tier color thresholds used for fit_score and
+ * readiness_score badges.
+ */
+
+import { describe, it, expect } from "vitest";
+import { scoreColor } from "@/components/KanbanCard";
+
+describe("scoreColor", () => {
+  // --- fit_score thresholds (high=8, mid=5) ---
+
+  it("returns green for values >= high threshold", () => {
+    expect(scoreColor(8, 8, 5)).toBe("bg-green-100 text-green-800");
+    expect(scoreColor(9.5, 8, 5)).toBe("bg-green-100 text-green-800");
+    expect(scoreColor(10, 8, 5)).toBe("bg-green-100 text-green-800");
+  });
+
+  it("returns yellow for values >= mid but < high", () => {
+    expect(scoreColor(5, 8, 5)).toBe("bg-yellow-100 text-yellow-800");
+    expect(scoreColor(7.9, 8, 5)).toBe("bg-yellow-100 text-yellow-800");
+    expect(scoreColor(6, 8, 5)).toBe("bg-yellow-100 text-yellow-800");
+  });
+
+  it("returns red for values < mid threshold", () => {
+    expect(scoreColor(4.9, 8, 5)).toBe("bg-red-100 text-red-800");
+    expect(scoreColor(0, 8, 5)).toBe("bg-red-100 text-red-800");
+    expect(scoreColor(1, 8, 5)).toBe("bg-red-100 text-red-800");
+  });
+
+  // --- readiness_score thresholds (high=80, mid=50) ---
+
+  it("works with readiness thresholds (80/50)", () => {
+    expect(scoreColor(80, 80, 50)).toBe("bg-green-100 text-green-800");
+    expect(scoreColor(95, 80, 50)).toBe("bg-green-100 text-green-800");
+    expect(scoreColor(50, 80, 50)).toBe("bg-yellow-100 text-yellow-800");
+    expect(scoreColor(79, 80, 50)).toBe("bg-yellow-100 text-yellow-800");
+    expect(scoreColor(49, 80, 50)).toBe("bg-red-100 text-red-800");
+    expect(scoreColor(0, 80, 50)).toBe("bg-red-100 text-red-800");
+  });
+
+  // --- edge cases ---
+
+  it("handles exact boundary values correctly", () => {
+    // Exactly at high threshold → green
+    expect(scoreColor(8, 8, 5)).toBe("bg-green-100 text-green-800");
+    // Exactly at mid threshold → yellow
+    expect(scoreColor(5, 8, 5)).toBe("bg-yellow-100 text-yellow-800");
+  });
+
+  it("handles negative values", () => {
+    expect(scoreColor(-1, 8, 5)).toBe("bg-red-100 text-red-800");
+  });
+});

--- a/frontend/src/__tests__/scoreColor.test.ts
+++ b/frontend/src/__tests__/scoreColor.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { scoreColor } from "@/components/KanbanCard";
+import { scoreColor } from "@/lib/utils";
 
 describe("scoreColor", () => {
   // --- fit_score thresholds (high=8, mid=5) ---

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -10,14 +10,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Ghost } from "lucide-react";
 import type { Application } from "@/api/types";
-import { cn } from "@/lib/utils";
-
-/** Map a numeric score to Tailwind color classes based on high/mid thresholds. */
-export function scoreColor(value: number, high: number, mid: number): string {
-  if (value >= high) return "bg-green-100 text-green-800";
-  if (value >= mid) return "bg-yellow-100 text-yellow-800";
-  return "bg-red-100 text-red-800";
-}
+import { cn, scoreColor } from "@/lib/utils";
 
 interface KanbanCardProps {
   readonly application: Application;

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -12,6 +12,12 @@ import { Ghost } from "lucide-react";
 import type { Application } from "@/api/types";
 import { cn } from "@/lib/utils";
 
+function scoreColor(value: number, high: number, mid: number): string {
+  if (value >= high) return "bg-green-100 text-green-800";
+  if (value >= mid) return "bg-yellow-100 text-yellow-800";
+  return "bg-red-100 text-red-800";
+}
+
 interface KanbanCardProps {
   readonly application: Application;
 }
@@ -92,11 +98,7 @@ export function KanbanCard({ application }: KanbanCardProps) {
             data-testid={`score-badge-${application.id}`}
             className={cn(
               "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
-              application.fit_score >= 8
-                ? "bg-green-100 text-green-800"
-                : application.fit_score >= 5
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-red-100 text-red-800",
+              scoreColor(application.fit_score, 8, 5),
             )}
           >
             {application.fit_score.toFixed(1)}
@@ -110,11 +112,7 @@ export function KanbanCard({ application }: KanbanCardProps) {
               title={`Readiness: ${rounded}%`}
               className={cn(
                 "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
-                rounded >= 80
-                  ? "bg-green-100 text-green-800"
-                  : rounded >= 50
-                    ? "bg-yellow-100 text-yellow-800"
-                    : "bg-red-100 text-red-800",
+                scoreColor(rounded, 80, 50),
               )}
             >
               {rounded}%

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -12,7 +12,8 @@ import { Ghost } from "lucide-react";
 import type { Application } from "@/api/types";
 import { cn } from "@/lib/utils";
 
-function scoreColor(value: number, high: number, mid: number): string {
+/** Map a numeric score to Tailwind color classes based on high/mid thresholds. */
+export function scoreColor(value: number, high: number, mid: number): string {
   if (value >= high) return "bg-green-100 text-green-800";
   if (value >= mid) return "bg-yellow-100 text-yellow-800";
   return "bg-red-100 text-red-800";

--- a/frontend/src/components/StarStoriesSection.tsx
+++ b/frontend/src/components/StarStoriesSection.tsx
@@ -31,6 +31,12 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: "bg-red-100 text-red-700",
+  "nice-to-have": "bg-yellow-100 text-yellow-700",
+};
+const DEFAULT_SEVERITY_COLOR = "bg-gray-100 text-gray-600";
+
 interface StarStoriesSectionProps {
   readonly applicationId: number;
   readonly profileId: number;
@@ -474,11 +480,7 @@ export function StarStoriesSection({
                       <span
                         className={cn(
                           "text-xs px-1.5 py-0.5 rounded-full",
-                          gap.severity === "critical"
-                            ? "bg-red-100 text-red-700"
-                            : gap.severity === "nice-to-have"
-                              ? "bg-yellow-100 text-yellow-700"
-                              : "bg-gray-100 text-gray-600",
+                          SEVERITY_COLORS[gap.severity] ?? DEFAULT_SEVERITY_COLOR,
                         )}
                       >
                         {gap.severity}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Map a numeric score to Tailwind color classes based on high/mid thresholds. */
+export function scoreColor(value: number, high: number, mid: number): string {
+  if (value >= high) return "bg-green-100 text-green-800";
+  if (value >= mid) return "bg-yellow-100 text-yellow-800";
+  return "bg-red-100 text-red-800";
+}

--- a/frontend/src/pages/ApplicationDetail.tsx
+++ b/frontend/src/pages/ApplicationDetail.tsx
@@ -161,7 +161,7 @@ export function ApplicationDetail() {
     STATUS_COLORS[normalizedStatus] ?? STATUS_COLORS.discovered;
 
   return (
-    <div data-testid="application-detail" className="space-y-6">
+    <section data-testid="application-detail" className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
@@ -554,7 +554,7 @@ export function ApplicationDetail() {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -618,9 +618,9 @@ function DateField({
 }>) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-500">
+      <span className="block text-sm font-medium text-gray-500">
         {label}
-      </label>
+      </span>
       <p data-testid={testId} className="mt-1 text-sm text-gray-900">
         {value ? formatDate(value) : <span className="text-gray-400">—</span>}
       </p>

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -44,6 +44,15 @@ class CreditsExhaustedError(Exception):
         super().__init__(message)
 
 
+def _extract_error_detail(response: httpx.Response) -> str:
+    """Best-effort extraction of error message from an OpenRouter error response."""
+    try:
+        body = response.json()
+        return body.get("error", {}).get("message", "")
+    except Exception:
+        return ""
+
+
 class OpenRouterProvider(AIProvider):
     """AI provider backed by OpenRouter API."""
 
@@ -96,12 +105,7 @@ class OpenRouterProvider(AIProvider):
                 json=payload,
             )
             if response.status_code in (402, 429):
-                detail = ""
-                try:
-                    body = response.json()
-                    detail = body.get("error", {}).get("message", "")
-                except Exception:
-                    pass  # best-effort JSON parse for error detail
+                detail = _extract_error_detail(response)
                 raise CreditsExhaustedError(status_code=response.status_code, detail=detail)
             response.raise_for_status()
             data = response.json()

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -101,7 +101,7 @@ class OpenRouterProvider(AIProvider):
                     body = response.json()
                     detail = body.get("error", {}).get("message", "")
                 except Exception:
-                    pass
+                    pass  # best-effort JSON parse for error detail
                 raise CreditsExhaustedError(status_code=response.status_code, detail=detail)
             response.raise_for_status()
             data = response.json()

--- a/src/career_os/api/applications.py
+++ b/src/career_os/api/applications.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.applications import (
     ActivityLogResponse,
@@ -31,7 +32,6 @@ from career_os.services.follow_ups import (
     is_ghost_application,
 )
 from career_os.services.gap_analysis import get_readiness_score
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(prefix="/api/applications", tags=["applications"])
 
@@ -44,7 +44,7 @@ def _enrich_with_readiness(app_response: ApplicationResponse, db: Session) -> Ap
     return app_response
 
 
-@router.post("", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create(
     payload: ApplicationCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -129,7 +129,7 @@ async def list_apps(
     )
 
 
-@router.get("/{application_id}", responses={404: {"description": "Not found"}})
+@router.get("/{application_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_detail(
     application_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -191,7 +191,7 @@ async def get_detail(
 
 @router.patch(
     "/{application_id}",
-    responses={404: {"description": "Not found"}, 422: {"description": "Validation error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
 )
 async def update(
     application_id: int,
@@ -218,7 +218,7 @@ async def update(
     return ApplicationResponse.model_validate(app_obj)
 
 
-@router.delete("/{application_id}", responses={404: {"description": "Not found"}})
+@router.delete("/{application_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def delete(
     application_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],

--- a/src/career_os/api/applications.py
+++ b/src/career_os/api/applications.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
 from career_os.schemas.applications import (
     ActivityLogResponse,
@@ -65,7 +65,7 @@ def _build_package_summary(pkg) -> ApplicationPackageSummaryResponse:
     )
 
 
-@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("", status_code=201, responses=RESP_404)
 async def create(
     payload: ApplicationCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -150,7 +150,7 @@ async def list_apps(
     )
 
 
-@router.get("/{application_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{application_id}", responses=RESP_404)
 async def get_detail(
     application_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -190,7 +190,7 @@ async def get_detail(
 
 @router.patch(
     "/{application_id}",
-    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
+    responses=RESP_404_422,
 )
 async def update(
     application_id: int,
@@ -217,7 +217,7 @@ async def update(
     return ApplicationResponse.model_validate(app_obj)
 
 
-@router.delete("/{application_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.delete("/{application_id}", responses=RESP_404)
 async def delete(
     application_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],

--- a/src/career_os/api/applications.py
+++ b/src/career_os/api/applications.py
@@ -44,6 +44,27 @@ def _enrich_with_readiness(app_response: ApplicationResponse, db: Session) -> Ap
     return app_response
 
 
+def _derive_package_type(pkg) -> str:
+    if pkg.cover_letter_path and pkg.cv_path:
+        return "full"
+    if pkg.cover_letter_path:
+        return "cover_letter"
+    if pkg.cv_path:
+        return "cv"
+    return "directory"
+
+
+def _build_package_summary(pkg) -> ApplicationPackageSummaryResponse:
+    pkg_dir = pkg.package_dir or ""
+    package_name = pkg_dir.rstrip("/").split("/")[-1] if pkg_dir else "Unknown"
+    return ApplicationPackageSummaryResponse(
+        id=pkg.id,
+        package_name=package_name,
+        file_path=pkg_dir,
+        package_type=_derive_package_type(pkg),
+    )
+
+
 @router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create(
     payload: ApplicationCreate,
@@ -150,29 +171,7 @@ async def get_detail(
     # Include follow-ups sorted by due date
     follow_ups_sorted = sorted(app_obj.follow_ups, key=lambda x: x.due_date)
 
-    # Build packages list with derived fields
-    packages_list = []
-    for pkg in app_obj.packages:
-        # Derive a readable package_name from the directory path
-        pkg_dir = pkg.package_dir or ""
-        package_name = pkg_dir.rstrip("/").split("/")[-1] if pkg_dir else "Unknown"
-        # Determine package_type from available files
-        if pkg.cover_letter_path and pkg.cv_path:
-            package_type = "full"
-        elif pkg.cover_letter_path:
-            package_type = "cover_letter"
-        elif pkg.cv_path:
-            package_type = "cv"
-        else:
-            package_type = "directory"
-        packages_list.append(
-            ApplicationPackageSummaryResponse(
-                id=pkg.id,
-                package_name=package_name,
-                file_path=pkg_dir,
-                package_type=package_type,
-            )
-        )
+    packages_list = [_build_package_summary(pkg) for pkg in app_obj.packages]
 
     # Compute readiness score if requirements exist
     readiness = get_readiness_score(db, app_obj.id, app_obj.profile_id)

--- a/src/career_os/api/calendar.py
+++ b/src/career_os/api/calendar.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.models.models import FollowUp
 from career_os.schemas.calendar import (
@@ -45,7 +45,7 @@ from career_os.services.calendar import (
 router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
 
-@router.post("/events", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/events", status_code=201, responses=RESP_404)
 async def create_event(
     payload: CalendarEventCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -83,7 +83,7 @@ async def list_events(
     )
 
 
-@router.get("/events/{event_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/events/{event_id}", responses=RESP_404)
 async def get_event(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -97,7 +97,7 @@ async def get_event(
     return CalendarEventResponse.model_validate(event)
 
 
-@router.patch("/events/{event_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.patch("/events/{event_id}", responses=RESP_404)
 async def update_event(
     event_id: int,
     payload: CalendarEventUpdate,
@@ -118,7 +118,7 @@ async def update_event(
 @router.delete(
     "/events/{event_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def delete_event(
     event_id: int,
@@ -140,7 +140,7 @@ async def delete_event(
 @router.post(
     "/events/from-follow-up/{follow_up_id}",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def create_from_follow_up(
     follow_up_id: int,
@@ -167,7 +167,7 @@ async def create_from_follow_up(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/ical", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/events/{event_id}/ical", responses=RESP_404)
 async def export_ical(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -218,7 +218,7 @@ async def export_all_ical(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/google", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/events/{event_id}/google", responses=RESP_404)
 async def google_calendar_url(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -237,7 +237,7 @@ async def google_calendar_url(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/fantastical", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/events/{event_id}/fantastical", responses=RESP_404)
 async def fantastical_url(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -256,7 +256,7 @@ async def fantastical_url(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/providers", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/events/{event_id}/providers", responses=RESP_404)
 async def event_providers(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],

--- a/src/career_os/api/calendar.py
+++ b/src/career_os/api/calendar.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import FollowUp
 from career_os.schemas.calendar import (
@@ -40,12 +41,11 @@ from career_os.services.calendar import (
     list_calendar_events,
     update_calendar_event,
 )
-from career_os.api.constants import DESC_PROFILE_ID
 
 router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
 
-@router.post("/events", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("/events", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create_event(
     payload: CalendarEventCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -83,7 +83,7 @@ async def list_events(
     )
 
 
-@router.get("/events/{event_id}", responses={404: {"description": "Not found"}})
+@router.get("/events/{event_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_event(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -97,7 +97,7 @@ async def get_event(
     return CalendarEventResponse.model_validate(event)
 
 
-@router.patch("/events/{event_id}", responses={404: {"description": "Not found"}})
+@router.patch("/events/{event_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_event(
     event_id: int,
     payload: CalendarEventUpdate,
@@ -118,7 +118,7 @@ async def update_event(
 @router.delete(
     "/events/{event_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def delete_event(
     event_id: int,
@@ -140,7 +140,7 @@ async def delete_event(
 @router.post(
     "/events/from-follow-up/{follow_up_id}",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def create_from_follow_up(
     follow_up_id: int,
@@ -167,7 +167,7 @@ async def create_from_follow_up(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/ical", responses={404: {"description": "Not found"}})
+@router.get("/events/{event_id}/ical", responses={404: {"description": RESP_NOT_FOUND}})
 async def export_ical(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -218,7 +218,7 @@ async def export_all_ical(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/google", responses={404: {"description": "Not found"}})
+@router.get("/events/{event_id}/google", responses={404: {"description": RESP_NOT_FOUND}})
 async def google_calendar_url(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -237,7 +237,7 @@ async def google_calendar_url(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/fantastical", responses={404: {"description": "Not found"}})
+@router.get("/events/{event_id}/fantastical", responses={404: {"description": RESP_NOT_FOUND}})
 async def fantastical_url(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -256,7 +256,7 @@ async def fantastical_url(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/events/{event_id}/providers", responses={404: {"description": "Not found"}})
+@router.get("/events/{event_id}/providers", responses={404: {"description": RESP_NOT_FOUND}})
 async def event_providers(
     event_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],

--- a/src/career_os/api/coaching.py
+++ b/src/career_os/api/coaching.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.coaching import (
     CoachingSuggestionResponse,
@@ -15,12 +16,11 @@ from career_os.services.coaching import (
     ProfileNotFoundError,
     get_coaching_suggestions,
 )
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(prefix="/api/coaching", tags=["coaching"])
 
 
-@router.get("/suggestions", responses={404: {"description": "Not found"}})
+@router.get("/suggestions", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_suggestions(
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/coaching.py
+++ b/src/career_os/api/coaching.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.coaching import (
     CoachingSuggestionResponse,
@@ -20,7 +20,7 @@ from career_os.services.coaching import (
 router = APIRouter(prefix="/api/coaching", tags=["coaching"])
 
 
-@router.get("/suggestions", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/suggestions", responses=RESP_404)
 async def get_suggestions(
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/constants.py
+++ b/src/career_os/api/constants.py
@@ -8,6 +8,12 @@ DESC_FILTER_BY_CATEGORY = "Filter by category"
 # OpenAPI response descriptions (used 93+ times across 22 API files)
 RESP_NOT_FOUND = "Not found"
 
+# Shared OpenAPI responses dicts for common endpoint patterns.
+# Using these avoids duplicating the same dict literal across dozens of routes.
+RESP_404 = {404: {"description": RESP_NOT_FOUND}}
+RESP_404_422 = {404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}}
+RESP_404_500 = {404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}}
+
 # Error messages (used 3+ times within single files)
 PROFILE_NOT_FOUND = "Profile not found"
 TIME_SESSION_NOT_FOUND = "Time session not found"

--- a/src/career_os/api/constants.py
+++ b/src/career_os/api/constants.py
@@ -5,6 +5,9 @@ DESC_PROFILE_ID = "Profile ID"
 DESC_ACTIVE_PROFILE_ID = "Active profile ID"
 DESC_FILTER_BY_CATEGORY = "Filter by category"
 
+# OpenAPI response descriptions (used 93+ times across 22 API files)
+RESP_NOT_FOUND = "Not found"
+
 # Error messages (used 3+ times within single files)
 PROFILE_NOT_FOUND = "Profile not found"
 TIME_SESSION_NOT_FOUND = "Time session not found"

--- a/src/career_os/api/contacts.py
+++ b/src/career_os/api/contacts.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.contacts import (
     ContactApplicationCreate,
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/api", tags=["contacts"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("/contacts", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/contacts", status_code=201, responses=RESP_404)
 async def create(
     payload: ContactCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -98,7 +98,7 @@ async def contacts_at_company(
     )
 
 
-@router.get("/contacts/{contact_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/contacts/{contact_id}", responses=RESP_404)
 async def get_detail(
     contact_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -122,7 +122,7 @@ async def get_detail(
     )
 
 
-@router.patch("/contacts/{contact_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.patch("/contacts/{contact_id}", responses=RESP_404)
 async def update(
     contact_id: int,
     payload: ContactUpdate,
@@ -140,7 +140,7 @@ async def update(
 @router.delete(
     "/contacts/{contact_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def delete(
     contact_id: int,
@@ -162,7 +162,7 @@ async def delete(
 @router.post(
     "/contacts/{contact_id}/interactions",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def log_interaction(
     contact_id: int,
@@ -180,7 +180,7 @@ async def log_interaction(
 
 @router.get(
     "/contacts/{contact_id}/interactions",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_interactions(
     contact_id: int,
@@ -226,7 +226,7 @@ async def link_application(
     return ContactApplicationResponse.model_validate(link)
 
 
-@router.get("/contacts/{contact_id}/applications", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/contacts/{contact_id}/applications", responses=RESP_404)
 async def get_linked_applications(
     contact_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -247,7 +247,7 @@ async def get_linked_applications(
 @router.delete(
     "/contacts/{contact_id}/applications/{application_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def unlink_application(
     contact_id: int,

--- a/src/career_os/api/contacts.py
+++ b/src/career_os/api/contacts.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.contacts import (
     ContactApplicationCreate,
@@ -35,7 +36,6 @@ from career_os.services.contacts import (
     unlink_contact_from_application,
     update_contact,
 )
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(prefix="/api", tags=["contacts"])
 
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/api", tags=["contacts"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("/contacts", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("/contacts", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create(
     payload: ContactCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -98,7 +98,7 @@ async def contacts_at_company(
     )
 
 
-@router.get("/contacts/{contact_id}", responses={404: {"description": "Not found"}})
+@router.get("/contacts/{contact_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_detail(
     contact_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -122,7 +122,7 @@ async def get_detail(
     )
 
 
-@router.patch("/contacts/{contact_id}", responses={404: {"description": "Not found"}})
+@router.patch("/contacts/{contact_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update(
     contact_id: int,
     payload: ContactUpdate,
@@ -140,7 +140,7 @@ async def update(
 @router.delete(
     "/contacts/{contact_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def delete(
     contact_id: int,
@@ -162,7 +162,7 @@ async def delete(
 @router.post(
     "/contacts/{contact_id}/interactions",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def log_interaction(
     contact_id: int,
@@ -180,7 +180,7 @@ async def log_interaction(
 
 @router.get(
     "/contacts/{contact_id}/interactions",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_interactions(
     contact_id: int,
@@ -206,7 +206,7 @@ async def get_interactions(
 @router.post(
     "/contacts/{contact_id}/applications",
     status_code=201,
-    responses={404: {"description": "Not found"}, 409: {"description": "Conflict"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 409: {"description": "Conflict"}},
 )
 async def link_application(
     contact_id: int,
@@ -226,7 +226,7 @@ async def link_application(
     return ContactApplicationResponse.model_validate(link)
 
 
-@router.get("/contacts/{contact_id}/applications", responses={404: {"description": "Not found"}})
+@router.get("/contacts/{contact_id}/applications", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_linked_applications(
     contact_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -247,7 +247,7 @@ async def get_linked_applications(
 @router.delete(
     "/contacts/{contact_id}/applications/{application_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def unlink_application(
     contact_id: int,

--- a/src/career_os/api/contacts.py
+++ b/src/career_os/api/contacts.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.contacts import (
     ContactApplicationCreate,
@@ -206,7 +206,7 @@ async def get_interactions(
 @router.post(
     "/contacts/{contact_id}/applications",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}, 409: {"description": "Conflict"}},
+    responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def link_application(
     contact_id: int,

--- a/src/career_os/api/discovery.py
+++ b/src/career_os/api/discovery.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.discovery import (
     DiscoveredJobResponse,
@@ -39,7 +39,7 @@ router = APIRouter(tags=["discovery"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("/api/discover", responses={404: {"description": "Not found"}})
+@router.post("/api/discover", responses={404: {"description": RESP_NOT_FOUND}})
 async def discover(
     payload: DiscoverRequest,
     db: Annotated[Session, Depends(get_db)],
@@ -84,7 +84,7 @@ async def discover(
 @router.post(
     "/api/search-profiles",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def create_search_profile_endpoint(
     payload: SearchProfileCreate,
@@ -121,7 +121,7 @@ async def list_search_profiles_endpoint(
 
 @router.get(
     "/api/search-profiles/{sp_id}",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_search_profile_endpoint(
     sp_id: int,
@@ -138,7 +138,7 @@ async def get_search_profile_endpoint(
 
 @router.put(
     "/api/search-profiles/{sp_id}",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def update_search_profile_endpoint(
     sp_id: int,
@@ -162,7 +162,7 @@ async def update_search_profile_endpoint(
 @router.delete(
     "/api/search-profiles/{sp_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def delete_search_profile_endpoint(
     sp_id: int,

--- a/src/career_os/api/discovery.py
+++ b/src/career_os/api/discovery.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.discovery import (
     DiscoveredJobResponse,
@@ -39,7 +39,7 @@ router = APIRouter(tags=["discovery"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("/api/discover", responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/api/discover", responses=RESP_404)
 async def discover(
     payload: DiscoverRequest,
     db: Annotated[Session, Depends(get_db)],
@@ -84,7 +84,7 @@ async def discover(
 @router.post(
     "/api/search-profiles",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def create_search_profile_endpoint(
     payload: SearchProfileCreate,
@@ -121,7 +121,7 @@ async def list_search_profiles_endpoint(
 
 @router.get(
     "/api/search-profiles/{sp_id}",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_search_profile_endpoint(
     sp_id: int,
@@ -138,7 +138,7 @@ async def get_search_profile_endpoint(
 
 @router.put(
     "/api/search-profiles/{sp_id}",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def update_search_profile_endpoint(
     sp_id: int,
@@ -162,7 +162,7 @@ async def update_search_profile_endpoint(
 @router.delete(
     "/api/search-profiles/{sp_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def delete_search_profile_endpoint(
     sp_id: int,

--- a/src/career_os/api/discovery.py
+++ b/src/career_os/api/discovery.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_PROFILE_ID
 from career_os.database import get_db
 from career_os.schemas.discovery import (
     DiscoveredJobResponse,
@@ -29,7 +30,6 @@ from career_os.services.discovery import (
     run_discovery,
     update_search_profile,
 )
-from career_os.api.constants import DESC_PROFILE_ID
 
 router = APIRouter(tags=["discovery"])
 
@@ -196,8 +196,8 @@ async def list_discovery_runs_endpoint(
 
 @router.get("/api/discovery-runs/latest")
 async def get_latest_discovery_run_endpoint(
-    profile_id: int = Query(..., description=DESC_PROFILE_ID),
-    db: Session = Depends(get_db),
+    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> DiscoveryRunResponse | None:
     """Get the most recent completed discovery run for a profile."""
     run = get_latest_discovery_run(db, profile_id)

--- a/src/career_os/api/follow_ups.py
+++ b/src/career_os/api/follow_ups.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.follow_ups import (
     FollowUpComplete,
@@ -22,12 +23,11 @@ from career_os.services.follow_ups import (
     get_overdue_count,
     list_follow_ups,
 )
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(prefix="/api/follow-ups", tags=["follow-ups"])
 
 
-@router.post("", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create(
     payload: FollowUpCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -96,7 +96,7 @@ async def list_all(
     )
 
 
-@router.patch("/{follow_up_id}", responses={404: {"description": "Not found"}})
+@router.patch("/{follow_up_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def complete(
     follow_up_id: int,
     payload: FollowUpComplete,

--- a/src/career_os/api/follow_ups.py
+++ b/src/career_os/api/follow_ups.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.follow_ups import (
     FollowUpComplete,
@@ -27,7 +27,7 @@ from career_os.services.follow_ups import (
 router = APIRouter(prefix="/api/follow-ups", tags=["follow-ups"])
 
 
-@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("", status_code=201, responses=RESP_404)
 async def create(
     payload: FollowUpCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -96,7 +96,7 @@ async def list_all(
     )
 
 
-@router.patch("/{follow_up_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.patch("/{follow_up_id}", responses=RESP_404)
 async def complete(
     follow_up_id: int,
     payload: FollowUpComplete,

--- a/src/career_os/api/gaps.py
+++ b/src/career_os/api/gaps.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Application
 from career_os.models.skills import JobRequirement
@@ -24,14 +25,13 @@ from career_os.services.gap_analysis import (
     analyze_gaps,
     create_job_requirements,
 )
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(tags=["gaps"])
 
 
 @router.get(
     "/api/applications/{application_id}/gaps",
-    responses={400: {"description": "Bad request"}, 404: {"description": "Not found"}},
+    responses={400: {"description": "Bad request"}, 404: {"description": RESP_NOT_FOUND}},
 )
 async def get_application_gaps(
     application_id: int,
@@ -67,7 +67,7 @@ async def get_application_gaps(
 
 @router.get(
     "/api/gaps/aggregate",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_aggregate_gaps(
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -120,7 +120,7 @@ async def get_requirements(
 @router.post(
     "/api/applications/{application_id}/requirements",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def create_requirements(
     application_id: int,

--- a/src/career_os/api/gaps.py
+++ b/src/career_os/api/gaps.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.models.models import Application
 from career_os.models.skills import JobRequirement
@@ -31,7 +31,7 @@ router = APIRouter(tags=["gaps"])
 
 @router.get(
     "/api/applications/{application_id}/gaps",
-    responses={400: {"description": "Bad request"}, 404: {"description": RESP_NOT_FOUND}},
+    responses={**RESP_404, 400: {"description": "Bad request"}},
 )
 async def get_application_gaps(
     application_id: int,

--- a/src/career_os/api/gaps.py
+++ b/src/career_os/api/gaps.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Application
 from career_os.models.skills import JobRequirement
@@ -67,7 +67,7 @@ async def get_application_gaps(
 
 @router.get(
     "/api/gaps/aggregate",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_aggregate_gaps(
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -120,7 +120,7 @@ async def get_requirements(
 @router.post(
     "/api/applications/{application_id}/requirements",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def create_requirements(
     application_id: int,

--- a/src/career_os/api/goals.py
+++ b/src/career_os/api/goals.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.goals import (
     AlternativePath,
@@ -32,7 +33,6 @@ from career_os.services.goals import (
     recalibrate_goal,
     update_goal,
 )
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
 
 router = APIRouter(prefix="/api/goals", tags=["goals"])
 
@@ -52,7 +52,7 @@ async def list_goals_endpoint(
     )
 
 
-@router.get("/{goal_id}", responses={404: {"description": "Not found"}})
+@router.get("/{goal_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -66,7 +66,7 @@ async def get_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.post("", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create_goal_endpoint(
     payload: GoalCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -89,7 +89,7 @@ async def create_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.put("/{goal_id}", responses={404: {"description": "Not found"}})
+@router.put("/{goal_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_goal_endpoint(
     goal_id: int,
     payload: GoalUpdate,
@@ -110,7 +110,7 @@ async def update_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.delete("/{goal_id}", status_code=204, responses={404: {"description": "Not found"}})
+@router.delete("/{goal_id}", status_code=204, responses={404: {"description": RESP_NOT_FOUND}})
 async def delete_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -123,7 +123,7 @@ async def delete_goal_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("/{goal_id}/reality-map", responses={404: {"description": "Not found"}})
+@router.get("/{goal_id}/reality-map", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_reality_map_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -148,7 +148,7 @@ async def get_reality_map_endpoint(
     )
 
 
-@router.get("/{goal_id}/progress", responses={404: {"description": "Not found"}})
+@router.get("/{goal_id}/progress", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_progress_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -168,7 +168,7 @@ async def get_progress_endpoint(
     )
 
 
-@router.put("/{goal_id}/recalibrate", responses={404: {"description": "Not found"}})
+@router.put("/{goal_id}/recalibrate", responses={404: {"description": RESP_NOT_FOUND}})
 async def recalibrate_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -189,7 +189,7 @@ async def recalibrate_goal_endpoint(
     )
 
 
-@router.get("/{goal_id}/alternatives", responses={404: {"description": "Not found"}})
+@router.get("/{goal_id}/alternatives", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_alternatives_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],

--- a/src/career_os/api/goals.py
+++ b/src/career_os/api/goals.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.goals import (
     AlternativePath,
@@ -52,7 +52,7 @@ async def list_goals_endpoint(
     )
 
 
-@router.get("/{goal_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{goal_id}", responses=RESP_404)
 async def get_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -66,7 +66,7 @@ async def get_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("", status_code=201, responses=RESP_404)
 async def create_goal_endpoint(
     payload: GoalCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -89,7 +89,7 @@ async def create_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.put("/{goal_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/{goal_id}", responses=RESP_404)
 async def update_goal_endpoint(
     goal_id: int,
     payload: GoalUpdate,
@@ -110,7 +110,7 @@ async def update_goal_endpoint(
     return GoalResponse.model_validate(goal)
 
 
-@router.delete("/{goal_id}", status_code=204, responses={404: {"description": RESP_NOT_FOUND}})
+@router.delete("/{goal_id}", status_code=204, responses=RESP_404)
 async def delete_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -123,7 +123,7 @@ async def delete_goal_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("/{goal_id}/reality-map", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{goal_id}/reality-map", responses=RESP_404)
 async def get_reality_map_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -148,7 +148,7 @@ async def get_reality_map_endpoint(
     )
 
 
-@router.get("/{goal_id}/progress", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{goal_id}/progress", responses=RESP_404)
 async def get_progress_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -168,7 +168,7 @@ async def get_progress_endpoint(
     )
 
 
-@router.put("/{goal_id}/recalibrate", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/{goal_id}/recalibrate", responses=RESP_404)
 async def recalibrate_goal_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -189,7 +189,7 @@ async def recalibrate_goal_endpoint(
     )
 
 
-@router.get("/{goal_id}/alternatives", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{goal_id}/alternatives", responses=RESP_404)
 async def get_alternatives_endpoint(
     goal_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],

--- a/src/career_os/api/integrations.py
+++ b/src/career_os/api/integrations.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import RESP_NOT_FOUND
+from career_os.api.constants import RESP_404
 from career_os.database import get_db
 from career_os.schemas.integrations import (
     IntegrationConfigResponse,
@@ -32,7 +32,7 @@ async def list_all_integrations(
     return IntegrationListResponse(integrations=integrations, count=len(integrations))
 
 
-@router.get("/{name}/config", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{name}/config", responses=RESP_404)
 async def get_integration_config(
     name: str,
     db: Annotated[Session, Depends(get_db)],
@@ -44,7 +44,7 @@ async def get_integration_config(
     return result
 
 
-@router.put("/{name}/config", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/{name}/config", responses=RESP_404)
 async def update_integration_config(
     name: str,
     payload: IntegrationConfigUpdate,
@@ -60,7 +60,7 @@ async def update_integration_config(
     return result
 
 
-@router.post("/{name}/test", responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/{name}/test", responses=RESP_404)
 async def test_integration(
     name: str,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/integrations.py
+++ b/src/career_os/api/integrations.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.integrations import (
     IntegrationConfigResponse,
@@ -31,7 +32,7 @@ async def list_all_integrations(
     return IntegrationListResponse(integrations=integrations, count=len(integrations))
 
 
-@router.get("/{name}/config", responses={404: {"description": "Not found"}})
+@router.get("/{name}/config", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_integration_config(
     name: str,
     db: Annotated[Session, Depends(get_db)],
@@ -43,7 +44,7 @@ async def get_integration_config(
     return result
 
 
-@router.put("/{name}/config", responses={404: {"description": "Not found"}})
+@router.put("/{name}/config", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_integration_config(
     name: str,
     payload: IntegrationConfigUpdate,
@@ -59,7 +60,7 @@ async def update_integration_config(
     return result
 
 
-@router.post("/{name}/test", responses={404: {"description": "Not found"}})
+@router.post("/{name}/test", responses={404: {"description": RESP_NOT_FOUND}})
 async def test_integration(
     name: str,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/intelligence.py
+++ b/src/career_os/api/intelligence.py
@@ -12,6 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.role_intelligence import (
     InterviewFormatResponse,
@@ -24,7 +25,6 @@ from career_os.services.role_intelligence import (
     get_interview_patterns,
     get_salary_benchmarks,
 )
-from career_os.api.constants import DESC_PROFILE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ router = APIRouter(prefix="/api/intelligence", tags=["role-intelligence"])
 
 @router.get(
     "/interview-format",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
 )
 async def interview_format_endpoint(
     company: Annotated[str, Query(min_length=1, description="Company name")],
@@ -77,7 +77,7 @@ async def interview_format_endpoint(
 
 @router.get(
     "/salary",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
 )
 async def salary_benchmark_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type to benchmark")],
@@ -119,7 +119,7 @@ async def salary_benchmark_endpoint(
 
 @router.get(
     "/patterns",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
 )
 async def interview_patterns_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type")],

--- a/src/career_os/api/intelligence.py
+++ b/src/career_os/api/intelligence.py
@@ -12,7 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404_500
 from career_os.database import get_db
 from career_os.schemas.role_intelligence import (
     InterviewFormatResponse,
@@ -38,7 +38,7 @@ router = APIRouter(prefix="/api/intelligence", tags=["role-intelligence"])
 
 @router.get(
     "/interview-format",
-    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
+    responses=RESP_404_500,
 )
 async def interview_format_endpoint(
     company: Annotated[str, Query(min_length=1, description="Company name")],
@@ -77,7 +77,7 @@ async def interview_format_endpoint(
 
 @router.get(
     "/salary",
-    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
+    responses=RESP_404_500,
 )
 async def salary_benchmark_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type to benchmark")],
@@ -119,7 +119,7 @@ async def salary_benchmark_endpoint(
 
 @router.get(
     "/patterns",
-    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
+    responses=RESP_404_500,
 )
 async def interview_patterns_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type")],

--- a/src/career_os/api/interview_prep.py
+++ b/src/career_os/api/interview_prep.py
@@ -14,7 +14,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404_500
 from career_os.database import get_db
 from career_os.schemas.interview_prep import (
     InterviewPrepResponse,
@@ -41,7 +41,7 @@ router = APIRouter(prefix="/api/applications", tags=["interview-prep"])
 
 @router.get(
     "/{application_id}/interview-prep",
-    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
+    responses=RESP_404_500,
 )
 async def get_interview_prep_endpoint(
     application_id: int,
@@ -81,7 +81,7 @@ async def get_interview_prep_endpoint(
 
 @router.patch(
     "/interview-prep/items/{item_id}",
-    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
+    responses=RESP_404_500,
 )
 async def update_prep_item_endpoint(
     item_id: int,

--- a/src/career_os/api/interview_prep.py
+++ b/src/career_os/api/interview_prep.py
@@ -14,6 +14,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.interview_prep import (
     InterviewPrepResponse,
@@ -27,7 +28,6 @@ from career_os.services.interview_prep import (
     get_or_create_interview_prep,
     update_prep_item,
 )
-from career_os.api.constants import DESC_PROFILE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ router = APIRouter(prefix="/api/applications", tags=["interview-prep"])
 
 @router.get(
     "/{application_id}/interview-prep",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
 )
 async def get_interview_prep_endpoint(
     application_id: int,
@@ -81,7 +81,7 @@ async def get_interview_prep_endpoint(
 
 @router.patch(
     "/interview-prep/items/{item_id}",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 500: {"description": "Internal server error"}},
 )
 async def update_prep_item_endpoint(
     item_id: int,

--- a/src/career_os/api/jobs.py
+++ b/src/career_os/api/jobs.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.jobs import (
     JobSearchResponse,
@@ -34,7 +34,7 @@ router = APIRouter(tags=["jobs"])
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/jobs", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/jobs", responses=RESP_404)
 async def search_jobs_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -113,7 +113,7 @@ async def search_jobs_endpoint(
 @router.post(
     "/api/saved-searches",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def create_saved_search_endpoint(
     payload: SavedSearchCreate,
@@ -152,7 +152,7 @@ async def list_saved_searches_endpoint(
 
 @router.get(
     "/api/saved-searches/{search_id}",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_saved_search_endpoint(
     search_id: int,
@@ -169,7 +169,7 @@ async def get_saved_search_endpoint(
 
 @router.put(
     "/api/saved-searches/{search_id}",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def update_saved_search_endpoint(
     search_id: int,
@@ -195,7 +195,7 @@ async def update_saved_search_endpoint(
 @router.delete(
     "/api/saved-searches/{search_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def delete_saved_search_endpoint(
     search_id: int,

--- a/src/career_os/api/jobs.py
+++ b/src/career_os/api/jobs.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.jobs import (
     JobSearchResponse,
@@ -34,7 +34,7 @@ router = APIRouter(tags=["jobs"])
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/jobs", responses={404: {"description": "Not found"}})
+@router.get("/api/jobs", responses={404: {"description": RESP_NOT_FOUND}})
 async def search_jobs_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -113,7 +113,7 @@ async def search_jobs_endpoint(
 @router.post(
     "/api/saved-searches",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def create_saved_search_endpoint(
     payload: SavedSearchCreate,
@@ -152,7 +152,7 @@ async def list_saved_searches_endpoint(
 
 @router.get(
     "/api/saved-searches/{search_id}",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_saved_search_endpoint(
     search_id: int,
@@ -169,7 +169,7 @@ async def get_saved_search_endpoint(
 
 @router.put(
     "/api/saved-searches/{search_id}",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def update_saved_search_endpoint(
     search_id: int,
@@ -195,7 +195,7 @@ async def update_saved_search_endpoint(
 @router.delete(
     "/api/saved-searches/{search_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def delete_saved_search_endpoint(
     search_id: int,

--- a/src/career_os/api/learning.py
+++ b/src/career_os/api/learning.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
 from career_os.schemas.learning import (
     GapRecommendationsResponse,
@@ -29,7 +29,7 @@ router = APIRouter(tags=["learning"])
 
 @router.get(
     "/api/gaps/{gap_id}/recommendations",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_recommendations(
     gap_id: int,
@@ -73,7 +73,7 @@ async def get_recommendations(
 @router.post(
     "/api/gaps/{gap_id}/recommendations",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def add_recommendation(
     gap_id: int,
@@ -109,7 +109,7 @@ async def add_recommendation(
 
 @router.patch(
     "/api/learning/{resource_id}/status",
-    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
+    responses=RESP_404_422,
 )
 async def update_status(
     resource_id: int,

--- a/src/career_os/api/learning.py
+++ b/src/career_os/api/learning.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.learning import (
     GapRecommendationsResponse,
@@ -29,7 +29,7 @@ router = APIRouter(tags=["learning"])
 
 @router.get(
     "/api/gaps/{gap_id}/recommendations",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_recommendations(
     gap_id: int,
@@ -73,7 +73,7 @@ async def get_recommendations(
 @router.post(
     "/api/gaps/{gap_id}/recommendations",
     status_code=201,
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def add_recommendation(
     gap_id: int,
@@ -109,7 +109,7 @@ async def add_recommendation(
 
 @router.patch(
     "/api/learning/{resource_id}/status",
-    responses={404: {"description": "Not found"}, 422: {"description": "Validation error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
 )
 async def update_status(
     resource_id: int,

--- a/src/career_os/api/market.py
+++ b/src/career_os/api/market.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.market import (
     HiringPatternsResponse,
@@ -35,7 +35,7 @@ router = APIRouter(tags=["market-intelligence"])
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/salary-trends", responses={404: {"description": "Not found"}})
+@router.get("/api/market/salary-trends", responses={404: {"description": RESP_NOT_FOUND}})
 async def salary_trends_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -60,7 +60,7 @@ async def salary_trends_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/skill-trends", responses={404: {"description": "Not found"}})
+@router.get("/api/market/skill-trends", responses={404: {"description": RESP_NOT_FOUND}})
 async def skill_trends_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -83,7 +83,7 @@ async def skill_trends_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/hiring-patterns", responses={404: {"description": "Not found"}})
+@router.get("/api/market/hiring-patterns", responses={404: {"description": RESP_NOT_FOUND}})
 async def hiring_patterns_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -106,7 +106,7 @@ async def hiring_patterns_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/positioning", responses={404: {"description": "Not found"}})
+@router.get("/api/market/positioning", responses={404: {"description": RESP_NOT_FOUND}})
 async def positioning_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -129,7 +129,7 @@ async def positioning_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/opportunity-radar", responses={404: {"description": "Not found"}})
+@router.get("/api/market/opportunity-radar", responses={404: {"description": RESP_NOT_FOUND}})
 async def opportunity_radar_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -175,7 +175,7 @@ async def opportunity_radar_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/api/market/refresh", responses={404: {"description": "Not found"}})
+@router.post("/api/market/refresh", responses={404: {"description": RESP_NOT_FOUND}})
 async def refresh_market_endpoint(
     payload: MarketRefreshRequest,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/market.py
+++ b/src/career_os/api/market.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.market import (
     HiringPatternsResponse,
@@ -35,7 +35,7 @@ router = APIRouter(tags=["market-intelligence"])
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/salary-trends", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/market/salary-trends", responses=RESP_404)
 async def salary_trends_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -60,7 +60,7 @@ async def salary_trends_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/skill-trends", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/market/skill-trends", responses=RESP_404)
 async def skill_trends_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -83,7 +83,7 @@ async def skill_trends_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/hiring-patterns", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/market/hiring-patterns", responses=RESP_404)
 async def hiring_patterns_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -106,7 +106,7 @@ async def hiring_patterns_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/positioning", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/market/positioning", responses=RESP_404)
 async def positioning_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -129,7 +129,7 @@ async def positioning_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/market/opportunity-radar", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/market/opportunity-radar", responses=RESP_404)
 async def opportunity_radar_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -175,7 +175,7 @@ async def opportunity_radar_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/api/market/refresh", responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/api/market/refresh", responses=RESP_404)
 async def refresh_market_endpoint(
     payload: MarketRefreshRequest,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import PROFILE_NOT_FOUND, RESP_NOT_FOUND
+from career_os.api.constants import PROFILE_NOT_FOUND, RESP_404, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Profile
 from career_os.schemas.profiles import (
@@ -31,7 +31,7 @@ async def list_profiles(db: Annotated[Session, Depends(get_db)]) -> ProfileListR
     )
 
 
-@router.get("/{profile_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{profile_id}", responses=RESP_404)
 async def get_profile(profile_id: int, db: Annotated[Session, Depends(get_db)]) -> ProfileResponse:
     """Get a specific profile by ID."""
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
@@ -62,7 +62,7 @@ async def create_profile(
     return ProfileResponse.model_validate(profile)
 
 
-@router.patch("/{profile_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.patch("/{profile_id}", responses=RESP_404)
 async def update_profile(
     profile_id: int,
     payload: ProfileUpdate,

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import PROFILE_NOT_FOUND, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Profile
 from career_os.schemas.profiles import (
@@ -16,7 +17,6 @@ from career_os.schemas.profiles import (
     ProfileUpdate,
 )
 from career_os.services.scoring import flag_stale_scores, regenerate_weights_for_job_family
-from career_os.api.constants import PROFILE_NOT_FOUND
 
 router = APIRouter(prefix="/api/profiles", tags=["profiles"])
 
@@ -31,7 +31,7 @@ async def list_profiles(db: Annotated[Session, Depends(get_db)]) -> ProfileListR
     )
 
 
-@router.get("/{profile_id}", responses={404: {"description": "Not found"}})
+@router.get("/{profile_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_profile(profile_id: int, db: Annotated[Session, Depends(get_db)]) -> ProfileResponse:
     """Get a specific profile by ID."""
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
@@ -62,7 +62,7 @@ async def create_profile(
     return ProfileResponse.model_validate(profile)
 
 
-@router.patch("/{profile_id}", responses={404: {"description": "Not found"}})
+@router.patch("/{profile_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_profile(
     profile_id: int,
     payload: ProfileUpdate,
@@ -104,7 +104,7 @@ async def update_profile(
 @router.delete(
     "/{profile_id}",
     status_code=204,
-    responses={404: {"description": "Not found"}, 409: {"description": "Conflict"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 409: {"description": "Conflict"}},
 )
 async def delete_profile(
     profile_id: int,

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import PROFILE_NOT_FOUND, RESP_404, RESP_NOT_FOUND
+from career_os.api.constants import PROFILE_NOT_FOUND, RESP_404
 from career_os.database import get_db
 from career_os.models.models import Profile
 from career_os.schemas.profiles import (
@@ -104,7 +104,7 @@ async def update_profile(
 @router.delete(
     "/{profile_id}",
     status_code=204,
-    responses={404: {"description": RESP_NOT_FOUND}, 409: {"description": "Conflict"}},
+    responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def delete_profile(
     profile_id: int,

--- a/src/career_os/api/research.py
+++ b/src/career_os/api/research.py
@@ -12,6 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from career_os.api.constants import RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.research import (
     CompanyResearchReport,
@@ -31,7 +32,7 @@ router = APIRouter(prefix="/api/research", tags=["research"])
 @router.post(
     "/company",
     responses={
-        404: {"description": "Not found"},
+        404: {"description": RESP_NOT_FOUND},
         500: {"description": "Internal server error"},
         502: {"description": "Bad gateway"},
     },

--- a/src/career_os/api/research.py
+++ b/src/career_os/api/research.py
@@ -12,7 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import RESP_NOT_FOUND
+from career_os.api.constants import RESP_404
 from career_os.database import get_db
 from career_os.schemas.research import (
     CompanyResearchReport,
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/research", tags=["research"])
 @router.post(
     "/company",
     responses={
-        404: {"description": RESP_NOT_FOUND},
+        **RESP_404,
         500: {"description": "Internal server error"},
         502: {"description": "Bad gateway"},
     },

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from career_os.ai.openrouter_provider import CreditsExhaustedError
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
@@ -98,7 +98,7 @@ async def score_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/scoring-weights", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/scoring-weights", responses=RESP_404)
 async def get_weights_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -112,7 +112,7 @@ async def get_weights_endpoint(
     return ScoringWeightsResponse.model_validate(weights)
 
 
-@router.put("/api/scoring-weights", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/api/scoring-weights", responses=RESP_404)
 async def update_weights_endpoint(
     payload: ScoringWeightsUpdate,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -196,7 +196,7 @@ async def batch_score_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/score/job/{discovered_job_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/api/score/job/{discovered_job_id}", responses=RESP_404)
 async def get_job_score_endpoint(
     discovered_job_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -211,7 +211,7 @@ async def get_job_score_endpoint(
 
 @router.get(
     "/api/score/application/{application_id}",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_application_score_endpoint(
     application_id: int,

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -48,6 +48,7 @@ router = APIRouter(tags=["scoring"])
     responses={
         402: {"description": "Payment required"},
         404: {"description": "Not found"},
+        422: {"description": "Profile incomplete"},
         500: {"description": "Internal server error"},
         502: {"description": "Bad gateway"},
     },
@@ -140,7 +141,11 @@ async def update_weights_endpoint(
 
 @router.post(
     "/api/score/batch",
-    responses={404: {"description": "Not found"}, 500: {"description": "Internal server error"}},
+    responses={
+        404: {"description": "Not found"},
+        422: {"description": "Profile incomplete"},
+        500: {"description": "Internal server error"},
+    },
 )
 async def batch_score_endpoint(
     payload: BatchScoreRequest,

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from career_os.ai.openrouter_provider import CreditsExhaustedError
-from career_os.api.constants import DESC_PROFILE_ID, RESP_404, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
@@ -46,8 +46,8 @@ router = APIRouter(tags=["scoring"])
     "/api/score",
     status_code=201,
     responses={
+        **RESP_404,
         402: {"description": "Payment required"},
-        404: {"description": RESP_NOT_FOUND},
         422: {"description": "Profile incomplete"},
         500: {"description": "Internal server error"},
         502: {"description": "Bad gateway"},
@@ -142,7 +142,7 @@ async def update_weights_endpoint(
 @router.post(
     "/api/score/batch",
     responses={
-        404: {"description": RESP_NOT_FOUND},
+        **RESP_404,
         422: {"description": "Profile incomplete"},
         500: {"description": "Internal server error"},
     },

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from career_os.ai.openrouter_provider import CreditsExhaustedError
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
@@ -47,7 +47,7 @@ router = APIRouter(tags=["scoring"])
     status_code=201,
     responses={
         402: {"description": "Payment required"},
-        404: {"description": "Not found"},
+        404: {"description": RESP_NOT_FOUND},
         422: {"description": "Profile incomplete"},
         500: {"description": "Internal server error"},
         502: {"description": "Bad gateway"},
@@ -98,7 +98,7 @@ async def score_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/scoring-weights", responses={404: {"description": "Not found"}})
+@router.get("/api/scoring-weights", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_weights_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -112,7 +112,7 @@ async def get_weights_endpoint(
     return ScoringWeightsResponse.model_validate(weights)
 
 
-@router.put("/api/scoring-weights", responses={404: {"description": "Not found"}})
+@router.put("/api/scoring-weights", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_weights_endpoint(
     payload: ScoringWeightsUpdate,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -142,7 +142,7 @@ async def update_weights_endpoint(
 @router.post(
     "/api/score/batch",
     responses={
-        404: {"description": "Not found"},
+        404: {"description": RESP_NOT_FOUND},
         422: {"description": "Profile incomplete"},
         500: {"description": "Internal server error"},
     },
@@ -196,7 +196,7 @@ async def batch_score_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/score/job/{discovered_job_id}", responses={404: {"description": "Not found"}})
+@router.get("/api/score/job/{discovered_job_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_job_score_endpoint(
     discovered_job_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -211,7 +211,7 @@ async def get_job_score_endpoint(
 
 @router.get(
     "/api/score/application/{application_id}",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_application_score_endpoint(
     application_id: int,

--- a/src/career_os/api/skills.py
+++ b/src/career_os/api/skills.py
@@ -6,7 +6,11 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, DESC_FILTER_BY_CATEGORY, RESP_NOT_FOUND
+from career_os.api.constants import (
+    DESC_ACTIVE_PROFILE_ID,
+    DESC_FILTER_BY_CATEGORY,
+    RESP_404,
+)
 from career_os.database import get_db
 from career_os.schemas.skills import (
     IngestRequest,
@@ -73,7 +77,7 @@ async def list_skills_endpoint(
     )
 
 
-@router.get("/{skill_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{skill_id}", responses=RESP_404)
 async def get_skill_endpoint(
     skill_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -87,7 +91,7 @@ async def get_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.get("/{skill_id}/history", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{skill_id}/history", responses=RESP_404)
 async def get_skill_history_endpoint(
     skill_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -101,7 +105,7 @@ async def get_skill_history_endpoint(
     return [SkillHistoryResponse.model_validate(h) for h in history]
 
 
-@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("", status_code=201, responses=RESP_404)
 async def create_skill_endpoint(
     payload: SkillCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -129,7 +133,7 @@ async def create_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.put("/{skill_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/{skill_id}", responses=RESP_404)
 async def update_skill_endpoint(
     skill_id: int,
     payload: SkillUpdate,
@@ -151,7 +155,7 @@ async def update_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.post("/ingest", responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("/ingest", responses=RESP_404)
 async def ingest_skills_endpoint(
     payload: IngestRequest,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/skills.py
+++ b/src/career_os/api/skills.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, DESC_FILTER_BY_CATEGORY
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, DESC_FILTER_BY_CATEGORY, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.skills import (
     IngestRequest,
@@ -73,7 +73,7 @@ async def list_skills_endpoint(
     )
 
 
-@router.get("/{skill_id}", responses={404: {"description": "Not found"}})
+@router.get("/{skill_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_skill_endpoint(
     skill_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -87,7 +87,7 @@ async def get_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.get("/{skill_id}/history", responses={404: {"description": "Not found"}})
+@router.get("/{skill_id}/history", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_skill_history_endpoint(
     skill_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -101,7 +101,7 @@ async def get_skill_history_endpoint(
     return [SkillHistoryResponse.model_validate(h) for h in history]
 
 
-@router.post("", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create_skill_endpoint(
     payload: SkillCreate,
     db: Annotated[Session, Depends(get_db)],
@@ -129,7 +129,7 @@ async def create_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.put("/{skill_id}", responses={404: {"description": "Not found"}})
+@router.put("/{skill_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_skill_endpoint(
     skill_id: int,
     payload: SkillUpdate,
@@ -151,7 +151,7 @@ async def update_skill_endpoint(
     return SkillResponse.model_validate(skill)
 
 
-@router.post("/ingest", responses={404: {"description": "Not found"}})
+@router.post("/ingest", responses={404: {"description": RESP_NOT_FOUND}})
 async def ingest_skills_endpoint(
     payload: IngestRequest,
     db: Annotated[Session, Depends(get_db)],

--- a/src/career_os/api/star_stories.py
+++ b/src/career_os/api/star_stories.py
@@ -12,7 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.star_stories import (
     RecommendedStoriesResponse,
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/api/star-stories", tags=["star-stories"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("", status_code=201, responses={404: {"description": "Not found"}})
+@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
 async def create_star_story_endpoint(
     body: StarStoryCreate,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -58,7 +58,7 @@ async def create_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("", responses={404: {"description": "Not found"}})
+@router.get("", responses={404: {"description": RESP_NOT_FOUND}})
 async def list_star_stories_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -70,7 +70,7 @@ async def list_star_stories_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("/{story_id}", responses={404: {"description": "Not found"}})
+@router.get("/{story_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_star_story_endpoint(
     story_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -85,7 +85,7 @@ async def get_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.put("/{story_id}", responses={404: {"description": "Not found"}})
+@router.put("/{story_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_star_story_endpoint(
     story_id: int,
     body: StarStoryUpdate,
@@ -101,7 +101,7 @@ async def update_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.delete("/{story_id}", status_code=204, responses={404: {"description": "Not found"}})
+@router.delete("/{story_id}", status_code=204, responses={404: {"description": RESP_NOT_FOUND}})
 async def delete_star_story_endpoint(
     story_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -125,7 +125,7 @@ app_router = APIRouter(prefix="/api/applications", tags=["star-stories"])
 
 @app_router.get(
     "/{application_id}/recommended-stories",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_recommended_stories_endpoint(
     application_id: int,
@@ -146,7 +146,7 @@ async def get_recommended_stories_endpoint(
 
 @app_router.get(
     "/{application_id}/story-gaps",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def get_story_gaps_endpoint(
     application_id: int,

--- a/src/career_os/api/star_stories.py
+++ b/src/career_os/api/star_stories.py
@@ -12,7 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.schemas.star_stories import (
     RecommendedStoriesResponse,
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/api/star-stories", tags=["star-stories"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("", status_code=201, responses={404: {"description": RESP_NOT_FOUND}})
+@router.post("", status_code=201, responses=RESP_404)
 async def create_star_story_endpoint(
     body: StarStoryCreate,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -58,7 +58,7 @@ async def create_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("", responses=RESP_404)
 async def list_star_stories_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
@@ -70,7 +70,7 @@ async def list_star_stories_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("/{story_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/{story_id}", responses=RESP_404)
 async def get_star_story_endpoint(
     story_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -85,7 +85,7 @@ async def get_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.put("/{story_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.put("/{story_id}", responses=RESP_404)
 async def update_star_story_endpoint(
     story_id: int,
     body: StarStoryUpdate,
@@ -101,7 +101,7 @@ async def update_star_story_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.delete("/{story_id}", status_code=204, responses={404: {"description": RESP_NOT_FOUND}})
+@router.delete("/{story_id}", status_code=204, responses=RESP_404)
 async def delete_star_story_endpoint(
     story_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -125,7 +125,7 @@ app_router = APIRouter(prefix="/api/applications", tags=["star-stories"])
 
 @app_router.get(
     "/{application_id}/recommended-stories",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_recommended_stories_endpoint(
     application_id: int,
@@ -146,7 +146,7 @@ async def get_recommended_stories_endpoint(
 
 @app_router.get(
     "/{application_id}/story-gaps",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def get_story_gaps_endpoint(
     application_id: int,

--- a/src/career_os/api/ticktick.py
+++ b/src/career_os/api/ticktick.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID
+from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Application, FollowUp
 from career_os.models.skills import Goal
@@ -65,7 +65,7 @@ async def ticktick_sync_status(
     "/push",
     responses={
         400: {"description": "Bad request"},
-        404: {"description": "Not found"},
+        404: {"description": RESP_NOT_FOUND},
         422: {"description": "Validation error"},
         502: {"description": "Bad gateway"},
     },

--- a/src/career_os/api/ticktick.py
+++ b/src/career_os/api/ticktick.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.models.models import Application, FollowUp
 from career_os.models.skills import Goal
@@ -65,8 +65,8 @@ async def ticktick_sync_status(
 @router.post(
     "/push",
     responses={
+        **RESP_404,
         400: {"description": "Bad request"},
-        404: {"description": RESP_NOT_FOUND},
         422: {"description": "Validation error"},
         502: {"description": "Bad gateway"},
     },

--- a/src/career_os/api/ticktick.py
+++ b/src/career_os/api/ticktick.py
@@ -10,6 +10,7 @@ from career_os.api.constants import DESC_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.models.models import Application, FollowUp
 from career_os.models.skills import Goal
+from career_os.models.ticktick_sync import TickTickSyncTask
 from career_os.schemas.ticktick import (
     TickTickConnectionTestResponse,
     TickTickPullResponse,
@@ -79,53 +80,7 @@ async def ticktick_push(
     Supports: follow_up, learning_goal, pipeline_action.
     """
     try:
-        if payload.entity_type == "follow_up":
-            follow_up = (
-                db.query(FollowUp)
-                .filter(
-                    FollowUp.id == payload.entity_id,
-                    FollowUp.profile_id == payload.profile_id,
-                )
-                .first()
-            )
-            if not follow_up:
-                raise HTTPException(status_code=404, detail="Follow-up not found")
-            sync_task = sync_follow_up_to_ticktick(db, follow_up)
-
-        elif payload.entity_type == "learning_goal":
-            goal = (
-                db.query(Goal)
-                .filter(
-                    Goal.id == payload.entity_id,
-                    Goal.profile_id == payload.profile_id,
-                )
-                .first()
-            )
-            if not goal:
-                raise HTTPException(status_code=404, detail="Learning goal not found")
-            sync_task = sync_learning_goal_to_ticktick(db, goal)
-
-        elif payload.entity_type == "pipeline_action":
-            application = (
-                db.query(Application)
-                .filter(
-                    Application.id == payload.entity_id,
-                    Application.profile_id == payload.profile_id,
-                )
-                .first()
-            )
-            if not application:
-                raise HTTPException(status_code=404, detail="Application not found")
-            sync_task = sync_pipeline_action_to_ticktick(
-                db, application, f"Action for {application.company}"
-            )
-        else:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Invalid entity_type: {payload.entity_type}. "
-                "Must be follow_up, learning_goal, or pipeline_action",
-            )
-
+        sync_task = _resolve_and_sync(db, payload)
         return TickTickPushResponse(
             success=True,
             message=f"Synced {payload.entity_type} {payload.entity_id} to TickTick",
@@ -144,6 +99,37 @@ async def ticktick_push(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except TickTickSyncError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+def _resolve_and_sync(db: Session, payload: TickTickPushRequest) -> TickTickSyncTask:
+    """Look up the entity and sync it to TickTick."""
+    if payload.entity_type == "follow_up":
+        entity = _fetch_entity(db, FollowUp, payload.entity_id, payload.profile_id, "Follow-up")
+        return sync_follow_up_to_ticktick(db, entity)
+
+    if payload.entity_type == "learning_goal":
+        entity = _fetch_entity(db, Goal, payload.entity_id, payload.profile_id, "Learning goal")
+        return sync_learning_goal_to_ticktick(db, entity)
+
+    if payload.entity_type == "pipeline_action":
+        entity = _fetch_entity(
+            db, Application, payload.entity_id, payload.profile_id, "Application"
+        )
+        return sync_pipeline_action_to_ticktick(db, entity, f"Action for {entity.company}")
+
+    raise HTTPException(
+        status_code=422,
+        detail=f"Invalid entity_type: {payload.entity_type}. "
+        "Must be follow_up, learning_goal, or pipeline_action",
+    )
+
+
+def _fetch_entity(db: Session, model, entity_id: int, profile_id: int, label: str):
+    """Query a model by id + profile_id, raising 404 if missing."""
+    obj = db.query(model).filter(model.id == entity_id, model.profile_id == profile_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail=f"{label} not found")
+    return obj
 
 
 @router.post("/pull", responses={400: {"description": "Bad request"}})

--- a/src/career_os/api/timingsapp.py
+++ b/src/career_os/api/timingsapp.py
@@ -13,7 +13,12 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_FILTER_BY_CATEGORY, DESC_PROFILE_ID, TIME_SESSION_NOT_FOUND
+from career_os.api.constants import (
+    DESC_FILTER_BY_CATEGORY,
+    DESC_PROFILE_ID,
+    RESP_NOT_FOUND,
+    TIME_SESSION_NOT_FOUND,
+)
 from career_os.database import get_db
 from career_os.schemas.timingsapp import (
     TimeAnalyticsResponse,
@@ -63,7 +68,7 @@ async def create_session(
 
 @router.put(
     "/sessions/{session_id}/stop",
-    responses={400: {"description": "Bad request"}, 404: {"description": "Not found"}},
+    responses={400: {"description": "Bad request"}, 404: {"description": RESP_NOT_FOUND}},
 )
 async def stop_session_endpoint(
     session_id: int,
@@ -124,7 +129,7 @@ async def get_running_session_endpoint(
     return TimeSessionResponse.model_validate(session_record)
 
 
-@router.get("/sessions/{session_id}", responses={404: {"description": "Not found"}})
+@router.get("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_session_endpoint(
     session_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -138,7 +143,7 @@ async def get_session_endpoint(
         raise HTTPException(status_code=404, detail=TIME_SESSION_NOT_FOUND) from exc
 
 
-@router.patch("/sessions/{session_id}", responses={404: {"description": "Not found"}})
+@router.patch("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def update_session_endpoint(
     session_id: int,
     payload: TimeSessionUpdate,

--- a/src/career_os/api/timingsapp.py
+++ b/src/career_os/api/timingsapp.py
@@ -17,7 +17,6 @@ from career_os.api.constants import (
     DESC_FILTER_BY_CATEGORY,
     DESC_PROFILE_ID,
     RESP_404,
-    RESP_NOT_FOUND,
     TIME_SESSION_NOT_FOUND,
 )
 from career_os.database import get_db
@@ -69,7 +68,7 @@ async def create_session(
 
 @router.put(
     "/sessions/{session_id}/stop",
-    responses={400: {"description": "Bad request"}, 404: {"description": RESP_NOT_FOUND}},
+    responses={**RESP_404, 400: {"description": "Bad request"}},
 )
 async def stop_session_endpoint(
     session_id: int,

--- a/src/career_os/api/timingsapp.py
+++ b/src/career_os/api/timingsapp.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from career_os.api.constants import (
     DESC_FILTER_BY_CATEGORY,
     DESC_PROFILE_ID,
+    RESP_404,
     RESP_NOT_FOUND,
     TIME_SESSION_NOT_FOUND,
 )
@@ -129,7 +130,7 @@ async def get_running_session_endpoint(
     return TimeSessionResponse.model_validate(session_record)
 
 
-@router.get("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/sessions/{session_id}", responses=RESP_404)
 async def get_session_endpoint(
     session_id: int,
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
@@ -143,7 +144,7 @@ async def get_session_endpoint(
         raise HTTPException(status_code=404, detail=TIME_SESSION_NOT_FOUND) from exc
 
 
-@router.patch("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.patch("/sessions/{session_id}", responses=RESP_404)
 async def update_session_endpoint(
     session_id: int,
     payload: TimeSessionUpdate,

--- a/src/career_os/api/voice.py
+++ b/src/career_os/api/voice.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
 from career_os.database import get_db
 from career_os.schemas.voice import (
     VoiceMessageCreate,
@@ -33,7 +33,7 @@ router = APIRouter(prefix="/api/voice", tags=["voice"])
 @router.post(
     "/sessions",
     status_code=201,
-    responses={404: {"description": "Not found"}, 422: {"description": "Validation error"}},
+    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
 )
 async def create_voice_session(
     data: VoiceSessionCreate,
@@ -78,7 +78,7 @@ async def list_voice_sessions(
     )
 
 
-@router.get("/sessions/{session_id}", responses={404: {"description": "Not found"}})
+@router.get("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
 async def get_voice_session(
     session_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -95,7 +95,7 @@ async def get_voice_session(
 
 @router.post(
     "/sessions/{session_id}/messages",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def send_voice_message(
     session_id: int,
@@ -128,7 +128,7 @@ async def send_voice_message(
 
 @router.post(
     "/sessions/{session_id}/complete",
-    responses={404: {"description": "Not found"}},
+    responses={404: {"description": RESP_NOT_FOUND}},
 )
 async def complete_voice_session(
     session_id: int,

--- a/src/career_os/api/voice.py
+++ b/src/career_os/api/voice.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_NOT_FOUND
+from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
 from career_os.schemas.voice import (
     VoiceMessageCreate,
@@ -33,7 +33,7 @@ router = APIRouter(prefix="/api/voice", tags=["voice"])
 @router.post(
     "/sessions",
     status_code=201,
-    responses={404: {"description": RESP_NOT_FOUND}, 422: {"description": "Validation error"}},
+    responses=RESP_404_422,
 )
 async def create_voice_session(
     data: VoiceSessionCreate,
@@ -78,7 +78,7 @@ async def list_voice_sessions(
     )
 
 
-@router.get("/sessions/{session_id}", responses={404: {"description": RESP_NOT_FOUND}})
+@router.get("/sessions/{session_id}", responses=RESP_404)
 async def get_voice_session(
     session_id: int,
     profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
@@ -95,7 +95,7 @@ async def get_voice_session(
 
 @router.post(
     "/sessions/{session_id}/messages",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def send_voice_message(
     session_id: int,
@@ -128,7 +128,7 @@ async def send_voice_message(
 
 @router.post(
     "/sessions/{session_id}/complete",
-    responses={404: {"description": RESP_NOT_FOUND}},
+    responses=RESP_404,
 )
 async def complete_voice_session(
     session_id: int,

--- a/src/career_os/services/applications.py
+++ b/src/career_os/services/applications.py
@@ -189,6 +189,47 @@ def list_applications(
     return applications, total
 
 
+def _handle_status_transition(db: Session, app_obj: Application, update_data: dict) -> None:
+    """Validate and log a status transition if present in update_data."""
+    if "status" not in update_data:
+        return
+    new_status = update_data["status"].strip().lower()
+    update_data["status"] = new_status
+    old_status = app_obj.status.strip().lower()
+    if not is_valid_transition(old_status, new_status):
+        raise InvalidStatusTransitionError(old_status, new_status)
+    _log_activity(
+        db,
+        profile_id=app_obj.profile_id,
+        application_id=app_obj.id,
+        action="status_changed",
+        details=f"Status changed from '{old_status}' to '{new_status}'",
+    )
+    if new_status == "applied" and app_obj.date_applied is None:
+        app_obj.date_applied = datetime.now(UTC)
+
+
+def _apply_field_updates(db: Session, app_obj: Application, update_data: dict) -> None:
+    """Set fields on the application and log non-status changes."""
+    changed_fields = []
+    for field, value in update_data.items():
+        if field == "status":
+            setattr(app_obj, field, value)
+        else:
+            old_val = getattr(app_obj, field, None)
+            if old_val != value:
+                changed_fields.append(field)
+                setattr(app_obj, field, value)
+    if changed_fields:
+        _log_activity(
+            db,
+            profile_id=app_obj.profile_id,
+            application_id=app_obj.id,
+            action="updated",
+            details=f"Updated fields: {', '.join(changed_fields)}",
+        )
+
+
 def update_application(
     db: Session,
     application_id: int,
@@ -203,58 +244,15 @@ def update_application(
     does not belong to that profile.
     """
     app_obj = _get_active_application(db, application_id, profile_id=profile_id)
-
     update_data = payload.model_dump(exclude_unset=True)
 
-    # Handle status transition validation
-    if "status" in update_data:
-        new_status = update_data["status"].strip().lower()
-        update_data["status"] = new_status  # ensure stored value is canonical
-        old_status = app_obj.status.strip().lower()
-        if not is_valid_transition(old_status, new_status):
-            raise InvalidStatusTransitionError(old_status, new_status)
+    _handle_status_transition(db, app_obj, update_data)
+    _apply_field_updates(db, app_obj, update_data)
 
-        # Log status change separately
-        _log_activity(
-            db,
-            profile_id=app_obj.profile_id,
-            application_id=app_obj.id,
-            action="status_changed",
-            details=f"Status changed from '{old_status}' to '{new_status}'",
-        )
-
-        # If transitioning to applied, set date_applied
-        if new_status == "applied" and app_obj.date_applied is None:
-            app_obj.date_applied = datetime.now(UTC)
-
-    # Track non-status changes
-    changed_fields = []
-    for field, value in update_data.items():
-        if field == "status":
-            setattr(app_obj, field, value)
-        else:
-            old_val = getattr(app_obj, field, None)
-            if old_val != value:
-                changed_fields.append(field)
-                setattr(app_obj, field, value)
-
-    # Log field updates (not status — that's logged above)
-    if changed_fields:
-        _log_activity(
-            db,
-            profile_id=app_obj.profile_id,
-            application_id=app_obj.id,
-            action="updated",
-            details=f"Updated fields: {', '.join(changed_fields)}",
-        )
-
-    # Capture status change for auto-sync before commit
     status_changed = "status" in update_data
-
     db.commit()
     db.refresh(app_obj)
 
-    # Auto-push status change to TickTick (no-op if not configured)
     if status_changed:
         from career_os.services.ticktick_sync import try_auto_push_pipeline_action
 

--- a/src/career_os/services/jobs.py
+++ b/src/career_os/services/jobs.py
@@ -109,7 +109,7 @@ def _build_job_filters(
             dt_to = datetime.fromisoformat(date_to).replace(tzinfo=UTC)
             query = query.filter(DiscoveredJob.created_at <= dt_to)
         except ValueError:
-            pass
+            pass  # ignore invalid date
 
     return query
 

--- a/src/career_os/services/learning.py
+++ b/src/career_os/services/learning.py
@@ -189,6 +189,24 @@ VALID_TRANSITIONS: dict[str, set[str]] = {
 }
 
 
+def _apply_status_timestamps(
+    db: Session, resource: LearningResource, new_status: str, now: datetime
+) -> None:
+    """Set timestamps and trigger side effects for a learning status transition."""
+    resource.status = new_status
+    if new_status == "in_progress":
+        if resource.started_at is None:
+            resource.started_at = now
+    elif new_status == "completed":
+        if resource.started_at is None:
+            resource.started_at = now
+        resource.completed_at = now
+        _upgrade_skill_on_completion(db, resource)
+    elif new_status == "not_started":
+        resource.started_at = None
+        resource.completed_at = None
+
+
 def update_learning_status(
     db: Session,
     resource_id: int,
@@ -238,24 +256,7 @@ def update_learning_status(
 
     now = _utcnow()
 
-    if new_status == "in_progress":
-        resource.status = "in_progress"
-        if resource.started_at is None:
-            resource.started_at = now
-
-    elif new_status == "completed":
-        resource.status = "completed"
-        if resource.started_at is None:
-            resource.started_at = now
-        resource.completed_at = now
-
-        # Trigger skill upgrade when completing learning
-        _upgrade_skill_on_completion(db, resource)
-
-    elif new_status == "not_started":
-        resource.status = "not_started"
-        resource.started_at = None
-        resource.completed_at = None
+    _apply_status_timestamps(db, resource, new_status, now)
 
     resource.updated_at = now
     db.commit()

--- a/src/career_os/services/pushover.py
+++ b/src/career_os/services/pushover.py
@@ -971,6 +971,33 @@ def test_pushover_connection(db: Session) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _deliver_single_notification(client: PushoverClient, log_entry: NotificationLog) -> bool:
+    """Attempt to send one queued notification. Returns True on success."""
+    metadata: dict = {}
+    if log_entry.error_message:
+        try:
+            metadata = json.loads(log_entry.error_message)
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
+
+    try:
+        client.send_notification(
+            message=log_entry.message,
+            title=log_entry.title,
+            url=metadata.get("url"),
+            url_title=metadata.get("url_title"),
+            priority=metadata.get("priority", PRIORITY_NORMAL),
+        )
+        log_entry.status = "sent"
+        log_entry.error_message = None
+        log_entry.sent_at = datetime.now(UTC)
+        return True
+    except (PushoverAuthError, PushoverAPIError) as exc:
+        log_entry.status = "failed"
+        log_entry.error_message = str(exc)
+        return False
+
+
 def deliver_queued_notifications(db: Session, profile_id: int) -> dict:
     """Deliver all queued notifications for a profile.
 
@@ -1004,29 +1031,9 @@ def deliver_queued_notifications(db: Session, profile_id: int) -> dict:
     failed = 0
 
     for log_entry in queued:
-        # Parse the stored metadata from error_message
-        metadata: dict = {}
-        if log_entry.error_message:
-            try:
-                metadata = json.loads(log_entry.error_message)
-            except (json.JSONDecodeError, TypeError):
-                metadata = {}
-
-        try:
-            client.send_notification(
-                message=log_entry.message,
-                title=log_entry.title,
-                url=metadata.get("url"),
-                url_title=metadata.get("url_title"),
-                priority=metadata.get("priority", PRIORITY_NORMAL),
-            )
-            log_entry.status = "sent"
-            log_entry.error_message = None
-            log_entry.sent_at = datetime.now(UTC)
+        if _deliver_single_notification(client, log_entry):
             delivered += 1
-        except (PushoverAuthError, PushoverAPIError) as exc:
-            log_entry.status = "failed"
-            log_entry.error_message = str(exc)
+        else:
             failed += 1
 
     db.commit()

--- a/src/career_os/services/skills_parsing.py
+++ b/src/career_os/services/skills_parsing.py
@@ -416,6 +416,22 @@ def parse_ccat(file_path: Path) -> list[ParsedSkill]:
     return skills
 
 
+_STRENGTH_KEYWORD_MAP: list[tuple[list[str], str]] = [
+    (["assertive", "deferential"], "Adaptive Assertiveness"),
+    (["sociable", "energetic"], "Social Energy"),
+    (["curiosity", "experiment"], "Experimental Mindset"),
+]
+
+
+def _match_strength_keyword(line: str) -> str | None:
+    """Return the skill name if any strength keywords match the line."""
+    lower = line.lower()
+    for keywords, skill_name in _STRENGTH_KEYWORD_MAP:
+        if any(kw in lower for kw in keywords):
+            return skill_name
+    return None
+
+
 def parse_workplace_insights(file_path: Path) -> list[ParsedSkill]:
     """Parse Workplace Insights report → soft skills from notable traits."""
     if not file_path.exists():
@@ -456,30 +472,11 @@ def parse_workplace_insights(file_path: Path) -> list[ParsedSkill]:
     if strengths_section:
         for line in strengths_section.group(1).strip().split("\n"):
             line = line.strip("- ").strip()
-            if "assertive" in line.lower() or "deferential" in line.lower():
+            matched = _match_strength_keyword(line)
+            if matched:
                 skills.append(
                     ParsedSkill(
-                        name="Adaptive Assertiveness",
-                        category="soft",
-                        proficiency="advanced",
-                        evidence_source="assessment:workplace-insights",
-                        evidence_detail=f"Workplace Insights strength: {line[:120]}",
-                    )
-                )
-            elif "sociable" in line.lower() or "energetic" in line.lower():
-                skills.append(
-                    ParsedSkill(
-                        name="Social Energy",
-                        category="soft",
-                        proficiency="advanced",
-                        evidence_source="assessment:workplace-insights",
-                        evidence_detail=f"Workplace Insights strength: {line[:120]}",
-                    )
-                )
-            elif "curiosity" in line.lower() or "experiment" in line.lower():
-                skills.append(
-                    ParsedSkill(
-                        name="Experimental Mindset",
+                        name=matched,
                         category="soft",
                         proficiency="advanced",
                         evidence_source="assessment:workplace-insights",

--- a/src/career_os/services/ticktick_sync.py
+++ b/src/career_os/services/ticktick_sync.py
@@ -10,6 +10,7 @@ Handles:
 import contextlib
 import json
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import or_ as db_or
@@ -421,48 +422,59 @@ def sync_completions_from_ticktick(
     return stats
 
 
+def _complete_follow_up(db: Session, sync_task: TickTickSyncTask, now: datetime) -> None:
+    follow_up = db.query(FollowUp).filter(FollowUp.id == sync_task.entity_id).first()
+    if not follow_up or follow_up.completed_at is not None:
+        return
+    follow_up.completed_at = now
+    db.add(
+        ActivityLog(
+            profile_id=sync_task.profile_id,
+            application_id=follow_up.application_id,
+            action="follow_up_completed",
+            details="Completed via TickTick sync",
+            source="ticktick_sync",
+        )
+    )
+
+
+def _complete_learning_goal(db: Session, sync_task: TickTickSyncTask, now: datetime) -> None:
+    goal = db.query(Goal).filter(Goal.id == sync_task.entity_id).first()
+    if goal and goal.status != "completed":
+        goal.status = "completed"
+        goal.updated_at = now
+
+
+def _complete_pipeline_action(db: Session, sync_task: TickTickSyncTask, now: datetime) -> None:
+    app_obj = db.query(Application).filter(Application.id == sync_task.entity_id).first()
+    if not app_obj:
+        return
+    if app_obj.next_step:
+        app_obj.next_step = f"[Done] {app_obj.next_step}"
+    app_obj.updated_at = now
+    db.add(
+        ActivityLog(
+            profile_id=sync_task.profile_id,
+            application_id=app_obj.id,
+            action="pipeline_action_completed",
+            details=f"TickTick task completed: {sync_task.title}",
+            source="ticktick_sync",
+        )
+    )
+
+
+_COMPLETION_HANDLERS: dict[str, Callable[[Session, TickTickSyncTask, datetime], None]] = {
+    "follow_up": _complete_follow_up,
+    "learning_goal": _complete_learning_goal,
+    "pipeline_action": _complete_pipeline_action,
+}
+
+
 def _apply_completion(db: Session, sync_task: TickTickSyncTask) -> None:
     """Apply a TickTick completion to the corresponding Career OS entity."""
-    now = datetime.now(UTC)
-
-    if sync_task.entity_type == "follow_up":
-        follow_up = db.query(FollowUp).filter(FollowUp.id == sync_task.entity_id).first()
-        if follow_up and follow_up.completed_at is None:
-            follow_up.completed_at = now
-            # Log activity
-            log = ActivityLog(
-                profile_id=sync_task.profile_id,
-                application_id=follow_up.application_id,
-                action="follow_up_completed",
-                details="Completed via TickTick sync",
-                source="ticktick_sync",
-            )
-            db.add(log)
-
-    elif sync_task.entity_type == "learning_goal":
-        goal = db.query(Goal).filter(Goal.id == sync_task.entity_id).first()
-        if goal and goal.status != "completed":
-            goal.status = "completed"
-            goal.updated_at = now
-
-    elif sync_task.entity_type == "pipeline_action":
-        # Completing a pipeline action task updates the Career OS
-        # application state (marks the action as done) and logs activity.
-        app_obj = db.query(Application).filter(Application.id == sync_task.entity_id).first()
-        if app_obj:
-            # Update application's next_step to reflect the action is done
-            if app_obj.next_step:
-                app_obj.next_step = f"[Done] {app_obj.next_step}"
-            app_obj.updated_at = now
-
-            log = ActivityLog(
-                profile_id=sync_task.profile_id,
-                application_id=app_obj.id,
-                action="pipeline_action_completed",
-                details=f"TickTick task completed: {sync_task.title}",
-                source="ticktick_sync",
-            )
-            db.add(log)
+    handler = _COMPLETION_HANDLERS.get(sync_task.entity_type)
+    if handler:
+        handler(db, sync_task, datetime.now(UTC))
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/services/voice.py
+++ b/src/career_os/services/voice.py
@@ -42,6 +42,17 @@ VALID_MODES = {"cover_letter", "coaching", "job_evaluation"}
 # ---------------------------------------------------------------------------
 
 
+def _generate_session_title(mode: str, app: Application | None) -> str:
+    """Auto-generate a session title based on mode and optional application."""
+    if mode == "cover_letter" and app:
+        return f"Cover Letter Brainstorm — {app.company} ({app.role})"
+    if mode == "job_evaluation" and app:
+        return f"Job Evaluation — {app.company} ({app.role})"
+    if mode == "coaching":
+        return "Coaching Session"
+    return f"Voice Discussion ({mode})"
+
+
 def create_session(
     db: Session,
     *,
@@ -86,16 +97,8 @@ def create_session(
                 f"Application {application_id} not found for profile {profile_id}"
             )
 
-    # Auto-generate title if not provided
     if not title:
-        if mode == "cover_letter" and app:
-            title = f"Cover Letter Brainstorm — {app.company} ({app.role})"
-        elif mode == "coaching":
-            title = "Coaching Session"
-        elif mode == "job_evaluation" and app:
-            title = f"Job Evaluation — {app.company} ({app.role})"
-        else:
-            title = f"Voice Discussion ({mode})"
+        title = _generate_session_title(mode, app)
 
     session = VoiceSession(
         profile_id=profile_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,22 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 
 
+# Shared Profile data used across test fixtures to avoid duplicating
+# the same constructor kwargs in every test module.
+DEFAULT_PROFILE_KWARGS = dict(
+    name="Test User",
+    email="test@example.com",
+    location="Frankfurt",
+    job_family="Software Engineering",
+)
+SECOND_PROFILE_KWARGS = dict(
+    name="Other User",
+    email="other@example.com",
+    location="Berlin",
+    job_family="Software Engineering",
+)
+
+
 @pytest.fixture
 def client() -> TestClient:
     """Create a FastAPI test client."""
@@ -68,7 +84,7 @@ def db_session(db_engine) -> Session:
 @pytest.fixture
 def profile(db_session: Session) -> Profile:
     """Seed a default test profile."""
-    p = Profile(id=1, name="Test User", email="test@example.com", location="Frankfurt")
+    p = Profile(id=1, **DEFAULT_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     return p

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,20 +17,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 
 
-# Shared Profile data used across test fixtures to avoid duplicating
-# the same constructor kwargs in every test module.
-DEFAULT_PROFILE_KWARGS = dict(
-    name="Test User",
-    email="test@example.com",
-    location="Frankfurt",
-    job_family="Software Engineering",
-)
-SECOND_PROFILE_KWARGS = dict(
-    name="Other User",
-    email="other@example.com",
-    location="Berlin",
-    job_family="Software Engineering",
-)
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/profile_data.py
+++ b/tests/profile_data.py
@@ -1,0 +1,14 @@
+"""Shared Profile fixture data to avoid duplicating constructor kwargs across test modules."""
+
+DEFAULT_PROFILE_KWARGS = dict(
+    name="Test User",
+    email="test@example.com",
+    location="Frankfurt",
+    job_family="Software Engineering",
+)
+SECOND_PROFILE_KWARGS = dict(
+    name="Other User",
+    email="other@example.com",
+    location="Berlin",
+    job_family="Software Engineering",
+)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -79,7 +79,12 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    p = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -89,7 +94,12 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Second profile for isolation tests."""
-    p = Profile(name="Other User", email="other@example.com", location="Berlin", job_family="Software Engineering")
+    p = Profile(
+        name="Other User",
+        email="other@example.com",
+        location="Berlin",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -34,7 +34,7 @@ from career_os.services.calendar import (
     list_calendar_events,
     update_calendar_event,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -34,6 +34,7 @@ from career_os.services.calendar import (
     list_calendar_events,
     update_calendar_event,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 
@@ -79,12 +80,7 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    p = Profile(**DEFAULT_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -94,12 +90,7 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Second profile for isolation tests."""
-    p = Profile(
-        name="Other User",
-        email="other@example.com",
-        location="Berlin",
-        job_family="Software Engineering",
-    )
+    p = Profile(**SECOND_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 """Tests for the Typer CLI skeleton."""
 
-import pytest
 from typer.testing import CliRunner
 
 from career_os.cli.main import app

--- a/tests/test_coaching.py
+++ b/tests/test_coaching.py
@@ -26,6 +26,7 @@ from career_os.models.skills import (
     LearningResource,
     Skill,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -60,12 +61,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -75,9 +71,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_coaching.py
+++ b/tests/test_coaching.py
@@ -60,7 +60,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -70,7 +75,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_coaching.py
+++ b/tests/test_coaching.py
@@ -26,7 +26,7 @@ from career_os.models.skills import (
     LearningResource,
     Skill,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_company_research.py
+++ b/tests/test_company_research.py
@@ -75,7 +75,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_company_research.py
+++ b/tests/test_company_research.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from career_os.database import Base, get_db
 from career_os.main import app
 from career_os.models.models import Profile
+from tests.profile_data import SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -75,9 +76,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -28,7 +28,7 @@ from career_os.services.gap_analysis import (
     analyze_gaps,
     classify_severity,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -28,6 +28,7 @@ from career_os.services.gap_analysis import (
     analyze_gaps,
     classify_severity,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -64,12 +65,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -79,9 +75,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -64,7 +64,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -74,7 +79,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -23,6 +23,7 @@ from career_os.main import app
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
 from career_os.models.skills import Goal, LearningResource, Skill
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -57,12 +58,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -72,9 +68,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -23,7 +23,7 @@ from career_os.main import app
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
 from career_os.models.skills import Goal, LearningResource, Skill
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -57,7 +57,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -67,7 +72,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_interview_prep.py
+++ b/tests/test_interview_prep.py
@@ -73,7 +73,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_interview_prep.py
+++ b/tests/test_interview_prep.py
@@ -24,6 +24,7 @@ from career_os.database import Base, get_db
 from career_os.main import app
 from career_os.models.models import Application, Profile
 from career_os.models.skills import JobRequirement, Skill
+from tests.profile_data import SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -73,9 +74,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from career_os.database import Base, get_db
 from career_os.models.models import Application, Profile
 from career_os.models.skills import JobRequirement, Skill
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -60,7 +60,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -70,7 +75,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from career_os.database import Base, get_db
 from career_os.models.models import Application, Profile
 from career_os.models.skills import JobRequirement, Skill
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -60,12 +61,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -75,9 +71,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -826,7 +826,9 @@ class TestMultiUserIsolation:
         import_csv(seeded_db, sample_csv, profile_id=1)
 
         # Create a second profile
-        p2 = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+        p2 = Profile(
+            name="Other User", email="other@example.com", job_family="Software Engineering"
+        )
         seeded_db.add(p2)
         seeded_db.commit()
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -36,6 +36,7 @@ from career_os.models.models import (
     ApplicationPackage,
     Profile,
 )
+from tests.profile_data import SECOND_PROFILE_KWARGS
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -826,9 +827,7 @@ class TestMultiUserIsolation:
         import_csv(seeded_db, sample_csv, profile_id=1)
 
         # Create a second profile
-        p2 = Profile(
-            name="Other User", email="other@example.com", job_family="Software Engineering"
-        )
+        p2 = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
         seeded_db.add(p2)
         seeded_db.commit()
 

--- a/tests/test_pipeline_api.py
+++ b/tests/test_pipeline_api.py
@@ -124,7 +124,7 @@ class TestCreateApplication:
         assert data["source"] == "linkedin"
         assert data["salary_range"] == "120k-160k EUR"
         assert data["notes"] == "Great opportunity"
-        assert data["fit_score"] == 8.5
+        assert data["fit_score"] == pytest.approx(8.5)
 
     def test_create_default_status_discovered(self, client: TestClient):
         data = _create_app(client)

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -41,7 +41,7 @@ from career_os.services.pushover_client import (
     PushoverAuthError,
     PushoverClient,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -41,6 +41,7 @@ from career_os.services.pushover_client import (
     PushoverAuthError,
     PushoverClient,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 
@@ -81,12 +82,7 @@ def db_session():
 @pytest.fixture()
 def profile(db_session):
     """Create a test profile."""
-    p = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    p = Profile(**DEFAULT_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -96,12 +92,7 @@ def profile(db_session):
 @pytest.fixture()
 def profile_b(db_session):
     """Create a second test profile for isolation tests."""
-    p = Profile(
-        name="Other User",
-        email="other@example.com",
-        location="Berlin",
-        job_family="Software Engineering",
-    )
+    p = Profile(**SECOND_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -699,7 +699,9 @@ class TestInterviewReminders:
         assert result["skipped"] == 1
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_custom_lead_time(self, mock_client_cls, db_session, profile, pushover_config, application):
+    def test_custom_lead_time(
+        self, mock_client_cls, db_session, profile, pushover_config, application
+    ):
         """Custom lead time is respected — short lead time misses far-future interview."""
         # Set very short lead time (30 minutes)
         update_preferences(
@@ -900,7 +902,13 @@ class TestCrossArea:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_category_disable_honored(
-        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up, ghost_application
+        self,
+        mock_client_cls,
+        db_session,
+        profile,
+        pushover_config,
+        due_follow_up,
+        ghost_application,
     ):
         """VAL-CROSS-018: Per-category disable prevents notification."""
         mock_instance = MagicMock()

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -388,12 +388,12 @@ class TestFollowUpReminders:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_due_follow_up_triggers_notification(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up, application
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up, application
     ):
         """Due follow-up triggers Pushover notification with company, role."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         result = trigger_follow_up_reminders(db_session, profile.id)
         assert result["triggered"] == 1
@@ -408,12 +408,12 @@ class TestFollowUpReminders:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_follow_up_logged(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """Follow-up notification creates a log entry."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         trigger_follow_up_reminders(db_session, profile.id)
 
@@ -446,10 +446,10 @@ class TestFollowUpReminders:
 
     def test_follow_up_api_trigger(self, db_session, profile, pushover_config, due_follow_up):
         """POST /api/notifications/trigger/follow-ups works via API."""
-        with patch("career_os.services.pushover.PushoverClient") as MockClient:
+        with patch("career_os.services.pushover.PushoverClient") as mock_client_cls:
             mock_instance = MagicMock()
             mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-            MockClient.return_value = mock_instance
+            mock_client_cls.return_value = mock_instance
 
             resp = client.post(f"/api/notifications/trigger/follow-ups?profile_id={profile.id}")
             assert resp.status_code == 200
@@ -467,12 +467,12 @@ class TestGhostAlerts:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_ghost_triggers_notification_with_days(
-        self, MockClient, db_session, profile, pushover_config, ghost_application
+        self, mock_client_cls, db_session, profile, pushover_config, ghost_application
     ):
         """Ghost application triggers notification with company, role, days count."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         result = trigger_ghost_alerts(db_session, profile.id)
         assert result["triggered"] >= 1
@@ -486,12 +486,12 @@ class TestGhostAlerts:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_ghost_notification_logged(
-        self, MockClient, db_session, profile, pushover_config, ghost_application
+        self, mock_client_cls, db_session, profile, pushover_config, ghost_application
     ):
         """Ghost notification creates a log entry with application_id."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         trigger_ghost_alerts(db_session, profile.id)
 
@@ -529,12 +529,12 @@ class TestDiscoveryAlerts:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_high_score_triggers_notification(
-        self, MockClient, db_session, profile, pushover_config
+        self, mock_client_cls, db_session, profile, pushover_config
     ):
         """High-scoring discovery sends notification with company, role, score."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         result = trigger_discovery_alert(
             db_session,
@@ -552,7 +552,7 @@ class TestDiscoveryAlerts:
         assert "High-Scoring" in call_args.kwargs["title"]
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_below_threshold_skipped(self, MockClient, db_session, profile, pushover_config):
+    def test_below_threshold_skipped(self, mock_client_cls, db_session, profile, pushover_config):
         """Score below threshold is skipped."""
         result = trigger_discovery_alert(
             db_session,
@@ -565,11 +565,11 @@ class TestDiscoveryAlerts:
         assert result["skipped"] == 1
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_custom_threshold(self, MockClient, db_session, profile, pushover_config):
+    def test_custom_threshold(self, mock_client_cls, db_session, profile, pushover_config):
         """Custom threshold is respected."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Set threshold to 9
         update_preferences(
@@ -616,10 +616,10 @@ class TestDiscoveryAlerts:
 
     def test_discovery_api_trigger(self, db_session, profile, pushover_config):
         """POST /api/notifications/trigger/discovery works via API."""
-        with patch("career_os.services.pushover.PushoverClient") as MockClient:
+        with patch("career_os.services.pushover.PushoverClient") as mock_client_cls:
             mock_instance = MagicMock()
             mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-            MockClient.return_value = mock_instance
+            mock_client_cls.return_value = mock_instance
 
             resp = client.post(
                 "/api/notifications/trigger/discovery"
@@ -639,12 +639,12 @@ class TestInterviewReminders:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_upcoming_interview_triggers_reminder(
-        self, MockClient, db_session, profile, pushover_config, interview_event
+        self, mock_client_cls, db_session, profile, pushover_config, interview_event
     ):
         """Upcoming interview within lead time triggers notification."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         result = trigger_interview_reminders(db_session, profile.id)
         assert result["triggered"] == 1
@@ -656,12 +656,12 @@ class TestInterviewReminders:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_interview_includes_meeting_link(
-        self, MockClient, db_session, profile, pushover_config, interview_event
+        self, mock_client_cls, db_session, profile, pushover_config, interview_event
     ):
         """Interview reminder includes meeting link."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         trigger_interview_reminders(db_session, profile.id)
 
@@ -670,12 +670,12 @@ class TestInterviewReminders:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_no_duplicate_interview_reminders(
-        self, MockClient, db_session, profile, pushover_config, interview_event, application
+        self, mock_client_cls, db_session, profile, pushover_config, interview_event, application
     ):
         """Already-notified interview is skipped on second trigger."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # First trigger sends
         result1 = trigger_interview_reminders(db_session, profile.id)
@@ -699,7 +699,7 @@ class TestInterviewReminders:
         assert result["skipped"] == 1
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_custom_lead_time(self, MockClient, db_session, profile, pushover_config, application):
+    def test_custom_lead_time(self, mock_client_cls, db_session, profile, pushover_config, application):
         """Custom lead time is respected — short lead time misses far-future interview."""
         # Set very short lead time (30 minutes)
         update_preferences(
@@ -738,12 +738,12 @@ class TestAuthFailure:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_auth_error_logged_not_crash(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """Auth failure is logged, doesn't crash, surfaces in integration status."""
         mock_instance = MagicMock()
         mock_instance.send_notification.side_effect = PushoverAuthError("Invalid credentials", 401)
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Should not raise
         result = trigger_follow_up_reminders(db_session, profile.id)
@@ -763,12 +763,12 @@ class TestAuthFailure:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_auth_error_updates_integration_status(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """Auth failure updates the integration status to 'error'."""
         mock_instance = MagicMock()
         mock_instance.send_notification.side_effect = PushoverAuthError("Invalid", 401)
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         trigger_follow_up_reminders(db_session, profile.id)
 
@@ -786,10 +786,10 @@ class TestAuthFailure:
 
     def test_send_test_with_invalid_creds(self, db_session, profile, pushover_config):
         """Send test notification with invalid creds logs failure."""
-        with patch("career_os.services.pushover.PushoverClient") as MockClient:
+        with patch("career_os.services.pushover.PushoverClient") as mock_client_cls:
             mock_instance = MagicMock()
             mock_instance.send_notification.side_effect = PushoverAuthError("Bad creds", 401)
-            MockClient.return_value = mock_instance
+            mock_client_cls.return_value = mock_instance
 
             result = send_test_notification(
                 db_session,
@@ -803,10 +803,10 @@ class TestAuthFailure:
 
     def test_auth_error_surfaced_in_api(self, db_session, profile, pushover_config, due_follow_up):
         """Auth error is visible via integration config API."""
-        with patch("career_os.services.pushover.PushoverClient") as MockClient:
+        with patch("career_os.services.pushover.PushoverClient") as mock_client_cls:
             mock_instance = MagicMock()
             mock_instance.send_notification.side_effect = PushoverAuthError("Invalid key", 401)
-            MockClient.return_value = mock_instance
+            mock_client_cls.return_value = mock_instance
 
             # Trigger to create the error state
             client.post(f"/api/notifications/trigger/follow-ups?profile_id={profile.id}")
@@ -829,12 +829,12 @@ class TestNotificationLog:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_log_entries_created(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """Sending notifications creates log entries."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         trigger_follow_up_reminders(db_session, profile.id)
 
@@ -876,12 +876,12 @@ class TestCrossArea:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_ghost_detection_notification_chain(
-        self, MockClient, db_session, profile, pushover_config, ghost_application
+        self, mock_client_cls, db_session, profile, pushover_config, ghost_application
     ):
         """VAL-CROSS-008: Ghost detection triggers Pushover with same application_id."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         result = trigger_ghost_alerts(db_session, profile.id)
         assert result["triggered"] >= 1
@@ -900,12 +900,12 @@ class TestCrossArea:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_category_disable_honored(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up, ghost_application
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up, ghost_application
     ):
         """VAL-CROSS-018: Per-category disable prevents notification."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Disable ghost alerts
         update_preferences(
@@ -925,12 +925,12 @@ class TestCrossArea:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_quiet_hours_queues_notifications(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """VAL-CROSS-018: Quiet hours queue notifications instead of dropping them."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Set quiet hours covering current hour
         now_hour = datetime.now(UTC).hour
@@ -972,12 +972,12 @@ class TestDeliverQueuedNotifications:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_deliver_queued_sends_and_marks_sent(
-        self, MockClient, db_session, profile, pushover_config, due_follow_up
+        self, mock_client_cls, db_session, profile, pushover_config, due_follow_up
     ):
         """Queued notifications are delivered and marked as sent."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Set quiet hours covering current hour to queue notifications
         now_hour = datetime.now(UTC).hour
@@ -1069,12 +1069,12 @@ class TestProfileIsolation:
 
     @patch("career_os.services.pushover.PushoverClient")
     def test_follow_ups_only_for_own_profile(
-        self, MockClient, db_session, profile, profile_b, pushover_config
+        self, mock_client_cls, db_session, profile, profile_b, pushover_config
     ):
         """Follow-up trigger only fires for the requesting profile's follow-ups."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         # Create application and follow-up for profile A
         app_obj = Application(profile_id=profile.id, company="ACo", role="Dev", status="applied")
@@ -1110,11 +1110,11 @@ class TestConnectionTest:
         assert data["success"] is False
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_test_connection_success(self, MockClient, db_session, pushover_config):
+    def test_test_connection_success(self, mock_client_cls, db_session, pushover_config):
         """Test connection with valid credentials succeeds."""
         mock_instance = MagicMock()
         mock_instance.validate_credentials.return_value = True
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         resp = client.post("/api/notifications/test-connection")
         assert resp.status_code == 200
@@ -1122,11 +1122,11 @@ class TestConnectionTest:
         assert data["success"] is True
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_test_connection_auth_failure(self, MockClient, db_session, pushover_config):
+    def test_test_connection_auth_failure(self, mock_client_cls, db_session, pushover_config):
         """Test connection with invalid credentials shows error."""
         mock_instance = MagicMock()
         mock_instance.validate_credentials.side_effect = PushoverAuthError("Bad key", 401)
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         resp = client.post("/api/notifications/test-connection")
         assert resp.status_code == 200
@@ -1148,11 +1148,11 @@ class TestSendNotificationAPI:
     """Tests for the manual send notification endpoint."""
 
     @patch("career_os.services.pushover.PushoverClient")
-    def test_send_notification_api(self, MockClient, db_session, profile, pushover_config):
+    def test_send_notification_api(self, mock_client_cls, db_session, profile, pushover_config):
         """POST /api/notifications/send sends a notification."""
         mock_instance = MagicMock()
         mock_instance.send_notification.return_value = {"status": 1, "request": "r1"}
-        MockClient.return_value = mock_instance
+        mock_client_cls.return_value = mock_instance
 
         resp = client.post(
             "/api/notifications/send",

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -81,7 +81,12 @@ def db_session():
 @pytest.fixture()
 def profile(db_session):
     """Create a test profile."""
-    p = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    p = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -91,7 +96,12 @@ def profile(db_session):
 @pytest.fixture()
 def profile_b(db_session):
     """Create a second test profile for isolation tests."""
-    p = Profile(name="Other User", email="other@example.com", location="Berlin", job_family="Software Engineering")
+    p = Profile(
+        name="Other User",
+        email="other@example.com",
+        location="Berlin",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_refactored_helpers.py
+++ b/tests/test_refactored_helpers.py
@@ -43,10 +43,14 @@ class TestMatchStrengthKeyword:
         assert _match_strength_keyword("Brings energetic presence") == "Social Energy"
 
     def test_curiosity_maps_to_experimental_mindset(self):
-        assert _match_strength_keyword("Intellectual curiosity is a driver") == "Experimental Mindset"
+        assert (
+            _match_strength_keyword("Intellectual curiosity is a driver") == "Experimental Mindset"
+        )
 
     def test_experiment_maps_to_experimental_mindset(self):
-        assert _match_strength_keyword("Likes to experiment with new ideas") == "Experimental Mindset"
+        assert (
+            _match_strength_keyword("Likes to experiment with new ideas") == "Experimental Mindset"
+        )
 
     def test_case_insensitive(self):
         assert _match_strength_keyword("ASSERTIVE leadership") == "Adaptive Assertiveness"
@@ -159,7 +163,9 @@ class TestDerivePackageType:
         from career_os.api.applications import _build_package_summary
 
         pkg = self._make_pkg(
-            package_dir="/home/user/packages/acme-corp/", cover_letter_path="/cl.pdf", cv_path="/cv.pdf"
+            package_dir="/home/user/packages/acme-corp/",
+            cover_letter_path="/cl.pdf",
+            cv_path="/cv.pdf",
         )
         summary = _build_package_summary(pkg)
         assert summary.package_name == "acme-corp"

--- a/tests/test_refactored_helpers.py
+++ b/tests/test_refactored_helpers.py
@@ -4,23 +4,85 @@ Covers:
 - skills_parsing: _match_strength_keyword, _STRENGTH_KEYWORD_MAP
 - voice: _generate_session_title
 - ticktick_sync: _complete_follow_up, _complete_learning_goal,
-  _complete_pipeline_action, _COMPLETION_HANDLERS
+  _complete_pipeline_action, _COMPLETION_HANDLERS, _apply_completion
 - api/applications: _derive_package_type, _build_package_summary
 - api/ticktick: _fetch_entity
-- components/KanbanCard: scoreColor (covered in frontend tests)
+- ai/openrouter_provider: _extract_error_detail
+- services/applications: _handle_status_transition, _apply_field_updates
+- services/learning: _apply_status_timestamps
+- services/pushover: _deliver_single_notification
 """
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 
+from career_os.ai.openrouter_provider import _extract_error_detail
+from career_os.api.applications import _build_package_summary, _derive_package_type
+from career_os.api.ticktick import _fetch_entity
+from career_os.services.applications import (
+    _apply_field_updates,
+    _handle_status_transition,
+)
+from career_os.services.learning import _apply_status_timestamps
+from career_os.services.pushover import PushoverAPIError, _deliver_single_notification
 from career_os.services.skills_parsing import (
     _STRENGTH_KEYWORD_MAP,
     _match_strength_keyword,
 )
+from career_os.services.ticktick_sync import (
+    _COMPLETION_HANDLERS,
+    _apply_completion,
+    _complete_follow_up,
+    _complete_learning_goal,
+    _complete_pipeline_action,
+)
 from career_os.services.voice import _generate_session_title
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def _mock_db(query_result=None):
+    """Create a MagicMock db session with a pre-configured query chain."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = query_result
+    return db
+
+
+def _mock_log_entry(*, error_message=None, message="Test", title="Test"):
+    """Create a MagicMock notification log entry."""
+    entry = MagicMock()
+    entry.error_message = error_message
+    entry.message = message
+    entry.title = title
+    return entry
+
+
+def _mock_app_obj(status="discovered", profile_id=1, app_id=10, date_applied=None):
+    """Create a MagicMock application object."""
+    obj = MagicMock()
+    obj.status = status
+    obj.profile_id = profile_id
+    obj.id = app_id
+    obj.date_applied = date_applied
+    return obj
+
+
+def _mock_sa_model():
+    """Create a mock SQLAlchemy model class with id and profile_id columns."""
+    model = MagicMock()
+    model.id = MagicMock()
+    model.profile_id = MagicMock()
+    return model
+
 
 # ---------------------------------------------------------------------------
 # _match_strength_keyword
@@ -65,9 +127,8 @@ class TestMatchStrengthKeyword:
 
     def test_first_match_wins(self):
         """If a line contains keywords from multiple categories, first match wins."""
-        # _STRENGTH_KEYWORD_MAP is iterated in order
         result = _match_strength_keyword("assertive and sociable person")
-        assert result == "Adaptive Assertiveness"  # first entry in the map
+        assert result == "Adaptive Assertiveness"
 
     def test_keyword_map_has_expected_entries(self):
         """Sanity check: the map has exactly 3 entries mapping to known skills."""
@@ -84,50 +145,48 @@ class TestMatchStrengthKeyword:
 class TestGenerateSessionTitle:
     """Tests for voice session title generation."""
 
-    def _make_app(self, company="Acme Corp", role="Senior Engineer"):
+    @staticmethod
+    def _app(company="Acme Corp", role="Senior Engineer"):
         return SimpleNamespace(company=company, role=role)
 
     def test_cover_letter_with_app(self):
-        app = self._make_app()
-        result = _generate_session_title("cover_letter", app)
-        assert result == "Cover Letter Brainstorm — Acme Corp (Senior Engineer)"
+        assert _generate_session_title("cover_letter", self._app()) == (
+            "Cover Letter Brainstorm — Acme Corp (Senior Engineer)"
+        )
 
     def test_job_evaluation_with_app(self):
-        app = self._make_app("Google", "PM")
-        result = _generate_session_title("job_evaluation", app)
-        assert result == "Job Evaluation — Google (PM)"
+        assert _generate_session_title("job_evaluation", self._app("Google", "PM")) == (
+            "Job Evaluation — Google (PM)"
+        )
 
     def test_coaching_mode(self):
-        result = _generate_session_title("coaching", None)
-        assert result == "Coaching Session"
+        assert _generate_session_title("coaching", None) == "Coaching Session"
 
     def test_coaching_ignores_app(self):
-        app = self._make_app()
-        result = _generate_session_title("coaching", app)
-        assert result == "Coaching Session"
+        assert _generate_session_title("coaching", self._app()) == "Coaching Session"
 
     def test_cover_letter_without_app_falls_through(self):
-        result = _generate_session_title("cover_letter", None)
-        assert result == "Voice Discussion (cover_letter)"
+        assert _generate_session_title("cover_letter", None) == "Voice Discussion (cover_letter)"
 
     def test_job_evaluation_without_app_falls_through(self):
-        result = _generate_session_title("job_evaluation", None)
-        assert result == "Voice Discussion (job_evaluation)"
+        assert (
+            _generate_session_title("job_evaluation", None) == "Voice Discussion (job_evaluation)"
+        )
 
     def test_unknown_mode(self):
-        result = _generate_session_title("brainstorm", None)
-        assert result == "Voice Discussion (brainstorm)"
+        assert _generate_session_title("brainstorm", None) == "Voice Discussion (brainstorm)"
 
 
 # ---------------------------------------------------------------------------
-# _derive_package_type  /  _build_package_summary
+# _derive_package_type / _build_package_summary
 # ---------------------------------------------------------------------------
 
 
 class TestDerivePackageType:
     """Tests for application package type derivation."""
 
-    def _make_pkg(self, cover_letter_path=None, cv_path=None, package_dir=None, pkg_id=1):
+    @staticmethod
+    def _pkg(cover_letter_path=None, cv_path=None, package_dir=None, pkg_id=1):
         return SimpleNamespace(
             id=pkg_id,
             cover_letter_path=cover_letter_path,
@@ -136,33 +195,22 @@ class TestDerivePackageType:
         )
 
     def test_full_package(self):
-        from career_os.api.applications import _derive_package_type
-
-        pkg = self._make_pkg(cover_letter_path="/cl.pdf", cv_path="/cv.pdf")
-        assert _derive_package_type(pkg) == "full"
+        assert (
+            _derive_package_type(self._pkg(cover_letter_path="/cl.pdf", cv_path="/cv.pdf"))
+            == "full"
+        )
 
     def test_cover_letter_only(self):
-        from career_os.api.applications import _derive_package_type
-
-        pkg = self._make_pkg(cover_letter_path="/cl.pdf")
-        assert _derive_package_type(pkg) == "cover_letter"
+        assert _derive_package_type(self._pkg(cover_letter_path="/cl.pdf")) == "cover_letter"
 
     def test_cv_only(self):
-        from career_os.api.applications import _derive_package_type
-
-        pkg = self._make_pkg(cv_path="/cv.pdf")
-        assert _derive_package_type(pkg) == "cv"
+        assert _derive_package_type(self._pkg(cv_path="/cv.pdf")) == "cv"
 
     def test_directory_fallback(self):
-        from career_os.api.applications import _derive_package_type
+        assert _derive_package_type(self._pkg()) == "directory"
 
-        pkg = self._make_pkg()
-        assert _derive_package_type(pkg) == "directory"
-
-    def test_build_package_summary_extracts_name_from_dir(self):
-        from career_os.api.applications import _build_package_summary
-
-        pkg = self._make_pkg(
+    def test_build_summary_extracts_name_from_dir(self):
+        pkg = self._pkg(
             package_dir="/home/user/packages/acme-corp/",
             cover_letter_path="/cl.pdf",
             cv_path="/cv.pdf",
@@ -172,23 +220,15 @@ class TestDerivePackageType:
         assert summary.package_type == "full"
         assert summary.file_path == "/home/user/packages/acme-corp/"
 
-    def test_build_package_summary_unknown_for_empty_dir(self):
-        from career_os.api.applications import _build_package_summary
+    def test_build_summary_unknown_for_empty_dir(self):
+        assert _build_package_summary(self._pkg(package_dir="")).package_name == "Unknown"
 
-        pkg = self._make_pkg(package_dir="")
-        summary = _build_package_summary(pkg)
-        assert summary.package_name == "Unknown"
-
-    def test_build_package_summary_unknown_for_none_dir(self):
-        from career_os.api.applications import _build_package_summary
-
-        pkg = self._make_pkg(package_dir=None)
-        summary = _build_package_summary(pkg)
-        assert summary.package_name == "Unknown"
+    def test_build_summary_unknown_for_none_dir(self):
+        assert _build_package_summary(self._pkg(package_dir=None)).package_name == "Unknown"
 
 
 # ---------------------------------------------------------------------------
-# _COMPLETION_HANDLERS  /  individual handlers
+# _COMPLETION_HANDLERS / individual handlers
 # ---------------------------------------------------------------------------
 
 
@@ -196,144 +236,78 @@ class TestCompletionHandlers:
     """Tests for TickTick completion handler dispatch table."""
 
     def test_handler_keys(self):
-        from career_os.services.ticktick_sync import _COMPLETION_HANDLERS
-
         assert set(_COMPLETION_HANDLERS.keys()) == {"follow_up", "learning_goal", "pipeline_action"}
 
     def test_all_handlers_are_callable(self):
-        from career_os.services.ticktick_sync import _COMPLETION_HANDLERS
-
         for key, handler in _COMPLETION_HANDLERS.items():
             assert callable(handler), f"Handler for {key} is not callable"
 
     def test_complete_follow_up_sets_completed_at(self):
-        from career_os.services.ticktick_sync import _complete_follow_up
-
-        db = MagicMock()
+        follow_up = MagicMock(completed_at=None, application_id=5)
+        db = _mock_db(follow_up)
         sync_task = SimpleNamespace(profile_id=1, entity_id=10)
-        follow_up = MagicMock()
-        follow_up.completed_at = None
-        follow_up.application_id = 5
-        db.query.return_value.filter.return_value.first.return_value = follow_up
-
-        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
-        _complete_follow_up(db, sync_task, now)
-
-        assert follow_up.completed_at == now
-        db.add.assert_called_once()  # activity log added
+        _complete_follow_up(db, sync_task, NOW)
+        assert follow_up.completed_at == NOW
+        db.add.assert_called_once()
 
     def test_complete_follow_up_skips_already_completed(self):
-        from career_os.services.ticktick_sync import _complete_follow_up
-
-        db = MagicMock()
-        sync_task = SimpleNamespace(profile_id=1, entity_id=10)
-        follow_up = MagicMock()
-        follow_up.completed_at = datetime(2026, 1, 1, tzinfo=UTC)  # already done
-        db.query.return_value.filter.return_value.first.return_value = follow_up
-
-        _complete_follow_up(db, sync_task, datetime.now(UTC))
+        follow_up = MagicMock(completed_at=datetime(2026, 1, 1, tzinfo=UTC))
+        db = _mock_db(follow_up)
+        _complete_follow_up(db, SimpleNamespace(profile_id=1, entity_id=10), datetime.now(UTC))
         db.add.assert_not_called()
 
     def test_complete_follow_up_skips_missing_entity(self):
-        from career_os.services.ticktick_sync import _complete_follow_up
-
-        db = MagicMock()
-        db.query.return_value.filter.return_value.first.return_value = None
-        sync_task = SimpleNamespace(profile_id=1, entity_id=999)
-
-        _complete_follow_up(db, sync_task, datetime.now(UTC))
+        db = _mock_db(None)
+        _complete_follow_up(db, SimpleNamespace(profile_id=1, entity_id=999), datetime.now(UTC))
         db.add.assert_not_called()
 
     def test_complete_learning_goal_sets_completed(self):
-        from career_os.services.ticktick_sync import _complete_learning_goal
-
-        db = MagicMock()
-        sync_task = SimpleNamespace(entity_id=20)
-        goal = MagicMock()
-        goal.status = "in_progress"
-        db.query.return_value.filter.return_value.first.return_value = goal
-
-        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
-        _complete_learning_goal(db, sync_task, now)
-
+        goal = MagicMock(status="in_progress")
+        db = _mock_db(goal)
+        _complete_learning_goal(db, SimpleNamespace(entity_id=20), NOW)
         assert goal.status == "completed"
-        assert goal.updated_at == now
+        assert goal.updated_at == NOW
 
     def test_complete_learning_goal_skips_already_completed(self):
-        from career_os.services.ticktick_sync import _complete_learning_goal
-
-        db = MagicMock()
-        sync_task = SimpleNamespace(entity_id=20)
-        goal = MagicMock()
-        goal.status = "completed"
-        db.query.return_value.filter.return_value.first.return_value = goal
-
-        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
-        _complete_learning_goal(db, sync_task, now)
-        assert goal.status == "completed"  # unchanged
+        goal = MagicMock(status="completed")
+        db = _mock_db(goal)
+        _complete_learning_goal(db, SimpleNamespace(entity_id=20), NOW)
+        assert goal.status == "completed"
 
     def test_complete_pipeline_action_marks_next_step_done(self):
-        from career_os.services.ticktick_sync import _complete_pipeline_action
-
-        db = MagicMock()
+        app_obj = MagicMock(next_step="Send follow-up email", id=30)
+        db = _mock_db(app_obj)
         sync_task = SimpleNamespace(profile_id=1, entity_id=30, title="Apply to Acme")
-        app_obj = MagicMock()
-        app_obj.next_step = "Send follow-up email"
-        app_obj.id = 30
-        db.query.return_value.filter.return_value.first.return_value = app_obj
-
-        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
-        _complete_pipeline_action(db, sync_task, now)
-
+        _complete_pipeline_action(db, sync_task, NOW)
         assert app_obj.next_step == "[Done] Send follow-up email"
-        assert app_obj.updated_at == now
+        assert app_obj.updated_at == NOW
         db.add.assert_called_once()
 
     def test_complete_pipeline_action_handles_no_next_step(self):
-        from career_os.services.ticktick_sync import _complete_pipeline_action
-
-        db = MagicMock()
-        sync_task = SimpleNamespace(profile_id=1, entity_id=30, title="Task")
-        app_obj = MagicMock()
-        app_obj.next_step = None
-        app_obj.id = 30
-        db.query.return_value.filter.return_value.first.return_value = app_obj
-
-        _complete_pipeline_action(db, sync_task, datetime.now(UTC))
-        assert app_obj.next_step is None  # unchanged, not "[Done] None"
+        app_obj = MagicMock(next_step=None, id=30)
+        db = _mock_db(app_obj)
+        _complete_pipeline_action(
+            db, SimpleNamespace(profile_id=1, entity_id=30, title="Task"), datetime.now(UTC)
+        )
+        assert app_obj.next_step is None
 
     def test_complete_pipeline_action_skips_missing_entity(self):
-        from career_os.services.ticktick_sync import _complete_pipeline_action
-
-        db = MagicMock()
-        db.query.return_value.filter.return_value.first.return_value = None
-        sync_task = SimpleNamespace(profile_id=1, entity_id=999, title="Task")
-
-        _complete_pipeline_action(db, sync_task, datetime.now(UTC))
+        db = _mock_db(None)
+        _complete_pipeline_action(
+            db, SimpleNamespace(profile_id=1, entity_id=999, title="Task"), datetime.now(UTC)
+        )
         db.add.assert_not_called()
 
     def test_apply_completion_dispatches_to_correct_handler(self):
-        """Integration test: _apply_completion routes to the right handler via the dict."""
-        from career_os.services.ticktick_sync import _apply_completion
-
-        db = MagicMock()
-        sync_task = SimpleNamespace(entity_type="follow_up", profile_id=1, entity_id=10)
-        follow_up = MagicMock()
-        follow_up.completed_at = None
-        follow_up.application_id = 5
-        db.query.return_value.filter.return_value.first.return_value = follow_up
-
-        _apply_completion(db, sync_task)
+        """_apply_completion routes to the right handler via the dispatch dict."""
+        follow_up = MagicMock(completed_at=None, application_id=5)
+        db = _mock_db(follow_up)
+        _apply_completion(db, SimpleNamespace(entity_type="follow_up", profile_id=1, entity_id=10))
         assert follow_up.completed_at is not None
 
     def test_apply_completion_unknown_type_is_noop(self):
-        """Unknown entity types should not raise — just be silently ignored."""
-        from career_os.services.ticktick_sync import _apply_completion
-
         db = MagicMock()
-        sync_task = SimpleNamespace(entity_type="unknown_thing", profile_id=1, entity_id=10)
-
-        _apply_completion(db, sync_task)  # should not raise
+        _apply_completion(db, SimpleNamespace(entity_type="unknown", profile_id=1, entity_id=10))
         db.query.assert_not_called()
 
 
@@ -345,55 +319,27 @@ class TestCompletionHandlers:
 class TestFetchEntity:
     """Tests for the generic entity fetcher in ticktick API."""
 
-    @staticmethod
-    def _make_model():
-        """Create a mock SQLAlchemy model class with id and profile_id columns."""
-        model = MagicMock()
-        model.id = MagicMock()
-        model.profile_id = MagicMock()
-        return model
-
     def test_returns_entity_when_found(self):
-        from career_os.api.ticktick import _fetch_entity
-
-        db = MagicMock()
-        model = self._make_model()
         mock_obj = SimpleNamespace(id=1, profile_id=1)
-        db.query.return_value.filter.return_value.first.return_value = mock_obj
-
-        result = _fetch_entity(db, model, 1, 1, "Follow-up")
-        assert result is mock_obj
+        db = _mock_db(mock_obj)
+        assert _fetch_entity(db, _mock_sa_model(), 1, 1, "Follow-up") is mock_obj
 
     def test_raises_404_when_not_found(self):
-        from fastapi import HTTPException
-
-        from career_os.api.ticktick import _fetch_entity
-
-        db = MagicMock()
-        model = self._make_model()
-        db.query.return_value.filter.return_value.first.return_value = None
-
+        db = _mock_db(None)
         with pytest.raises(HTTPException) as exc_info:
-            _fetch_entity(db, model, 999, 1, "Follow-up")
+            _fetch_entity(db, _mock_sa_model(), 999, 1, "Follow-up")
         assert exc_info.value.status_code == 404
         assert "Follow-up not found" in exc_info.value.detail
 
     def test_404_message_uses_label(self):
-        from fastapi import HTTPException
-
-        from career_os.api.ticktick import _fetch_entity
-
-        db = MagicMock()
-        model = self._make_model()
-        db.query.return_value.filter.return_value.first.return_value = None
-
+        db = _mock_db(None)
         with pytest.raises(HTTPException) as exc_info:
-            _fetch_entity(db, model, 1, 1, "Learning goal")
+            _fetch_entity(db, _mock_sa_model(), 1, 1, "Learning goal")
         assert "Learning goal not found" in exc_info.value.detail
 
 
 # ---------------------------------------------------------------------------
-# Batch 2 helpers
+# _extract_error_detail (openrouter)
 # ---------------------------------------------------------------------------
 
 
@@ -401,68 +347,42 @@ class TestExtractErrorDetail:
     """Tests for OpenRouter error detail extraction."""
 
     def test_extracts_message_from_valid_json(self):
-        from career_os.ai.openrouter_provider import _extract_error_detail
-
         response = MagicMock()
         response.json.return_value = {"error": {"message": "Insufficient credits"}}
         assert _extract_error_detail(response) == "Insufficient credits"
 
     def test_returns_empty_on_json_error(self):
-        from career_os.ai.openrouter_provider import _extract_error_detail
-
         response = MagicMock()
         response.json.side_effect = ValueError("bad json")
         assert _extract_error_detail(response) == ""
 
     def test_returns_empty_when_no_error_key(self):
-        from career_os.ai.openrouter_provider import _extract_error_detail
-
         response = MagicMock()
         response.json.return_value = {"status": "fail"}
         assert _extract_error_detail(response) == ""
+
+
+# ---------------------------------------------------------------------------
+# _handle_status_transition / _apply_field_updates
+# ---------------------------------------------------------------------------
 
 
 class TestHandleStatusTransition:
     """Tests for application status transition handler."""
 
     def test_skips_when_no_status_in_data(self):
-        from career_os.services.applications import _handle_status_transition
-
-        db = MagicMock()
-        app_obj = MagicMock()
-        update_data = {"notes": "updated"}
-        _handle_status_transition(db, app_obj, update_data)
-        # No activity logged for non-status changes
+        db = _mock_db()
+        _handle_status_transition(db, _mock_app_obj(), {"notes": "updated"})
         db.add.assert_not_called()
 
     def test_normalizes_and_validates_status(self):
-        from career_os.services.applications import (
-            _handle_status_transition,
-        )
-
-        db = MagicMock()
-        app_obj = MagicMock()
-        app_obj.status = "discovered"
-        app_obj.profile_id = 1
-        app_obj.id = 10
-
-        # discovered → interested is a valid transition
         update_data = {"status": "  Interested  "}
-        _handle_status_transition(db, app_obj, update_data)
+        _handle_status_transition(_mock_db(), _mock_app_obj(), update_data)
         assert update_data["status"] == "interested"
 
     def test_sets_date_applied_on_applied_transition(self):
-        from career_os.services.applications import _handle_status_transition
-
-        db = MagicMock()
-        app_obj = MagicMock()
-        # interested → applied is a valid transition
-        app_obj.status = "interested"
-        app_obj.profile_id = 1
-        app_obj.id = 10
-        app_obj.date_applied = None
-
-        _handle_status_transition(db, app_obj, {"status": "applied"})
+        app_obj = _mock_app_obj(status="interested", date_applied=None)
+        _handle_status_transition(_mock_db(), app_obj, {"status": "applied"})
         assert app_obj.date_applied is not None
 
 
@@ -470,142 +390,91 @@ class TestApplyFieldUpdates:
     """Tests for application field update tracker."""
 
     def test_tracks_changed_fields(self):
-        from career_os.services.applications import _apply_field_updates
-
-        db = MagicMock()
-        app_obj = MagicMock()
+        app_obj = _mock_app_obj()
         app_obj.notes = "old"
-        app_obj.url = "https://old.com"
-
-        _apply_field_updates(db, app_obj, {"notes": "new"})
-        # Should have called setattr and logged
+        _apply_field_updates(_mock_db(), app_obj, {"notes": "new"})
         assert app_obj.notes == "new"
 
     def test_sets_status_without_logging(self):
-        from career_os.services.applications import _apply_field_updates
+        app_obj = _mock_app_obj()
+        _apply_field_updates(_mock_db(), app_obj, {"status": "applied"})
 
-        db = MagicMock()
-        app_obj = MagicMock()
-        app_obj.status = "discovered"
-        app_obj.profile_id = 1
-        app_obj.id = 10
 
-        # Status field should be set but not counted as a changed field
-        _apply_field_updates(db, app_obj, {"status": "applied"})
+# ---------------------------------------------------------------------------
+# _apply_status_timestamps (learning)
+# ---------------------------------------------------------------------------
 
 
 class TestApplyStatusTimestamps:
     """Tests for learning resource status timestamp handler."""
 
     def test_in_progress_sets_started_at(self):
-        from career_os.services.learning import _apply_status_timestamps
-
-        db = MagicMock()
-        resource = MagicMock()
-        resource.started_at = None
-        now = datetime(2026, 4, 10, tzinfo=UTC)
-
-        _apply_status_timestamps(db, resource, "in_progress", now)
+        resource = MagicMock(started_at=None)
+        _apply_status_timestamps(MagicMock(), resource, "in_progress", NOW)
         assert resource.status == "in_progress"
-        assert resource.started_at == now
+        assert resource.started_at == NOW
 
     def test_in_progress_preserves_existing_started_at(self):
-        from career_os.services.learning import _apply_status_timestamps
-
-        db = MagicMock()
-        resource = MagicMock()
         old_time = datetime(2026, 1, 1, tzinfo=UTC)
-        resource.started_at = old_time
-        now = datetime(2026, 4, 10, tzinfo=UTC)
-
-        _apply_status_timestamps(db, resource, "in_progress", now)
-        assert resource.started_at == old_time  # preserved
+        resource = MagicMock(started_at=old_time)
+        _apply_status_timestamps(MagicMock(), resource, "in_progress", NOW)
+        assert resource.started_at == old_time
 
     def test_completed_sets_both_timestamps(self):
-        from career_os.services.learning import _apply_status_timestamps
-
-        db = MagicMock()
-        resource = MagicMock()
-        resource.started_at = None
-        now = datetime(2026, 4, 10, tzinfo=UTC)
-
-        _apply_status_timestamps(db, resource, "completed", now)
+        resource = MagicMock(started_at=None)
+        _apply_status_timestamps(MagicMock(), resource, "completed", NOW)
         assert resource.status == "completed"
-        assert resource.started_at == now
-        assert resource.completed_at == now
+        assert resource.started_at == NOW
+        assert resource.completed_at == NOW
 
     def test_not_started_clears_timestamps(self):
-        from career_os.services.learning import _apply_status_timestamps
-
-        db = MagicMock()
-        resource = MagicMock()
-        resource.started_at = datetime(2026, 1, 1, tzinfo=UTC)
-        resource.completed_at = datetime(2026, 2, 1, tzinfo=UTC)
-        now = datetime(2026, 4, 10, tzinfo=UTC)
-
-        _apply_status_timestamps(db, resource, "not_started", now)
+        resource = MagicMock(
+            started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            completed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        _apply_status_timestamps(MagicMock(), resource, "not_started", NOW)
         assert resource.status == "not_started"
         assert resource.started_at is None
         assert resource.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# _deliver_single_notification (pushover)
+# ---------------------------------------------------------------------------
 
 
 class TestDeliverSingleNotification:
     """Tests for the individual notification delivery helper."""
 
     def test_successful_delivery(self):
-        from career_os.services.pushover import _deliver_single_notification
-
         client = MagicMock()
-        log_entry = MagicMock()
-        log_entry.error_message = None
-        log_entry.message = "Test notification"
-        log_entry.title = "Test"
-
-        result = _deliver_single_notification(client, log_entry)
+        entry = _mock_log_entry(message="Test notification")
+        result = _deliver_single_notification(client, entry)
         assert result is True
-        assert log_entry.status == "sent"
-        assert log_entry.error_message is None
+        assert entry.status == "sent"
+        assert entry.error_message is None
         client.send_notification.assert_called_once()
 
     def test_failed_delivery(self):
-        from career_os.services.pushover import PushoverAPIError, _deliver_single_notification
-
         client = MagicMock()
         client.send_notification.side_effect = PushoverAPIError("API down")
-        log_entry = MagicMock()
-        log_entry.error_message = None
-        log_entry.message = "Test"
-        log_entry.title = "Test"
-
-        result = _deliver_single_notification(client, log_entry)
+        entry = _mock_log_entry()
+        result = _deliver_single_notification(client, entry)
         assert result is False
-        assert log_entry.status == "failed"
-        assert "API down" in log_entry.error_message
+        assert entry.status == "failed"
+        assert "API down" in entry.error_message
 
     def test_parses_metadata_from_error_message_json(self):
-        import json
-
-        from career_os.services.pushover import _deliver_single_notification
-
         client = MagicMock()
-        log_entry = MagicMock()
-        log_entry.error_message = json.dumps({"url": "https://example.com", "priority": 1})
-        log_entry.message = "Test"
-        log_entry.title = "Test"
-
-        _deliver_single_notification(client, log_entry)
+        entry = _mock_log_entry(
+            error_message=json.dumps({"url": "https://example.com", "priority": 1})
+        )
+        _deliver_single_notification(client, entry)
         call_kwargs = client.send_notification.call_args.kwargs
         assert call_kwargs["url"] == "https://example.com"
         assert call_kwargs["priority"] == 1
 
     def test_handles_invalid_json_metadata(self):
-        from career_os.services.pushover import _deliver_single_notification
-
         client = MagicMock()
-        log_entry = MagicMock()
-        log_entry.error_message = "not valid json {{"
-        log_entry.message = "Test"
-        log_entry.title = "Test"
-
-        result = _deliver_single_notification(client, log_entry)
-        assert result is True  # should still send successfully
+        entry = _mock_log_entry(error_message="not valid json {{")
+        assert _deliver_single_notification(client, entry) is True

--- a/tests/test_refactored_helpers.py
+++ b/tests/test_refactored_helpers.py
@@ -1,0 +1,386 @@
+"""Unit tests for helper functions extracted during S3776 complexity refactoring.
+
+Covers:
+- skills_parsing: _match_strength_keyword, _STRENGTH_KEYWORD_MAP
+- voice: _generate_session_title
+- ticktick_sync: _complete_follow_up, _complete_learning_goal,
+  _complete_pipeline_action, _COMPLETION_HANDLERS
+- api/applications: _derive_package_type, _build_package_summary
+- api/ticktick: _fetch_entity
+- components/KanbanCard: scoreColor (covered in frontend tests)
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from career_os.services.skills_parsing import (
+    _STRENGTH_KEYWORD_MAP,
+    _match_strength_keyword,
+)
+from career_os.services.voice import _generate_session_title
+
+# ---------------------------------------------------------------------------
+# _match_strength_keyword
+# ---------------------------------------------------------------------------
+
+
+class TestMatchStrengthKeyword:
+    """Tests for the strength keyword lookup extracted from parse_workplace_insights."""
+
+    def test_assertive_maps_to_adaptive_assertiveness(self):
+        assert _match_strength_keyword("You are assertive in meetings") == "Adaptive Assertiveness"
+
+    def test_deferential_maps_to_adaptive_assertiveness(self):
+        assert _match_strength_keyword("Sometimes deferential in tone") == "Adaptive Assertiveness"
+
+    def test_sociable_maps_to_social_energy(self):
+        assert _match_strength_keyword("Very sociable and outgoing") == "Social Energy"
+
+    def test_energetic_maps_to_social_energy(self):
+        assert _match_strength_keyword("Brings energetic presence") == "Social Energy"
+
+    def test_curiosity_maps_to_experimental_mindset(self):
+        assert _match_strength_keyword("Intellectual curiosity is a driver") == "Experimental Mindset"
+
+    def test_experiment_maps_to_experimental_mindset(self):
+        assert _match_strength_keyword("Likes to experiment with new ideas") == "Experimental Mindset"
+
+    def test_case_insensitive(self):
+        assert _match_strength_keyword("ASSERTIVE leadership") == "Adaptive Assertiveness"
+        assert _match_strength_keyword("SOCIABLE team player") == "Social Energy"
+        assert _match_strength_keyword("CURIOSITY driven") == "Experimental Mindset"
+
+    def test_no_match_returns_none(self):
+        assert _match_strength_keyword("Detail-oriented and thorough") is None
+
+    def test_empty_string_returns_none(self):
+        assert _match_strength_keyword("") is None
+
+    def test_first_match_wins(self):
+        """If a line contains keywords from multiple categories, first match wins."""
+        # _STRENGTH_KEYWORD_MAP is iterated in order
+        result = _match_strength_keyword("assertive and sociable person")
+        assert result == "Adaptive Assertiveness"  # first entry in the map
+
+    def test_keyword_map_has_expected_entries(self):
+        """Sanity check: the map has exactly 3 entries mapping to known skills."""
+        assert len(_STRENGTH_KEYWORD_MAP) == 3
+        skill_names = {name for _, name in _STRENGTH_KEYWORD_MAP}
+        assert skill_names == {"Adaptive Assertiveness", "Social Energy", "Experimental Mindset"}
+
+
+# ---------------------------------------------------------------------------
+# _generate_session_title
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSessionTitle:
+    """Tests for voice session title generation."""
+
+    def _make_app(self, company="Acme Corp", role="Senior Engineer"):
+        return SimpleNamespace(company=company, role=role)
+
+    def test_cover_letter_with_app(self):
+        app = self._make_app()
+        result = _generate_session_title("cover_letter", app)
+        assert result == "Cover Letter Brainstorm — Acme Corp (Senior Engineer)"
+
+    def test_job_evaluation_with_app(self):
+        app = self._make_app("Google", "PM")
+        result = _generate_session_title("job_evaluation", app)
+        assert result == "Job Evaluation — Google (PM)"
+
+    def test_coaching_mode(self):
+        result = _generate_session_title("coaching", None)
+        assert result == "Coaching Session"
+
+    def test_coaching_ignores_app(self):
+        app = self._make_app()
+        result = _generate_session_title("coaching", app)
+        assert result == "Coaching Session"
+
+    def test_cover_letter_without_app_falls_through(self):
+        result = _generate_session_title("cover_letter", None)
+        assert result == "Voice Discussion (cover_letter)"
+
+    def test_job_evaluation_without_app_falls_through(self):
+        result = _generate_session_title("job_evaluation", None)
+        assert result == "Voice Discussion (job_evaluation)"
+
+    def test_unknown_mode(self):
+        result = _generate_session_title("brainstorm", None)
+        assert result == "Voice Discussion (brainstorm)"
+
+
+# ---------------------------------------------------------------------------
+# _derive_package_type  /  _build_package_summary
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePackageType:
+    """Tests for application package type derivation."""
+
+    def _make_pkg(self, cover_letter_path=None, cv_path=None, package_dir=None, pkg_id=1):
+        return SimpleNamespace(
+            id=pkg_id,
+            cover_letter_path=cover_letter_path,
+            cv_path=cv_path,
+            package_dir=package_dir,
+        )
+
+    def test_full_package(self):
+        from career_os.api.applications import _derive_package_type
+
+        pkg = self._make_pkg(cover_letter_path="/cl.pdf", cv_path="/cv.pdf")
+        assert _derive_package_type(pkg) == "full"
+
+    def test_cover_letter_only(self):
+        from career_os.api.applications import _derive_package_type
+
+        pkg = self._make_pkg(cover_letter_path="/cl.pdf")
+        assert _derive_package_type(pkg) == "cover_letter"
+
+    def test_cv_only(self):
+        from career_os.api.applications import _derive_package_type
+
+        pkg = self._make_pkg(cv_path="/cv.pdf")
+        assert _derive_package_type(pkg) == "cv"
+
+    def test_directory_fallback(self):
+        from career_os.api.applications import _derive_package_type
+
+        pkg = self._make_pkg()
+        assert _derive_package_type(pkg) == "directory"
+
+    def test_build_package_summary_extracts_name_from_dir(self):
+        from career_os.api.applications import _build_package_summary
+
+        pkg = self._make_pkg(
+            package_dir="/home/user/packages/acme-corp/", cover_letter_path="/cl.pdf", cv_path="/cv.pdf"
+        )
+        summary = _build_package_summary(pkg)
+        assert summary.package_name == "acme-corp"
+        assert summary.package_type == "full"
+        assert summary.file_path == "/home/user/packages/acme-corp/"
+
+    def test_build_package_summary_unknown_for_empty_dir(self):
+        from career_os.api.applications import _build_package_summary
+
+        pkg = self._make_pkg(package_dir="")
+        summary = _build_package_summary(pkg)
+        assert summary.package_name == "Unknown"
+
+    def test_build_package_summary_unknown_for_none_dir(self):
+        from career_os.api.applications import _build_package_summary
+
+        pkg = self._make_pkg(package_dir=None)
+        summary = _build_package_summary(pkg)
+        assert summary.package_name == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# _COMPLETION_HANDLERS  /  individual handlers
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionHandlers:
+    """Tests for TickTick completion handler dispatch table."""
+
+    def test_handler_keys(self):
+        from career_os.services.ticktick_sync import _COMPLETION_HANDLERS
+
+        assert set(_COMPLETION_HANDLERS.keys()) == {"follow_up", "learning_goal", "pipeline_action"}
+
+    def test_all_handlers_are_callable(self):
+        from career_os.services.ticktick_sync import _COMPLETION_HANDLERS
+
+        for key, handler in _COMPLETION_HANDLERS.items():
+            assert callable(handler), f"Handler for {key} is not callable"
+
+    def test_complete_follow_up_sets_completed_at(self):
+        from career_os.services.ticktick_sync import _complete_follow_up
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(profile_id=1, entity_id=10)
+        follow_up = MagicMock()
+        follow_up.completed_at = None
+        follow_up.application_id = 5
+        db.query.return_value.filter.return_value.first.return_value = follow_up
+
+        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+        _complete_follow_up(db, sync_task, now)
+
+        assert follow_up.completed_at == now
+        db.add.assert_called_once()  # activity log added
+
+    def test_complete_follow_up_skips_already_completed(self):
+        from career_os.services.ticktick_sync import _complete_follow_up
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(profile_id=1, entity_id=10)
+        follow_up = MagicMock()
+        follow_up.completed_at = datetime(2026, 1, 1, tzinfo=UTC)  # already done
+        db.query.return_value.filter.return_value.first.return_value = follow_up
+
+        _complete_follow_up(db, sync_task, datetime.now(UTC))
+        db.add.assert_not_called()
+
+    def test_complete_follow_up_skips_missing_entity(self):
+        from career_os.services.ticktick_sync import _complete_follow_up
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        sync_task = SimpleNamespace(profile_id=1, entity_id=999)
+
+        _complete_follow_up(db, sync_task, datetime.now(UTC))
+        db.add.assert_not_called()
+
+    def test_complete_learning_goal_sets_completed(self):
+        from career_os.services.ticktick_sync import _complete_learning_goal
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(entity_id=20)
+        goal = MagicMock()
+        goal.status = "in_progress"
+        db.query.return_value.filter.return_value.first.return_value = goal
+
+        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+        _complete_learning_goal(db, sync_task, now)
+
+        assert goal.status == "completed"
+        assert goal.updated_at == now
+
+    def test_complete_learning_goal_skips_already_completed(self):
+        from career_os.services.ticktick_sync import _complete_learning_goal
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(entity_id=20)
+        goal = MagicMock()
+        goal.status = "completed"
+        db.query.return_value.filter.return_value.first.return_value = goal
+
+        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+        _complete_learning_goal(db, sync_task, now)
+        assert goal.status == "completed"  # unchanged
+
+    def test_complete_pipeline_action_marks_next_step_done(self):
+        from career_os.services.ticktick_sync import _complete_pipeline_action
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(profile_id=1, entity_id=30, title="Apply to Acme")
+        app_obj = MagicMock()
+        app_obj.next_step = "Send follow-up email"
+        app_obj.id = 30
+        db.query.return_value.filter.return_value.first.return_value = app_obj
+
+        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+        _complete_pipeline_action(db, sync_task, now)
+
+        assert app_obj.next_step == "[Done] Send follow-up email"
+        assert app_obj.updated_at == now
+        db.add.assert_called_once()
+
+    def test_complete_pipeline_action_handles_no_next_step(self):
+        from career_os.services.ticktick_sync import _complete_pipeline_action
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(profile_id=1, entity_id=30, title="Task")
+        app_obj = MagicMock()
+        app_obj.next_step = None
+        app_obj.id = 30
+        db.query.return_value.filter.return_value.first.return_value = app_obj
+
+        _complete_pipeline_action(db, sync_task, datetime.now(UTC))
+        assert app_obj.next_step is None  # unchanged, not "[Done] None"
+
+    def test_complete_pipeline_action_skips_missing_entity(self):
+        from career_os.services.ticktick_sync import _complete_pipeline_action
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        sync_task = SimpleNamespace(profile_id=1, entity_id=999, title="Task")
+
+        _complete_pipeline_action(db, sync_task, datetime.now(UTC))
+        db.add.assert_not_called()
+
+    def test_apply_completion_dispatches_to_correct_handler(self):
+        """Integration test: _apply_completion routes to the right handler via the dict."""
+        from career_os.services.ticktick_sync import _apply_completion
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(entity_type="follow_up", profile_id=1, entity_id=10)
+        follow_up = MagicMock()
+        follow_up.completed_at = None
+        follow_up.application_id = 5
+        db.query.return_value.filter.return_value.first.return_value = follow_up
+
+        _apply_completion(db, sync_task)
+        assert follow_up.completed_at is not None
+
+    def test_apply_completion_unknown_type_is_noop(self):
+        """Unknown entity types should not raise — just be silently ignored."""
+        from career_os.services.ticktick_sync import _apply_completion
+
+        db = MagicMock()
+        sync_task = SimpleNamespace(entity_type="unknown_thing", profile_id=1, entity_id=10)
+
+        _apply_completion(db, sync_task)  # should not raise
+        db.query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_entity (api/ticktick)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEntity:
+    """Tests for the generic entity fetcher in ticktick API."""
+
+    @staticmethod
+    def _make_model():
+        """Create a mock SQLAlchemy model class with id and profile_id columns."""
+        model = MagicMock()
+        model.id = MagicMock()
+        model.profile_id = MagicMock()
+        return model
+
+    def test_returns_entity_when_found(self):
+        from career_os.api.ticktick import _fetch_entity
+
+        db = MagicMock()
+        model = self._make_model()
+        mock_obj = SimpleNamespace(id=1, profile_id=1)
+        db.query.return_value.filter.return_value.first.return_value = mock_obj
+
+        result = _fetch_entity(db, model, 1, 1, "Follow-up")
+        assert result is mock_obj
+
+    def test_raises_404_when_not_found(self):
+        from fastapi import HTTPException
+
+        from career_os.api.ticktick import _fetch_entity
+
+        db = MagicMock()
+        model = self._make_model()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            _fetch_entity(db, model, 999, 1, "Follow-up")
+        assert exc_info.value.status_code == 404
+        assert "Follow-up not found" in exc_info.value.detail
+
+    def test_404_message_uses_label(self):
+        from fastapi import HTTPException
+
+        from career_os.api.ticktick import _fetch_entity
+
+        db = MagicMock()
+        model = self._make_model()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            _fetch_entity(db, model, 1, 1, "Learning goal")
+        assert "Learning goal not found" in exc_info.value.detail

--- a/tests/test_refactored_helpers.py
+++ b/tests/test_refactored_helpers.py
@@ -384,3 +384,222 @@ class TestFetchEntity:
         with pytest.raises(HTTPException) as exc_info:
             _fetch_entity(db, model, 1, 1, "Learning goal")
         assert "Learning goal not found" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractErrorDetail:
+    """Tests for OpenRouter error detail extraction."""
+
+    def test_extracts_message_from_valid_json(self):
+        from career_os.ai.openrouter_provider import _extract_error_detail
+
+        response = MagicMock()
+        response.json.return_value = {"error": {"message": "Insufficient credits"}}
+        assert _extract_error_detail(response) == "Insufficient credits"
+
+    def test_returns_empty_on_json_error(self):
+        from career_os.ai.openrouter_provider import _extract_error_detail
+
+        response = MagicMock()
+        response.json.side_effect = ValueError("bad json")
+        assert _extract_error_detail(response) == ""
+
+    def test_returns_empty_when_no_error_key(self):
+        from career_os.ai.openrouter_provider import _extract_error_detail
+
+        response = MagicMock()
+        response.json.return_value = {"status": "fail"}
+        assert _extract_error_detail(response) == ""
+
+
+class TestHandleStatusTransition:
+    """Tests for application status transition handler."""
+
+    def test_skips_when_no_status_in_data(self):
+        from career_os.services.applications import _handle_status_transition
+
+        db = MagicMock()
+        app_obj = MagicMock()
+        update_data = {"notes": "updated"}
+        _handle_status_transition(db, app_obj, update_data)
+        # No activity logged for non-status changes
+        db.add.assert_not_called()
+
+    def test_normalizes_and_validates_status(self):
+        from career_os.services.applications import (
+            _handle_status_transition,
+        )
+
+        db = MagicMock()
+        app_obj = MagicMock()
+        app_obj.status = "discovered"
+        app_obj.profile_id = 1
+        app_obj.id = 10
+
+        # discovered → interested is a valid transition
+        update_data = {"status": "  Interested  "}
+        _handle_status_transition(db, app_obj, update_data)
+        assert update_data["status"] == "interested"
+
+    def test_sets_date_applied_on_applied_transition(self):
+        from career_os.services.applications import _handle_status_transition
+
+        db = MagicMock()
+        app_obj = MagicMock()
+        # interested → applied is a valid transition
+        app_obj.status = "interested"
+        app_obj.profile_id = 1
+        app_obj.id = 10
+        app_obj.date_applied = None
+
+        _handle_status_transition(db, app_obj, {"status": "applied"})
+        assert app_obj.date_applied is not None
+
+
+class TestApplyFieldUpdates:
+    """Tests for application field update tracker."""
+
+    def test_tracks_changed_fields(self):
+        from career_os.services.applications import _apply_field_updates
+
+        db = MagicMock()
+        app_obj = MagicMock()
+        app_obj.notes = "old"
+        app_obj.url = "https://old.com"
+
+        _apply_field_updates(db, app_obj, {"notes": "new"})
+        # Should have called setattr and logged
+        assert app_obj.notes == "new"
+
+    def test_sets_status_without_logging(self):
+        from career_os.services.applications import _apply_field_updates
+
+        db = MagicMock()
+        app_obj = MagicMock()
+        app_obj.status = "discovered"
+        app_obj.profile_id = 1
+        app_obj.id = 10
+
+        # Status field should be set but not counted as a changed field
+        _apply_field_updates(db, app_obj, {"status": "applied"})
+
+
+class TestApplyStatusTimestamps:
+    """Tests for learning resource status timestamp handler."""
+
+    def test_in_progress_sets_started_at(self):
+        from career_os.services.learning import _apply_status_timestamps
+
+        db = MagicMock()
+        resource = MagicMock()
+        resource.started_at = None
+        now = datetime(2026, 4, 10, tzinfo=UTC)
+
+        _apply_status_timestamps(db, resource, "in_progress", now)
+        assert resource.status == "in_progress"
+        assert resource.started_at == now
+
+    def test_in_progress_preserves_existing_started_at(self):
+        from career_os.services.learning import _apply_status_timestamps
+
+        db = MagicMock()
+        resource = MagicMock()
+        old_time = datetime(2026, 1, 1, tzinfo=UTC)
+        resource.started_at = old_time
+        now = datetime(2026, 4, 10, tzinfo=UTC)
+
+        _apply_status_timestamps(db, resource, "in_progress", now)
+        assert resource.started_at == old_time  # preserved
+
+    def test_completed_sets_both_timestamps(self):
+        from career_os.services.learning import _apply_status_timestamps
+
+        db = MagicMock()
+        resource = MagicMock()
+        resource.started_at = None
+        now = datetime(2026, 4, 10, tzinfo=UTC)
+
+        _apply_status_timestamps(db, resource, "completed", now)
+        assert resource.status == "completed"
+        assert resource.started_at == now
+        assert resource.completed_at == now
+
+    def test_not_started_clears_timestamps(self):
+        from career_os.services.learning import _apply_status_timestamps
+
+        db = MagicMock()
+        resource = MagicMock()
+        resource.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+        resource.completed_at = datetime(2026, 2, 1, tzinfo=UTC)
+        now = datetime(2026, 4, 10, tzinfo=UTC)
+
+        _apply_status_timestamps(db, resource, "not_started", now)
+        assert resource.status == "not_started"
+        assert resource.started_at is None
+        assert resource.completed_at is None
+
+
+class TestDeliverSingleNotification:
+    """Tests for the individual notification delivery helper."""
+
+    def test_successful_delivery(self):
+        from career_os.services.pushover import _deliver_single_notification
+
+        client = MagicMock()
+        log_entry = MagicMock()
+        log_entry.error_message = None
+        log_entry.message = "Test notification"
+        log_entry.title = "Test"
+
+        result = _deliver_single_notification(client, log_entry)
+        assert result is True
+        assert log_entry.status == "sent"
+        assert log_entry.error_message is None
+        client.send_notification.assert_called_once()
+
+    def test_failed_delivery(self):
+        from career_os.services.pushover import PushoverAPIError, _deliver_single_notification
+
+        client = MagicMock()
+        client.send_notification.side_effect = PushoverAPIError("API down")
+        log_entry = MagicMock()
+        log_entry.error_message = None
+        log_entry.message = "Test"
+        log_entry.title = "Test"
+
+        result = _deliver_single_notification(client, log_entry)
+        assert result is False
+        assert log_entry.status == "failed"
+        assert "API down" in log_entry.error_message
+
+    def test_parses_metadata_from_error_message_json(self):
+        import json
+
+        from career_os.services.pushover import _deliver_single_notification
+
+        client = MagicMock()
+        log_entry = MagicMock()
+        log_entry.error_message = json.dumps({"url": "https://example.com", "priority": 1})
+        log_entry.message = "Test"
+        log_entry.title = "Test"
+
+        _deliver_single_notification(client, log_entry)
+        call_kwargs = client.send_notification.call_args.kwargs
+        assert call_kwargs["url"] == "https://example.com"
+        assert call_kwargs["priority"] == 1
+
+    def test_handles_invalid_json_metadata(self):
+        from career_os.services.pushover import _deliver_single_notification
+
+        client = MagicMock()
+        log_entry = MagicMock()
+        log_entry.error_message = "not valid json {{"
+        log_entry.message = "Test"
+        log_entry.title = "Test"
+
+        result = _deliver_single_notification(client, log_entry)
+        assert result is True  # should still send successfully

--- a/tests/test_role_intelligence.py
+++ b/tests/test_role_intelligence.py
@@ -22,6 +22,7 @@ from career_os.main import app
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Profile
 from career_os.schemas.ai import AIFeature
+from tests.profile_data import SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -71,9 +72,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_role_intelligence.py
+++ b/tests/test_role_intelligence.py
@@ -71,7 +71,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from career_os.database import Base, get_db
 from career_os.models.models import Profile
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from career_os.database import Base, get_db
 from career_os.models.models import Profile
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -53,12 +54,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -68,9 +64,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -53,7 +53,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -63,7 +68,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_skills_parsing.py
+++ b/tests/test_skills_parsing.py
@@ -74,7 +74,12 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    profile = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -84,7 +89,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_skills_parsing.py
+++ b/tests/test_skills_parsing.py
@@ -34,6 +34,7 @@ from career_os.services.skills_parsing import (
     parse_profile_docs,
     parse_workplace_insights,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -74,12 +75,7 @@ def test_db(_db_engine):
 @pytest.fixture
 def test_profile(test_db: Session) -> Profile:
     """Seed a test profile."""
-    profile = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    profile = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)
@@ -89,9 +85,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_skills_parsing.py
+++ b/tests/test_skills_parsing.py
@@ -34,7 +34,7 @@ from career_os.services.skills_parsing import (
     parse_profile_docs,
     parse_workplace_insights,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_star_stories.py
+++ b/tests/test_star_stories.py
@@ -68,7 +68,9 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(name="Other User", email="other@example.com", job_family="Software Engineering")
+    profile = Profile(
+        name="Other User", email="other@example.com", job_family="Software Engineering"
+    )
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_star_stories.py
+++ b/tests/test_star_stories.py
@@ -19,6 +19,7 @@ from career_os.database import Base, get_db
 from career_os.main import app
 from career_os.models.models import Application, Profile
 from career_os.models.skills import JobRequirement
+from tests.profile_data import SECOND_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -68,9 +69,7 @@ def test_profile(test_db: Session) -> Profile:
 @pytest.fixture
 def second_profile(test_db: Session) -> Profile:
     """Create a second profile for scoping tests."""
-    profile = Profile(
-        name="Other User", email="other@example.com", job_family="Software Engineering"
-    )
+    profile = Profile(**{k: v for k, v in SECOND_PROFILE_KWARGS.items() if k != "location"})
     test_db.add(profile)
     test_db.commit()
     test_db.refresh(profile)

--- a/tests/test_ticktick.py
+++ b/tests/test_ticktick.py
@@ -35,6 +35,7 @@ from career_os.services.ticktick_sync import (
     sync_learning_goal_to_ticktick,
     sync_pipeline_action_to_ticktick,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 
@@ -80,12 +81,7 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    p = Profile(**DEFAULT_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -95,12 +91,7 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Create a second test profile for isolation tests."""
-    p = Profile(
-        name="Other User",
-        email="other@example.com",
-        location="Berlin",
-        job_family="Software Engineering",
-    )
+    p = Profile(**SECOND_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_ticktick.py
+++ b/tests/test_ticktick.py
@@ -80,7 +80,12 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    p = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -90,7 +95,12 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Create a second test profile for isolation tests."""
-    p = Profile(name="Other User", email="other@example.com", location="Berlin", job_family="Software Engineering")
+    p = Profile(
+        name="Other User",
+        email="other@example.com",
+        location="Berlin",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_ticktick.py
+++ b/tests/test_ticktick.py
@@ -35,7 +35,7 @@ from career_os.services.ticktick_sync import (
     sync_learning_goal_to_ticktick,
     sync_pipeline_action_to_ticktick,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 client = TestClient(app)
 

--- a/tests/test_timingsapp.py
+++ b/tests/test_timingsapp.py
@@ -89,7 +89,12 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    p = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -99,7 +104,12 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Second profile for isolation tests."""
-    p = Profile(name="Other User", email="other@example.com", location="Berlin", job_family="Software Engineering")
+    p = Profile(
+        name="Other User",
+        email="other@example.com",
+        location="Berlin",
+        job_family="Software Engineering",
+    )
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_timingsapp.py
+++ b/tests/test_timingsapp.py
@@ -44,6 +44,7 @@ from career_os.services.timingsapp_client import (
     TimingsAppAPIError,
     TimingsAppClient,
 )
+from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 api_client = TestClient(app)
 
@@ -89,12 +90,7 @@ def db_session():
 @pytest.fixture()
 def profile(db_session) -> Profile:
     """Create a test profile."""
-    p = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    p = Profile(**DEFAULT_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)
@@ -104,12 +100,7 @@ def profile(db_session) -> Profile:
 @pytest.fixture()
 def profile_b(db_session) -> Profile:
     """Second profile for isolation tests."""
-    p = Profile(
-        name="Other User",
-        email="other@example.com",
-        location="Berlin",
-        job_family="Software Engineering",
-    )
+    p = Profile(**SECOND_PROFILE_KWARGS)
     db_session.add(p)
     db_session.commit()
     db_session.refresh(p)

--- a/tests/test_timingsapp.py
+++ b/tests/test_timingsapp.py
@@ -44,7 +44,7 @@ from career_os.services.timingsapp_client import (
     TimingsAppAPIError,
     TimingsAppClient,
 )
-from tests.conftest import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
+from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS
 
 api_client = TestClient(app)
 

--- a/tests/test_ut_cross_flow_fixes.py
+++ b/tests/test_ut_cross_flow_fixes.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from career_os.database import Base, get_db
 from career_os.main import app
 from career_os.models.models import Application, FollowUp, Profile
+from tests.conftest import DEFAULT_PROFILE_KWARGS
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -51,12 +52,7 @@ def test_db(_db_engine):
 
 @pytest.fixture
 def profile(test_db: Session) -> Profile:
-    p = Profile(
-        name="Test User",
-        email="test@example.com",
-        location="Frankfurt",
-        job_family="Software Engineering",
-    )
+    p = Profile(**DEFAULT_PROFILE_KWARGS)
     test_db.add(p)
     test_db.commit()
     test_db.refresh(p)

--- a/tests/test_ut_cross_flow_fixes.py
+++ b/tests/test_ut_cross_flow_fixes.py
@@ -51,7 +51,12 @@ def test_db(_db_engine):
 
 @pytest.fixture
 def profile(test_db: Session) -> Profile:
-    p = Profile(name="Test User", email="test@example.com", location="Frankfurt", job_family="Software Engineering")
+    p = Profile(
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="Software Engineering",
+    )
     test_db.add(p)
     test_db.commit()
     test_db.refresh(p)

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -75,7 +75,12 @@ def profile(test_db: Session) -> Profile:
 
 @pytest.fixture
 def profile_b(test_db: Session) -> Profile:
-    p = Profile(name="Other User", email="other@test.com", location="Berlin", job_family="Software Engineering")
+    p = Profile(
+        name="Other User",
+        email="other@test.com",
+        location="Berlin",
+        job_family="Software Engineering",
+    )
     test_db.add(p)
     test_db.commit()
     test_db.refresh(p)


### PR DESCRIPTION
## Summary

Addresses remaining SonarCloud issues from #22, #48, #59, and #62 across Python backend, API layer, and frontend.

### Python backend
- **S8410**: Last bare `Depends`/`Query` in `discovery.py` → `Annotated` pattern
- **S8415**: Added 422 response docs to both scoring endpoints
- **S1244**: `pytest.approx()` for remaining float comparison
- **S117**: Renamed `MockClient` → `mock_client_cls` in `test_pushover.py` (PEP 8)
- **S108**: Added clarifying comments to 2 empty `except: pass` blocks in `src/`
- **S1192**: Extracted `RESP_NOT_FOUND` constant replacing **93 occurrences** across **22 API files**
- **S3776**: Reduced cognitive complexity in **9 functions** by extracting helpers:
  - `ticktick_sync._apply_completion` → dispatch table with per-entity handlers
  - `api/ticktick.ticktick_push` → `_resolve_and_sync` + `_fetch_entity`
  - `voice.create_session` → `_generate_session_title`
  - `api/applications.get_detail` → `_build_package_summary` + `_derive_package_type`
  - `skills_parsing.parse_workplace_insights` → keyword lookup table
  - `openrouter_provider.complete` → `_extract_error_detail`
  - `applications.update_application` → `_handle_status_transition` + `_apply_field_updates`
  - `learning.update_learning_status` → `_apply_status_timestamps`
  - `pushover.deliver_queued_notifications` → `_deliver_single_notification`

### Frontend
- **S3358**: Extracted `scoreColor()` helper and `SEVERITY_COLORS` map replacing nested ternaries in `KanbanCard.tsx` and `StarStoriesSection.tsx`
- **S6853**: Replaced decorative `<label>` with `<span>` in `ApplicationDetail.tsx`
- Semantic HTML: `<div>` → `<section>` for `ApplicationDetail` root wrapper

### Testing
- **56 new Python unit tests** covering all extracted helpers (`test_refactored_helpers.py`)
- **6 new frontend tests** for `scoreColor()` boundary behavior
- Full regression: **1943 Python tests pass**, **229 frontend tests pass**, **0 regressions**

### Security review
- No high or medium severity issues found
- Profile scoping and authorization preserved across all refactored endpoints
- Exception chaining (`from exc`) maintained in all error paths
- 1 low pre-existing concern noted (raw exception in scoring 500 responses)

## Test plan
- [x] `pytest tests/test_refactored_helpers.py` — 56/56 pass
- [x] `vitest run src/__tests__/scoreColor.test.ts` — 6/6 pass
- [x] Full Python suite — 1943 passed, 0 regressions
- [x] Full frontend suite — 229/229 pass
- [x] `ruff check src/` — all clean
- [x] `tsc --noEmit` — no type errors
- [x] Security review completed — no issues

Refs #22, #48, #59, #62

https://claude.ai/code/session_01KZ4r63GGUUTVjUUdtpDteD