### PR TITLE
Improve Docker troubleshooting docs and add health checks

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,12 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8100:8100"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8100/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
     volumes:
       - career-data:/app/data
     environment:

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -85,23 +85,57 @@ Docker might have stopped. Check:
 
 This is a known macOS issue. Docker containers sometimes fail to recover after sleep/wake.
 
-**Quick fix (works most of the time):**
+**1. Check what's happening**
+
+Open Terminal, `cd` to your Kestrel folder, and run:
+
 ```
-cd ~/Downloads/kestrel-main
+docker ps
+```
+
+- If you see the Kestrel containers listed with status `Up`, they're running but may be unresponsive — skip to step 2.
+- If the list is empty or the containers show `Exited`, they stopped — skip to step 3.
+- If the command itself hangs or errors with "Cannot connect to the Docker daemon," Docker Desktop isn't running. Open it, wait for the whale icon in the menu bar to stop animating (about 30 seconds), then try again.
+
+For more detail on why a container is unhappy, look at its logs:
+
+```
+docker compose logs backend
+docker compose logs frontend
+```
+
+Recent errors appear at the bottom.
+
+**2. Nudge the containers (fastest)**
+
+If the containers are `Up` but the page won't load, restart them in place:
+
+```
+docker compose restart
+```
+
+Wait 30 seconds, then open http://localhost:8101.
+
+**3. Bring them back up**
+
+If the containers are stopped, or restart didn't help:
+
+```
 docker compose up -d
 ```
 
-**If that didn't work:**
+Wait 30 seconds, then open http://localhost:8101.
 
-1. Check if Docker Desktop is running (whale icon in menu bar). If not, open it and wait 30 seconds.
-2. Then run:
-   ```
-   docker compose down
-   docker compose up -d
-   ```
-3. Wait 30 seconds, then open http://localhost:8101
+**4. Full reset (last resort)**
 
-**Automatic monitoring (optional):**
+If nothing above works, tear down and recreate the containers. Your data is safe — it lives in a volume, not the container.
+
+```
+docker compose down
+docker compose up -d
+```
+
+**Automatic monitoring (optional)**
 
 Kestrel includes a watchdog script that checks and restarts containers for you:
 
@@ -113,6 +147,16 @@ To run it continuously in the background:
 ```
 bash scripts/docker-watchdog.sh --watch
 ```
+
+**When to file a bug**
+
+If none of the above gets Kestrel back, it's worth reporting. Open an issue at https://github.com/pleasedodisturb/kestrel/issues and include:
+
+- The output of `docker ps`
+- The last ~50 lines of `docker compose logs backend`
+- Your macOS version (Apple menu > About This Mac)
+- Your Docker Desktop version (Docker Desktop > About)
+- Roughly how long the laptop was asleep before this started
 
 Your data is never lost during sleep/wake — it's saved in a database file on your computer, not in Docker's memory.
 


### PR DESCRIPTION
## Summary
This PR enhances the Docker troubleshooting documentation with clearer, step-by-step guidance and adds health checks to the production Docker Compose configuration to improve container monitoring.

## Key Changes

- **Documentation improvements (docs/HELP.md)**
  - Restructured the macOS Docker recovery section into 4 numbered steps with clear decision points
  - Added diagnostic guidance: `docker ps` to check container status and `docker compose logs` to view errors
  - Clarified the progression from quick fixes (restart) to full reset (down/up)
  - Added a new "When to file a bug" section with specific information to include in issue reports
  - Improved formatting and clarity throughout

- **Health checks (docker-compose.prod.yml)**
  - Added health check configuration to the backend service
  - Checks `/health` endpoint every 10 seconds with 5-second timeout
  - 15-second startup grace period before health checks begin
  - Retries up to 3 times before marking container unhealthy
  - Enables Docker to automatically detect and report unresponsive containers

## Implementation Details
The health check uses a simple HTTP GET to the backend's health endpoint, allowing Docker to distinguish between stopped containers and unresponsive ones. This complements the improved troubleshooting docs by providing automated monitoring capabilities.

https://claude.ai/code/session_01PEkm38c9gbDQw8KZ7UFD8n