### PR TITLE
Add onboarding wizard, discovery nudge, and credits banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy to .env and customize: cp .env.example .env
 
 # -- AI Provider ----------------------------------------------------------
-# mock = fully offline, no API key needed (default)
+# demo (alias: mock) = fully offline Demo Mode, no API key needed (default)
 # openrouter = real AI via OpenRouter (requires API key below)
 AI_PROVIDER=mock
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .venv/
 .venv-career/
 env/
+uv.lock
 
 # IDE
 .vscode/

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -278,7 +278,7 @@ AIFeature
 Switch providers with a single environment variable:
 
 ```bash
-AI_PROVIDER=mock              # Offline, deterministic (default)
+AI_PROVIDER=mock              # Demo Mode — offline, deterministic (default; "demo" is an accepted alias)
 AI_PROVIDER=openrouter        # Claude, GPT via OpenRouter
 AI_PROVIDER=anthropic         # Direct Anthropic API
 AI_PROVIDER=openai            # Direct OpenAI API

--- a/frontend/src/__tests__/AIHealthDashboard.test.tsx
+++ b/frontend/src/__tests__/AIHealthDashboard.test.tsx
@@ -53,7 +53,7 @@ const MOCK_HEALTH_DATA: AIHealthResponse = {
   providers: [
     {
       name: "mock",
-      display_name: "Mock (Development)",
+      display_name: "Demo Mode",
       status: "reachable",
       is_default: true,
       error_message: null,
@@ -130,6 +130,7 @@ const MOCK_HEALTH_DATA: AIHealthResponse = {
 describe("AIHealthDashboard", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    sessionStorage.clear();
   });
 
   it("shows loading state while fetching", () => {
@@ -164,7 +165,7 @@ describe("AIHealthDashboard", () => {
     mockFetchAIHealth.mockResolvedValue(MOCK_HEALTH_DATA);
     renderDashboard();
     await waitFor(() => {
-      expect(screen.getByText("Mock (Development)")).toBeInTheDocument();
+      expect(screen.getByText("Demo Mode")).toBeInTheDocument();
       expect(screen.getByText("OpenRouter")).toBeInTheDocument();
       expect(screen.getByText("Anthropic")).toBeInTheDocument();
       expect(screen.getByText("OpenAI")).toBeInTheDocument();

--- a/frontend/src/__tests__/CreditsExhaustedBanner.test.tsx
+++ b/frontend/src/__tests__/CreditsExhaustedBanner.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for CreditsExhaustedBanner (#28).
+ *
+ * Covers:
+ * - Returns null when no flag is set
+ * - Renders when sessionStorage.credits_exhausted === "true"
+ * - Dismiss button persists credits_exhausted_dismissed flag
+ */
+
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { CreditsExhaustedBanner } from "@/components/CreditsExhaustedBanner";
+
+describe("CreditsExhaustedBanner", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("renders nothing when flag is unset", () => {
+    const { container } = render(<CreditsExhaustedBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders banner when credits_exhausted flag is set", () => {
+    sessionStorage.setItem("credits_exhausted", "true");
+    render(<CreditsExhaustedBanner />);
+    expect(screen.getByTestId("credits-exhausted-banner")).toBeInTheDocument();
+    expect(
+      screen.getByText(/AI scoring stopped.*openrouter\.ai/i),
+    ).toBeInTheDocument();
+  });
+
+  it("has a link to openrouter.ai", () => {
+    sessionStorage.setItem("credits_exhausted", "true");
+    render(<CreditsExhaustedBanner />);
+    const link = screen.getByTestId("credits-exhausted-link");
+    expect(link).toHaveAttribute("href", "https://openrouter.ai");
+  });
+
+  it("dismiss hides the banner and persists the dismissed flag", () => {
+    sessionStorage.setItem("credits_exhausted", "true");
+    const { queryByTestId, getByTestId } = render(<CreditsExhaustedBanner />);
+    act(() => {
+      getByTestId("credits-exhausted-dismiss").click();
+    });
+    expect(queryByTestId("credits-exhausted-banner")).not.toBeInTheDocument();
+    expect(sessionStorage.getItem("credits_exhausted_dismissed")).toBe("true");
+  });
+
+  it("stays hidden when already dismissed", () => {
+    sessionStorage.setItem("credits_exhausted", "true");
+    sessionStorage.setItem("credits_exhausted_dismissed", "true");
+    const { container } = render(<CreditsExhaustedBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/KanbanBoard.test.tsx
+++ b/frontend/src/__tests__/KanbanBoard.test.tsx
@@ -122,6 +122,11 @@ function makeApp(
 describe("KanbanBoard", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    // Onboarding wizard auto-appears on empty boards; pre-dismiss it for
+    // tests that aren't about the wizard so existing assertions stay clean.
+    localStorage.setItem("kestrel.wizard_dismissed", "true");
   });
 
   it("shows loading state while fetching", () => {
@@ -468,6 +473,111 @@ describe("KanbanBoard", () => {
       });
 
       expect(mockUpdateApplication).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Onboarding wizard (#20) ----
+  describe("onboarding wizard", () => {
+    beforeEach(() => {
+      mockFetchApplications.mockResolvedValue({
+        applications: [],
+        total: 0,
+      });
+      // Undo the global pre-dismiss so wizard can appear.
+      localStorage.removeItem("kestrel.wizard_dismissed");
+    });
+
+    it("shows wizard on first visit with empty board", async () => {
+      renderBoard();
+      expect(
+        await screen.findByTestId("onboarding-wizard"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show wizard when dismiss flag is set in localStorage", async () => {
+      localStorage.setItem("kestrel.wizard_dismissed", "true");
+      renderBoard();
+      await screen.findByTestId("kanban-empty");
+      expect(
+        screen.queryByTestId("onboarding-wizard"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("dismiss button persists flag and hides wizard", async () => {
+      const { getByTestId, queryByTestId } = renderBoard();
+      const dismiss = await screen.findByTestId("onboarding-dismiss");
+      act(() => {
+        dismiss.click();
+      });
+      await waitFor(() => {
+        expect(queryByTestId("onboarding-wizard")).not.toBeInTheDocument();
+      });
+      expect(localStorage.getItem("kestrel.wizard_dismissed")).toBe("true");
+      // Empty-state CTA is still present
+      expect(getByTestId("kanban-empty")).toBeInTheDocument();
+    });
+  });
+
+  // ---- Discovery nudge (#30) ----
+  describe("discovery nudge", () => {
+    function manyApps(n: number): Application[] {
+      return Array.from({ length: n }, (_, i) =>
+        makeApp({ id: i + 1, company: `Co${i}`, status: "applied" }),
+      );
+    }
+
+    it("appears when total >= 10 and user has never visited Discovery", async () => {
+      const apps = manyApps(10);
+      mockFetchApplications.mockResolvedValue({
+        applications: apps,
+        total: apps.length,
+      });
+      renderBoard();
+      expect(await screen.findByTestId("discovery-nudge")).toBeInTheDocument();
+    });
+
+    it("is hidden when user has visited Discovery (lastDiscoveryVisit set)", async () => {
+      localStorage.setItem("lastDiscoveryVisit", new Date().toISOString());
+      const apps = manyApps(10);
+      mockFetchApplications.mockResolvedValue({
+        applications: apps,
+        total: apps.length,
+      });
+      renderBoard();
+      await screen.findByTestId("kanban-board");
+      expect(screen.queryByTestId("discovery-nudge")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when total < 10", async () => {
+      const apps = manyApps(5);
+      mockFetchApplications.mockResolvedValue({
+        applications: apps,
+        total: apps.length,
+      });
+      renderBoard();
+      await screen.findByTestId("kanban-board");
+      expect(screen.queryByTestId("discovery-nudge")).not.toBeInTheDocument();
+    });
+
+    it("dismiss persists the flag and hides the nudge", async () => {
+      const apps = manyApps(12);
+      mockFetchApplications.mockResolvedValue({
+        applications: apps,
+        total: apps.length,
+      });
+      renderBoard();
+      const dismiss = await screen.findByTestId("discovery-nudge-dismiss");
+      act(() => {
+        dismiss.click();
+      });
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("discovery-nudge"),
+        ).not.toBeInTheDocument();
+      });
+      expect(
+        localStorage.getItem("kestrel.discovery_nudge_dismissed"),
+      ).toBe("true");
     });
   });
 });

--- a/frontend/src/api/aiHealth.ts
+++ b/frontend/src/api/aiHealth.ts
@@ -31,10 +31,22 @@ export interface AIHealthResponse {
 
 const API_BASE = "/api/ai";
 
+/**
+ * Record a credits-exhausted / rate-limited response so the UI banner
+ * (CreditsExhaustedBanner) can surface it. Called from any endpoint that
+ * could trip OpenRouter's 402/429.
+ */
+function markCreditsIssue(status: number): void {
+  if (status === 402 || status === 429) {
+    sessionStorage.setItem("credits_exhausted", "true");
+  }
+}
+
 /** Fetch health status for all AI providers. */
 export async function fetchAIHealth(): Promise<AIHealthResponse> {
   const res = await fetch(`${API_BASE}/health`);
   if (!res.ok) {
+    markCreditsIssue(res.status);
     throw new Error(`Failed to fetch AI health: ${res.status}`);
   }
   return res.json() as Promise<AIHealthResponse>;
@@ -46,6 +58,7 @@ export async function fetchProviderHealth(
 ): Promise<ProviderHealthStatus> {
   const res = await fetch(`${API_BASE}/health/check?provider=${encodeURIComponent(provider)}`);
   if (!res.ok) {
+    markCreditsIssue(res.status);
     throw new Error(`Failed to check provider health: ${res.status}`);
   }
   return res.json() as Promise<ProviderHealthStatus>;

--- a/frontend/src/api/scoring.ts
+++ b/frontend/src/api/scoring.ts
@@ -29,10 +29,10 @@ export async function batchScore(
     body: JSON.stringify(params),
   });
 
-  if (resp.status === 402) {
+  if (resp.status === 402 || resp.status === 429) {
     sessionStorage.setItem("credits_exhausted", "true");
     throw new Error(
-      "AI scoring credits exhausted. Add credits at openrouter.ai",
+      "AI scoring stopped — add credits at openrouter.ai",
     );
   }
 
@@ -48,6 +48,12 @@ export async function batchScore(
 
   if (data.credits_exhausted) {
     sessionStorage.setItem("credits_exhausted", "true");
+  } else {
+    // A fully-successful scoring run means credits are flowing again;
+    // clear the flag + any prior dismissal so the banner can resurface
+    // next time scoring breaks.
+    sessionStorage.removeItem("credits_exhausted");
+    sessionStorage.removeItem("credits_exhausted_dismissed");
   }
 
   return data;

--- a/frontend/src/components/CreditsExhaustedBanner.tsx
+++ b/frontend/src/components/CreditsExhaustedBanner.tsx
@@ -1,0 +1,77 @@
+/**
+ * CreditsExhaustedBanner — surfaces OpenRouter 402/429 failures to the user.
+ *
+ * The banner reads from sessionStorage flags set by the API clients
+ * (scoring.ts / aiHealth.ts). It's mounted on Kanban, Discovery, and the
+ * AI Health dashboard so the user sees it wherever scoring might fail.
+ *
+ * Issue: #28
+ */
+
+import { useEffect, useState } from "react";
+import { XCircle, X } from "lucide-react";
+
+const FLAG_KEY = "credits_exhausted";
+const DISMISS_KEY = "credits_exhausted_dismissed";
+
+export function CreditsExhaustedBanner() {
+  const [exhausted, setExhausted] = useState(
+    () => sessionStorage.getItem(FLAG_KEY) === "true",
+  );
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem(DISMISS_KEY) === "true",
+  );
+
+  // Re-read sessionStorage when the window regains focus — the flag may
+  // have been set by a scoring call in a different tab.
+  useEffect(() => {
+    const refresh = () => {
+      setExhausted(sessionStorage.getItem(FLAG_KEY) === "true");
+      setDismissed(sessionStorage.getItem(DISMISS_KEY) === "true");
+    };
+    window.addEventListener("focus", refresh);
+    return () => window.removeEventListener("focus", refresh);
+  }, []);
+
+  if (!exhausted || dismissed) return null;
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, "true");
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      data-testid="credits-exhausted-banner"
+      className="mb-4 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3"
+    >
+      <XCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-600" />
+      <div className="flex-1">
+        <p className="text-sm font-medium text-red-800">
+          AI scoring stopped — add credits at openrouter.ai
+        </p>
+        <p className="mt-0.5 text-xs text-red-700">
+          OpenRouter returned a credits/rate-limit error. Top up at{" "}
+          <a
+            data-testid="credits-exhausted-link"
+            href="https://openrouter.ai"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            openrouter.ai
+          </a>{" "}
+          to resume scoring.
+        </p>
+      </div>
+      <button
+        data-testid="credits-exhausted-dismiss"
+        onClick={handleDismiss}
+        aria-label="Dismiss credits exhausted banner"
+        className="flex-shrink-0 rounded p-1 text-red-700 hover:bg-red-100 hover:text-red-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/DiscoveryNudge.tsx
+++ b/frontend/src/components/DiscoveryNudge.tsx
@@ -1,0 +1,66 @@
+/**
+ * DiscoveryNudge — subtle prompt for users who manually track many jobs
+ * but have never visited the Discovery page.
+ *
+ * Detection logic lives in the parent (KanbanBoard). This component only
+ * renders the banner UI and owns the dismiss action.
+ *
+ * Dismissal persists via `localStorage.kestrel.discovery_nudge_dismissed`.
+ *
+ * Issue: #30
+ */
+
+import { Sparkles, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+export const NUDGE_DISMISSED_KEY = "kestrel.discovery_nudge_dismissed";
+
+export interface DiscoveryNudgeProps {
+  onDismiss: () => void;
+}
+
+export function DiscoveryNudge({ onDismiss }: Readonly<DiscoveryNudgeProps>) {
+  const navigate = useNavigate();
+
+  const handleDismiss = () => {
+    localStorage.setItem(NUDGE_DISMISSED_KEY, "true");
+    onDismiss();
+  };
+
+  const handleTry = () => {
+    handleDismiss();
+    navigate("/discovery");
+  };
+
+  return (
+    <div
+      data-testid="discovery-nudge"
+      className="mb-4 flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3"
+    >
+      <Sparkles className="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600" />
+      <div className="flex-1">
+        <p className="text-sm font-medium text-blue-900">
+          Did you know Kestrel can find jobs for you automatically?
+        </p>
+        <p className="mt-0.5 text-xs text-blue-700">
+          Discovery scans job boards and scores matches against your profile.
+        </p>
+        <button
+          data-testid="discovery-nudge-try"
+          onClick={handleTry}
+          className="mt-2 inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm hover:bg-blue-700"
+        >
+          Try Discovery
+        </button>
+      </div>
+      <button
+        data-testid="discovery-nudge-dismiss"
+        onClick={handleDismiss}
+        aria-label="Dismiss Discovery nudge"
+        className="flex-shrink-0 rounded p-1 text-blue-700 hover:bg-blue-100 hover:text-blue-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -25,6 +25,15 @@ import { KanbanCard } from "@/components/KanbanCard";
 import { CreateApplicationDialog } from "@/components/CreateApplicationDialog";
 import { PipelineFilters, type FilterState } from "@/components/PipelineFilters";
 import { OverdueBanner } from "@/components/OverdueBanner";
+import { CreditsExhaustedBanner } from "@/components/CreditsExhaustedBanner";
+import {
+  OnboardingWizard,
+  WIZARD_DISMISSED_KEY,
+} from "@/components/OnboardingWizard";
+import {
+  DiscoveryNudge,
+  NUDGE_DISMISSED_KEY,
+} from "@/components/DiscoveryNudge";
 import { useApplications, useUpdateApplication } from "@/hooks/useApplications";
 import { Briefcase, Plus } from "lucide-react";
 
@@ -50,6 +59,12 @@ export function KanbanBoard() {
   const updateMutation = useUpdateApplication();
   const [activeApp, setActiveApp] = useState<Application | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showWizard, setShowWizard] = useState(
+    () => localStorage.getItem(WIZARD_DISMISSED_KEY) !== "true",
+  );
+  const [nudgeDismissed, setNudgeDismissed] = useState(
+    () => localStorage.getItem(NUDGE_DISMISSED_KEY) === "true",
+  );
   // Track which column the dragged card is currently over (needed because
   // closestCorners may resolve over.id to a sibling card's sortable ID
   // instead of the column droppable ID).
@@ -185,6 +200,15 @@ export function KanbanBoard() {
 
   const totalCount = data?.total ?? 0;
 
+  // Discovery nudge: user has added 10+ applications but has never opened
+  // the Discovery page (no `lastDiscoveryVisit` key — set by Discovery.tsx
+  // on every visit). Once dismissed, never reappears.
+  const showDiscoveryNudge =
+    !nudgeDismissed &&
+    totalCount >= 10 &&
+    typeof window !== "undefined" &&
+    localStorage.getItem("lastDiscoveryVisit") === null;
+
   // Empty board CTA
   if (totalCount === 0 && !filters.status && !filters.search && !filters.sort) {
     return (
@@ -205,6 +229,12 @@ export function KanbanBoard() {
             Add Application
           </button>
         </div>
+        {showWizard && (
+          <OnboardingWizard
+            onClose={() => setShowWizard(false)}
+            onAddApplication={() => setShowCreateDialog(true)}
+          />
+        )}
         <CreateApplicationDialog
           open={showCreateDialog}
           onClose={() => setShowCreateDialog(false)}
@@ -236,8 +266,16 @@ export function KanbanBoard() {
         </div>
       </header>
 
+      {/* Credits exhausted banner (402/429 from OpenRouter) */}
+      <CreditsExhaustedBanner />
+
       {/* Overdue follow-ups banner */}
       <OverdueBanner />
+
+      {/* Discovery nudge for users who haven't tried Discovery yet */}
+      {showDiscoveryNudge && (
+        <DiscoveryNudge onDismiss={() => setNudgeDismissed(true)} />
+      )}
 
       {/* Filter and sort controls */}
       <div className="mb-4">

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,0 +1,146 @@
+/**
+ * OnboardingWizard — welcome overlay shown on the first visit to an empty
+ * Kanban board. Offers three CTAs: edit profile, add first app, try Discovery.
+ *
+ * Dismissal persists via `localStorage.kestrel.wizard_dismissed=true`.
+ * Once dismissed, the wizard never reappears.
+ *
+ * Issue: #20
+ */
+
+import { useNavigate } from "react-router-dom";
+import { User, Plus, Sparkles, X } from "lucide-react";
+
+export const WIZARD_DISMISSED_KEY = "kestrel.wizard_dismissed";
+
+export interface OnboardingWizardProps {
+  onClose: () => void;
+  onAddApplication: () => void;
+}
+
+export function OnboardingWizard({
+  onClose,
+  onAddApplication,
+}: Readonly<OnboardingWizardProps>) {
+  const navigate = useNavigate();
+
+  const handleDismiss = () => {
+    localStorage.setItem(WIZARD_DISMISSED_KEY, "true");
+    onClose();
+  };
+
+  const goProfile = () => {
+    handleDismiss();
+    navigate("/settings");
+  };
+
+  const goAdd = () => {
+    handleDismiss();
+    onAddApplication();
+  };
+
+  const goDiscovery = () => {
+    handleDismiss();
+    navigate("/discovery");
+  };
+
+  return (
+    <div
+      data-testid="onboarding-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleDismiss();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") handleDismiss();
+      }}
+      role="presentation"
+    >
+      <div
+        data-testid="onboarding-wizard"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h2
+              id="onboarding-title"
+              className="text-lg font-semibold text-gray-900"
+            >
+              Welcome to Kestrel
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">
+              Here are three ways to get started:
+            </p>
+          </div>
+          <button
+            data-testid="onboarding-close"
+            onClick={handleDismiss}
+            aria-label="Close onboarding"
+            className="flex-shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <button
+            data-testid="onboarding-edit-profile"
+            onClick={goProfile}
+            className="flex w-full items-center gap-3 rounded-md border border-gray-200 bg-white px-4 py-3 text-left text-sm shadow-sm hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-1"
+          >
+            <User className="h-5 w-5 flex-shrink-0 text-gray-500" />
+            <div className="flex-1">
+              <p className="font-medium text-gray-900">Set up your profile</p>
+              <p className="text-xs text-gray-500">
+                Tell Kestrel who you are so scoring can personalize to you.
+              </p>
+            </div>
+          </button>
+
+          <button
+            data-testid="onboarding-add-app"
+            onClick={goAdd}
+            className="flex w-full items-center gap-3 rounded-md border border-gray-200 bg-white px-4 py-3 text-left text-sm shadow-sm hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-1"
+          >
+            <Plus className="h-5 w-5 flex-shrink-0 text-gray-500" />
+            <div className="flex-1">
+              <p className="font-medium text-gray-900">
+                Add your first application
+              </p>
+              <p className="text-xs text-gray-500">
+                Paste a job link or enter details manually.
+              </p>
+            </div>
+          </button>
+
+          <button
+            data-testid="onboarding-try-discovery"
+            onClick={goDiscovery}
+            className="flex w-full items-center gap-3 rounded-md border border-gray-200 bg-white px-4 py-3 text-left text-sm shadow-sm hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-1"
+          >
+            <Sparkles className="h-5 w-5 flex-shrink-0 text-gray-500" />
+            <div className="flex-1">
+              <p className="font-medium text-gray-900">
+                Let Kestrel find jobs for you
+              </p>
+              <p className="text-xs text-gray-500">
+                Discovery automatically scans sources and scores matches.
+              </p>
+            </div>
+          </button>
+        </div>
+
+        <button
+          data-testid="onboarding-dismiss"
+          onClick={handleDismiss}
+          className="mt-5 w-full text-center text-xs text-gray-500 hover:text-gray-700"
+        >
+          Don&apos;t show this again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AIHealthDashboard.tsx
+++ b/frontend/src/pages/AIHealthDashboard.tsx
@@ -10,6 +10,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchAIHealth } from "@/api/aiHealth";
 import type { ProviderHealthStatus } from "@/api/aiHealth";
+import { CreditsExhaustedBanner } from "@/components/CreditsExhaustedBanner";
 import {
   RefreshCw,
   CheckCircle2,
@@ -69,6 +70,8 @@ export function AIHealthDashboard() {
 
   return (
     <section data-testid="ai-health-dashboard" className="space-y-6">
+      <CreditsExhaustedBanner />
+
       {/* Header */}
       <header className="flex items-center justify-between">
         <div>

--- a/frontend/src/pages/Discovery.tsx
+++ b/frontend/src/pages/Discovery.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/api/types";
 import { GradeBadge } from "@/components/GradeBadge";
 import { RedFlagBadge } from "@/components/RedFlagBadge";
+import { CreditsExhaustedBanner } from "@/components/CreditsExhaustedBanner";
 import {
   Search,
   Loader2,
@@ -508,9 +509,6 @@ export function Discovery() {
   const [page, setPage] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
-  const [creditsExhausted, setCreditsExhausted] = useState(
-    () => sessionStorage.getItem("credits_exhausted") === "true",
-  );
   const [profileIncomplete, setProfileIncomplete] = useState(
     () => sessionStorage.getItem("profile_incomplete") !== null,
   );
@@ -755,42 +753,8 @@ export function Discovery() {
         />
       )}
 
-      {/* Credits exhausted banner */}
-      {creditsExhausted && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
-          <div className="flex items-start justify-between">
-            <div className="flex gap-3">
-              <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
-              <div>
-                <h3 className="text-sm font-semibold text-amber-800">
-                  AI Scoring Stopped
-                </h3>
-                <p className="mt-1 text-sm text-amber-700">
-                  OpenRouter credits have been exhausted. Some jobs may not have
-                  scores.{" "}
-                  <a
-                    href="https://openrouter.ai"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-medium underline hover:text-amber-900"
-                  >
-                    Add credits at openrouter.ai
-                  </a>
-                </p>
-              </div>
-            </div>
-            <button
-              onClick={() => {
-                setCreditsExhausted(false);
-                sessionStorage.removeItem("credits_exhausted");
-              }}
-              className="ml-4 text-amber-400 hover:text-amber-600"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      )}
+      {/* Credits exhausted banner (shared with Kanban / AI Health) */}
+      <CreditsExhaustedBanner />
 
       {/* Profile incomplete banner */}
       {profileIncomplete && (

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -6,8 +6,9 @@ from career_os.ai.base import AIProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.openrouter_provider import OpenRouterProvider
 
-# Registry of supported provider names → constructors
-_SUPPORTED_PROVIDERS = {"mock", "openrouter"}
+# Registry of supported provider names → constructors.
+# "demo" is a user-facing alias for "mock" — both resolve to MockProvider.
+_SUPPORTED_PROVIDERS = {"mock", "demo", "openrouter"}
 
 
 class UnsupportedProviderError(Exception):
@@ -19,7 +20,8 @@ class UnsupportedProviderError(Exception):
         super().__init__(
             f"Unsupported AI provider: '{provider_name}'. "
             f"Supported providers: {supported}. "
-            f"Set AI_PROVIDER env var to one of: {supported}"
+            f"Set AI_PROVIDER env var to one of: {supported} "
+            f"('demo' is an alias for 'mock')"
         )
 
 
@@ -31,13 +33,16 @@ def get_ai_provider(provider_name: str | None = None) -> AIProvider:
     2. AI_PROVIDER env var
     3. Default: "mock"
 
+    Both "mock" and "demo" resolve to MockProvider — "demo" is a friendlier
+    user-facing alias so non-technical users don't think "mock" means broken.
+
     Raises:
         UnsupportedProviderError: If the provider name is not recognized.
     """
     name = provider_name or os.getenv("AI_PROVIDER", "mock")
     name = name.strip().lower()
 
-    if name == "mock":
+    if name in ("mock", "demo"):
         return MockProvider()
 
     if name == "openrouter":

--- a/src/career_os/services/ai_health.py
+++ b/src/career_os/services/ai_health.py
@@ -31,7 +31,7 @@ RUNTIME_SUPPORTED_PROVIDERS = {"mock", "openrouter"}
 
 # Provider display names
 _PROVIDER_DISPLAY_NAMES = {
-    "mock": "Mock (Development)",
+    "mock": "Demo Mode",
     "openrouter": "OpenRouter",
 }
 
@@ -50,7 +50,7 @@ async def _check_mock() -> ProviderHealthStatus:
     """Mock provider is always reachable."""
     return ProviderHealthStatus(
         name="mock",
-        display_name="Mock (Development)",
+        display_name="Demo Mode",
         status="reachable",
         is_default=False,
         error_message=None,
@@ -218,7 +218,7 @@ async def check_all_providers(db: Session | None = None) -> AIHealthResponse:
     except Exception as exc:
         status = ProviderHealthStatus(
             name="mock",
-            display_name="Mock (Development)",
+            display_name="Demo Mode",
             status="error",
             error_message=str(exc),
         )

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -331,6 +331,22 @@ class TestProviderFactory:
         provider = get_ai_provider("  mock  ")
         assert isinstance(provider, MockProvider)
 
+    def test_demo_alias_returns_mock(self) -> None:
+        """AI_PROVIDER=demo returns MockProvider (alias for mock)."""
+        provider = get_ai_provider("demo")
+        assert isinstance(provider, MockProvider)
+
+    def test_demo_env_var(self) -> None:
+        """AI_PROVIDER=demo env var resolves to MockProvider."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "demo"}):
+            provider = get_ai_provider()
+            assert isinstance(provider, MockProvider)
+
+    def test_demo_case_insensitive(self) -> None:
+        """Demo alias is case-insensitive and whitespace-trimmed."""
+        assert isinstance(get_ai_provider("Demo"), MockProvider)
+        assert isinstance(get_ai_provider("  DEMO  "), MockProvider)
+
     def test_openrouter_without_key_raises(self) -> None:
         """OpenRouter without API key raises ValueError."""
         with (


### PR DESCRIPTION
## Summary
This PR introduces three new UI components to improve user onboarding and provide contextual feedback:

1. **OnboardingWizard** — A welcome overlay shown on first visit to an empty Kanban board, offering three CTAs: edit profile, add first app, or try Discovery. Dismissal persists via localStorage.

2. **DiscoveryNudge** — A subtle banner that appears when users have manually tracked 10+ applications but have never visited the Discovery page, encouraging them to try automated job discovery.

3. **CreditsExhaustedBanner** — A shared error banner that surfaces OpenRouter 402/429 (credits exhausted / rate-limited) failures across Kanban, Discovery, and the AI Health dashboard. Reads from sessionStorage flags set by API clients.

## Key Changes

- **New Components:**
  - `OnboardingWizard.tsx` — Modal dialog with three action buttons and persistent dismissal
  - `DiscoveryNudge.tsx` — Inline banner with "Try Discovery" CTA
  - `CreditsExhaustedBanner.tsx` — Reusable error banner with link to OpenRouter

- **KanbanBoard Integration:**
  - Shows OnboardingWizard when board is empty and wizard hasn't been dismissed
  - Shows DiscoveryNudge when total applications ≥ 10 and user hasn't visited Discovery
  - Mounts CreditsExhaustedBanner for consistent error visibility
  - Pre-dismisses wizard in test setup to keep existing assertions clean

- **Discovery Page Refactor:**
  - Replaces inline credits-exhausted banner with shared `CreditsExhaustedBanner` component
  - Sets `lastDiscoveryVisit` localStorage key on every visit (used by nudge detection)

- **AI Health & Scoring:**
  - `aiHealth.ts` now calls `markCreditsIssue()` on 402/429 responses
  - `scoring.ts` treats both 402 and 429 as credits-exhausted conditions
  - Successful scoring runs clear the exhausted flag so banner can resurface on next failure

- **AI Provider Naming:**
  - Added "demo" as user-facing alias for "mock" provider
  - Updated display name from "Mock (Development)" to "Demo Mode"
  - Updated docs and error messages to reflect the alias

- **Test Coverage:**
  - Added comprehensive tests for OnboardingWizard (visibility, dismissal, persistence)
  - Added tests for DiscoveryNudge (threshold detection, dismissal)
  - Added tests for CreditsExhaustedBanner (rendering, dismissal, link validation)
  - Updated AIHealthDashboard tests to reflect "Demo Mode" naming

## Implementation Details

- **Dismissal Persistence:** OnboardingWizard and DiscoveryNudge use localStorage keys; CreditsExhaustedBanner uses sessionStorage (cleared on tab close)
- **Focus Management:** OnboardingWizard supports Escape key and backdrop click for dismissal
- **Accessibility:** All components include proper ARIA labels and semantic HTML
- **Window Focus Handling:** CreditsExhaustedBanner re-reads sessionStorage on window focus to catch flags set by other tabs

https://claude.ai/code/session_015LWYcYnKr3W6y8VBLMnSE3