### PR TITLE
G-217, G-218: Dimensional scores + ATS keyword extraction

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -110,6 +110,21 @@ export interface RedFlag {
   description: string;
 }
 
+export interface DimensionalScores {
+  technical_fit: number;
+  seniority_alignment: number;
+  compensation_fit: number;
+  location_fit: number;
+  career_trajectory: number;
+  company_fit: number;
+}
+
+export interface ATSKeyword {
+  keyword: string;
+  category: "technical" | "soft_skill" | "tool" | "certification" | "domain";
+  matched: boolean;
+}
+
 export interface Application {
   id: number;
   profile_id: number;
@@ -126,6 +141,8 @@ export interface Application {
   readiness_score: number | null;
   letter_grade?: string | null;
   red_flags?: RedFlag[] | null;
+  dimensional_scores?: DimensionalScores | null;
+  ats_keywords?: ATSKeyword[] | null;
   date_applied: string | null;
   created_at: string;
   updated_at: string;
@@ -391,6 +408,8 @@ export interface DiscoveredJob {
   readiness_score: number | null;
   letter_grade?: string | null;
   red_flags?: RedFlag[] | null;
+  dimensional_scores?: DimensionalScores | null;
+  ats_keywords?: ATSKeyword[] | null;
   application_id: number | null;
   created_at: string;
   updated_at: string;

--- a/frontend/src/components/ATSKeywordChecklist.tsx
+++ b/frontend/src/components/ATSKeywordChecklist.tsx
@@ -1,0 +1,66 @@
+import { Check, X } from "lucide-react";
+import type { ATSKeyword } from "@/api/types";
+
+interface ATSKeywordChecklistProps {
+  readonly keywords: ATSKeyword[] | null | undefined;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  technical: "Technical Skills",
+  soft_skill: "Soft Skills",
+  tool: "Tools & Platforms",
+  certification: "Certifications",
+  domain: "Domain Knowledge",
+};
+
+export default function ATSKeywordChecklist({ keywords }: ATSKeywordChecklistProps) {
+  if (!keywords || keywords.length === 0) return null;
+
+  const grouped = keywords.reduce<Record<string, ATSKeyword[]>>((acc, kw) => {
+    const cat = kw.category || "technical";
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(kw);
+    return acc;
+  }, {});
+
+  const matchedCount = keywords.filter((k) => k.matched).length;
+
+  return (
+    <div className="w-full">
+      <div className="mb-2 flex items-center justify-between">
+        <h4 className="text-sm font-medium text-gray-700">ATS Keywords</h4>
+        <span className="text-xs text-gray-500">
+          {matchedCount}/{keywords.length} matched
+        </span>
+      </div>
+      <div className="space-y-3">
+        {Object.entries(grouped).map(([category, kws]) => (
+          <div key={category}>
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {CATEGORY_LABELS[category] ?? category}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {kws.map((kw) => (
+                <span
+                  key={kw.keyword}
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs ${
+                    kw.matched
+                      ? "bg-green-50 text-green-700"
+                      : "bg-red-50 text-red-600"
+                  }`}
+                >
+                  {kw.matched ? (
+                    <Check className="h-3 w-3" />
+                  ) : (
+                    <X className="h-3 w-3" />
+                  )}
+                  {kw.keyword}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ScoreRadarChart.tsx
+++ b/frontend/src/components/ScoreRadarChart.tsx
@@ -1,0 +1,92 @@
+import {
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import type { DimensionalScores } from "@/api/types";
+import { useEffect, useState } from "react";
+
+interface ScoreRadarChartProps {
+  readonly dimensionalScores: DimensionalScores | null | undefined;
+}
+
+const AXIS_LABELS: Record<keyof DimensionalScores, string> = {
+  technical_fit: "Technical",
+  seniority_alignment: "Seniority",
+  compensation_fit: "Compensation",
+  location_fit: "Location",
+  career_trajectory: "Career Path",
+  company_fit: "Company",
+};
+
+function barColor(value: number): string {
+  if (value >= 7) return "#22c55e";
+  if (value >= 4) return "#eab308";
+  return "#ef4444";
+}
+
+export default function ScoreRadarChart({ dimensionalScores }: ScoreRadarChartProps) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 640);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  if (!dimensionalScores) return null;
+
+  const data = (Object.keys(AXIS_LABELS) as (keyof DimensionalScores)[]).map((key) => ({
+    axis: AXIS_LABELS[key],
+    value: dimensionalScores[key],
+  }));
+
+  if (isMobile) {
+    return (
+      <div className="w-full">
+        <h4 className="mb-2 text-sm font-medium text-gray-700">Score Dimensions</h4>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={data} layout="vertical" margin={{ top: 5, right: 20, left: 60, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+            <XAxis type="number" domain={[0, 10]} tick={{ fontSize: 11 }} />
+            <YAxis type="category" dataKey="axis" tick={{ fontSize: 11 }} width={55} />
+            <Tooltip
+              formatter={(v: number) => [v.toFixed(1), "Score"]}
+              contentStyle={{ borderRadius: 8, border: "1px solid #e2e8f0" }}
+            />
+            <Bar dataKey="value" fill="#22c55e" radius={[0, 4, 4, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <h4 className="mb-2 text-sm font-medium text-gray-700">Score Dimensions</h4>
+      <ResponsiveContainer width="100%" height={260}>
+        <RadarChart data={data} cx="50%" cy="50%" outerRadius="75%">
+          <PolarGrid stroke="#e2e8f0" />
+          <PolarAngleAxis dataKey="axis" tick={{ fontSize: 11, fill: "#64748b" }} />
+          <PolarRadiusAxis domain={[0, 10]} tick={{ fontSize: 10 }} axisLine={false} />
+          <Radar
+            dataKey="value"
+            stroke="#16a34a"
+            fill="#22c55e"
+            fillOpacity={0.3}
+          />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/pages/ApplicationDetail.tsx
+++ b/frontend/src/pages/ApplicationDetail.tsx
@@ -27,8 +27,10 @@ import {
   FolderOpen,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import ATSKeywordChecklist from "@/components/ATSKeywordChecklist";
 import { GradeBadge } from "@/components/GradeBadge";
 import { RedFlagBadge } from "@/components/RedFlagBadge";
+import ScoreRadarChart from "@/components/ScoreRadarChart";
 import { CalendarSection } from "@/components/CalendarSection";
 import { FollowUpSection } from "@/components/FollowUpSection";
 import { InterviewPrepSection } from "@/components/InterviewPrepSection";
@@ -446,6 +448,20 @@ export function ApplicationDetail() {
                     testId="red-flags-detail"
                   />
                 </div>
+              </div>
+            )}
+
+            {/* Dimensional score radar chart */}
+            {data.dimensional_scores && (
+              <div className="mt-4">
+                <ScoreRadarChart dimensionalScores={data.dimensional_scores} />
+              </div>
+            )}
+
+            {/* ATS keyword checklist */}
+            {data.ats_keywords && data.ats_keywords.length > 0 && (
+              <div className="mt-4">
+                <ATSKeywordChecklist keywords={data.ats_keywords} />
               </div>
             )}
           </div>

--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -10,8 +10,10 @@ from career_os.ai.base import AIProvider
 from career_os.schemas.ai import (
     AIFeature,
     AIResponse,
+    ATSKeyword,
     CoachingResult,
     CompanyResearchResult,
+    DimensionalScores,
     GapAnalysisResult,
     GoalRecalibrationResult,
     InterviewFormatResult,
@@ -192,6 +194,36 @@ def _handle_score(prompt: str, context: dict | None) -> AIResponse:
     ]
     reasoning = ". ".join(factors) + f". Overall a solid fit with score {fit}/10."
 
+    # Dimensional sub-scores (deterministic from seed, 0-10 each)
+    dimensional = DimensionalScores(
+        technical_fit=round(2.0 + (seed % 80) / 10.0, 1),
+        seniority_alignment=round(3.0 + ((seed >> 3) % 70) / 10.0, 1),
+        compensation_fit=round(2.0 + ((seed >> 5) % 80) / 10.0, 1),
+        location_fit=round(4.0 + ((seed >> 7) % 60) / 10.0, 1),
+        career_trajectory=round(2.0 + ((seed >> 9) % 80) / 10.0, 1),
+        company_fit=round(3.0 + ((seed >> 11) % 70) / 10.0, 1),
+    )
+
+    # Mock ATS keywords (deterministic selection from a pool)
+    _keyword_pool = [
+        ("Python", "technical"), ("React", "technical"), ("TypeScript", "technical"),
+        ("Docker", "tool"), ("Kubernetes", "tool"), ("AWS", "tool"),
+        ("FastAPI", "technical"), ("PostgreSQL", "tool"), ("REST APIs", "technical"),
+        ("CI/CD", "tool"), ("Git", "tool"), ("Agile", "soft_skill"),
+        ("Leadership", "soft_skill"), ("Communication", "soft_skill"),
+        ("System Design", "technical"), ("Machine Learning", "domain"),
+        ("Data Analysis", "domain"), ("PMP", "certification"),
+    ]
+    kw_count = 10 + (seed % 6)  # 10-15 keywords
+    ats_kws = [
+        ATSKeyword(
+            keyword=_keyword_pool[i % len(_keyword_pool)][0],
+            category=_keyword_pool[i % len(_keyword_pool)][1],
+            matched=((seed + i) % 3 != 0),  # ~67% matched
+        )
+        for i in range(kw_count)
+    ]
+
     structured = ScoreResult(
         fit_score=fit,
         reasoning=reasoning,
@@ -204,6 +236,8 @@ def _handle_score(prompt: str, context: dict | None) -> AIResponse:
         readiness_score=readiness,
         career_alignment=career,
         score_breakdown=breakdown_factors,
+        dimensional_scores=dimensional,
+        ats_keywords=ats_kws,
     )
     return AIResponse(
         content=structured.reasoning,

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -137,7 +137,12 @@ class OpenRouterProvider(AIProvider):
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "
             f"score_breakdown (array of ≥3 objects, each with: factor (string), "
-            f"contribution (positive or negative float), description (string)).\n\n"
+            f"contribution (positive or negative float), description (string)), "
+            f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
+            f"seniority_alignment, compensation_fit, location_fit, career_trajectory, company_fit), "
+            f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
+            f"category (one of: technical, soft_skill, tool, certification, domain), "
+            f"matched (boolean - true if candidate profile demonstrates this keyword)).\n\n"
             f"Job Description:\n{job_description}\n\n"
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )
@@ -154,7 +159,13 @@ def _system_prompt_for_feature(feature: AIFeature) -> str | None:
             "readiness_score (0-100), career_alignment (0-10), "
             "score_breakdown (REQUIRED array of ≥3 objects, each with: "
             "factor (string), contribution (positive or negative float), "
-            "description (string explaining impact))."
+            "description (string explaining impact)), "
+            "dimensional_scores (REQUIRED object with 6 floats 0-10: "
+            "technical_fit, seniority_alignment, compensation_fit, "
+            "location_fit, career_trajectory, company_fit), "
+            "ats_keywords (REQUIRED array of 10-15 objects, each with: "
+            "keyword (string), category (technical|soft_skill|tool|certification|domain), "
+            "matched (boolean — true if candidate profile demonstrates this keyword))."
         ),
         AIFeature.gap_analysis: (
             "You are a skills gap analysis AI. Return valid JSON with: gaps (list of "

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -90,7 +90,7 @@ async def score_endpoint(
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Scoring error: {exc}") from exc
 
-    return ScoreResponse.model_validate(scored)
+    return ScoreResponse.from_orm_with_dimensions(scored)
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +185,7 @@ async def batch_score_endpoint(
     return BatchScoreResponse(
         scored_count=result["scored_count"],
         total_time_seconds=result["total_time_seconds"],
-        scores=[ScoreResponse.model_validate(s) for s in result["scores"]],
+        scores=[ScoreResponse.from_orm_with_dimensions(s) for s in result["scores"]],
         errors=result["errors"],
         credits_exhausted=credits_exhausted,
     )
@@ -206,7 +206,7 @@ async def get_job_score_endpoint(
     scored = get_score_for_job(db, profile_id, discovered_job_id)
     if not scored:
         raise HTTPException(status_code=404, detail="No score found for this job")
-    return ScoreResponse.model_validate(scored)
+    return ScoreResponse.from_orm_with_dimensions(scored)
 
 
 @router.get(
@@ -222,7 +222,7 @@ async def get_application_score_endpoint(
     scored = get_score_for_application(db, profile_id, application_id)
     if not scored:
         raise HTTPException(status_code=404, detail="No score found for this application")
-    return ScoreResponse.model_validate(scored)
+    return ScoreResponse.from_orm_with_dimensions(scored)
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -59,6 +59,28 @@ class ScoreBreakdownFactor(BaseModel):
     description: str = Field(..., description="Explanation of this factor's impact")
 
 
+class DimensionalScores(BaseModel):
+    """Six-axis dimensional sub-scores (0-10 each)."""
+
+    technical_fit: float = Field(..., ge=0, le=10, description="Skill/tool match and experience alignment")
+    seniority_alignment: float = Field(..., ge=0, le=10, description="Over/under-qualified detection")
+    compensation_fit: float = Field(..., ge=0, le=10, description="Salary range vs expectations")
+    location_fit: float = Field(..., ge=0, le=10, description="Remote policy, commute, relocation")
+    career_trajectory: float = Field(..., ge=0, le=10, description="Does this role advance stated goals?")
+    company_fit: float = Field(..., ge=0, le=10, description="Company stage, industry, culture signals")
+
+
+class ATSKeyword(BaseModel):
+    """A single ATS keyword extracted from a JD."""
+
+    keyword: str = Field(..., description="The keyword or skill term")
+    category: str = Field(
+        ...,
+        description="Category: technical, soft_skill, tool, certification, or domain",
+    )
+    matched: bool = Field(..., description="True if the candidate profile demonstrates this keyword")
+
+
 class ScoreResult(BaseModel):
     """Structured scoring response."""
 
@@ -74,6 +96,14 @@ class ScoreResult(BaseModel):
         ...,
         min_length=3,
         description="Detailed breakdown of scoring factors with +/- contributions (≥3 factors)",
+    )
+    dimensional_scores: DimensionalScores | None = Field(
+        default=None,
+        description="Six-axis dimensional sub-scores (0-10 each)",
+    )
+    ats_keywords: list[ATSKeyword] = Field(
+        default_factory=list,
+        description="Top 10-15 ATS keywords from the JD with match status",
     )
 
 

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from career_os.schemas.ai import ScoreBreakdownFactor
+from career_os.schemas.ai import ATSKeyword, DimensionalScores, ScoreBreakdownFactor
 
 
 def _ensure_utc(v: Any) -> datetime | None:
@@ -50,6 +50,27 @@ def score_to_letter_grade(score: float | None) -> str | None:
     if score >= 3.0:
         return "D"
     return "F"
+
+
+_DIM_FIELD_MAP = {
+    "technical_fit": "dim_technical_fit",
+    "seniority_alignment": "dim_seniority_alignment",
+    "compensation_fit": "dim_compensation_fit",
+    "location_fit": "dim_location_fit",
+    "career_trajectory": "dim_career_trajectory",
+    "company_fit": "dim_company_fit",
+}
+
+
+def _assemble_dimensional(source: Any) -> DimensionalScores | None:
+    """Try to build DimensionalScores from an object with dim_* attributes."""
+    vals = {}
+    for short_name, db_col in _DIM_FIELD_MAP.items():
+        v = getattr(source, db_col, None) if not isinstance(source, dict) else source.get(db_col)
+        if v is None:
+            return None
+        vals[short_name] = v
+    return DimensionalScores(**vals)
 
 
 # ---------------------------------------------------------------------------
@@ -102,14 +123,22 @@ class ScoreResponse(BaseModel):
     # Detailed breakdown
     score_breakdown: list[ScoreBreakdownFactor] = Field(
         default_factory=list,
-        description="Breakdown of scoring factors with +/- contributions (≥3 factors)",
+        description="Breakdown of scoring factors with +/- contributions (\u22653 factors)",
     )
     red_flags: list[RedFlag] = Field(
         default_factory=list,
         description="Rule-based red flags detected in the JD (zero AI cost)",
     )
+    dimensional_scores: DimensionalScores | None = Field(
+        default=None,
+        description="Six-axis dimensional sub-scores (0-10 each)",
+    )
+    ats_keywords: list[ATSKeyword] = Field(
+        default_factory=list,
+        description="Top 10-15 ATS keywords from the JD with match status",
+    )
     reasoning: str = Field(
-        ..., min_length=100, description="Scoring explanation (≥100 chars, ≥3 factors)"
+        ..., min_length=100, description="Scoring explanation (\u2265100 chars, \u22653 factors)"
     )
     estimated_salary: str = Field(..., description="Estimated salary range")
     effort_flag: str = Field(..., description="Effort level: low / medium / high")
@@ -150,17 +179,39 @@ class ScoreResponse(BaseModel):
                 return []
         return v
 
+    @field_validator("ats_keywords", mode="before")
+    @classmethod
+    def _parse_ats_keywords(cls, v: Any) -> list[ATSKeyword]:
+        """Parse ats_keywords from JSON string if it comes from DB."""
+        if v is None:
+            return []
+        if isinstance(v, str):
+            try:
+                parsed = json_mod.loads(v)
+                return [ATSKeyword(**item) for item in parsed]
+            except (json_mod.JSONDecodeError, TypeError):
+                return []
+        return v
+
     @field_validator("created_at", "updated_at", mode="before")
     @classmethod
     def _ensure_utc(cls, v: Any) -> datetime | None:
         return _ensure_utc(v)
 
     @model_validator(mode="after")
-    def _populate_letter_grade(self) -> "ScoreResponse":
-        """Derive letter_grade from fit_score whenever it is not set."""
+    def _populate_computed_fields(self) -> "ScoreResponse":
+        """Derive letter_grade from fit_score when not explicitly set."""
         if self.letter_grade is None:
             self.letter_grade = score_to_letter_grade(self.fit_score)
         return self
+
+    @classmethod
+    def from_orm_with_dimensions(cls, obj: Any) -> "ScoreResponse":
+        """Build ScoreResponse from a ScoredJob ORM object, assembling dim_* into dimensional_scores."""
+        response = cls.model_validate(obj)
+        if response.dimensional_scores is None:
+            response.dimensional_scores = _assemble_dimensional(obj)
+        return response
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -397,6 +397,26 @@ async def score_job(
     )
     red_flags_json = json.dumps(red_flags) if red_flags else None
 
+    # Dimensional sub-scores (may be None for older AI responses)
+    dim = score_data.dimensional_scores
+    dim_kwargs: dict = {}
+    if dim is not None:
+        dim_kwargs = {
+            "dim_technical_fit": dim.technical_fit,
+            "dim_seniority_alignment": dim.seniority_alignment,
+            "dim_compensation_fit": dim.compensation_fit,
+            "dim_location_fit": dim.location_fit,
+            "dim_career_trajectory": dim.career_trajectory,
+            "dim_company_fit": dim.company_fit,
+        }
+
+    # ATS keywords
+    ats_keywords_json = (
+        json.dumps([kw.model_dump() for kw in score_data.ats_keywords])
+        if score_data.ats_keywords
+        else None
+    )
+
     # Persist the score
     scored_job = ScoredJob(
         profile_id=profile_id,
@@ -412,8 +432,10 @@ async def score_job(
         prep_notes=score_data.prep_notes,
         score_breakdown=breakdown_json,
         red_flags=red_flags_json,
+        ats_keywords=ats_keywords_json,
         is_stale=False,
         weights_snapshot=json.dumps(profile_data["weights"]),
+        **dim_kwargs,
     )
     db.add(scored_job)
 


### PR DESCRIPTION
## Summary
- Adds 6 dimensional sub-scores (0-10 each) to scoring: technical_fit, seniority_alignment, compensation_fit, location_fit, career_trajectory, company_fit
- Adds ATS keyword extraction (10-15 keywords per JD with category and match status)
- Both piggyback on the existing scoring prompt — single AI call, marginal token cost
- Mock provider returns deterministic dimensional scores and keywords
- DB columns already exist from PR #83 migration

Closes #74, closes #75

## Test plan
- [x] 101 tests pass (scoring + letter grades + red flags)
- [x] TypeScript compiles clean
- [ ] Manual: score a job with `AI_PROVIDER=mock`, verify `dimensional_scores` and `ats_keywords` in API response
- [ ] Manual: verify old scores with null dim_* columns still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)