### PR TITLE
Add Perplexity Computer to job search tool comparison

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -6,7 +6,7 @@ The job search tool space splits into two camps: polished SaaS trackers that hel
 
 ## The Landscape
 
-Job search tools fall into four categories:
+Job search tools fall into five categories:
 
 **Commercial trackers** (Huntr, Teal) - Polished SaaS with Chrome extensions, kanban boards, and AI resume builders. Good UX, cloud-only, $25-40/month for full features. Manual job discovery - you clip jobs yourself.
 
@@ -14,50 +14,54 @@ Job search tools fall into four categories:
 
 **Open source tools** (Career-Ops, JobSync, Kestrel) - Self-hosted, data stays with you, free or near-free. Each takes a different approach: Career-Ops is a prompt framework, JobSync is a tracker with AI review, Kestrel adds automated discovery and scoring.
 
-**AI assistants** (ChatGPT, Claude, Perplexity) - Can do any individual task well (evaluate a JD, draft a cover letter) but cannot maintain state across sessions, run daily scans, or manage a pipeline over weeks.
+**AI assistants** (ChatGPT, Claude, vanilla Perplexity) - Can do any individual task well (evaluate a JD, draft a cover letter) but cannot maintain state across sessions, run daily scans, or manage a pipeline over weeks.
+
+**Agentic AI** (Perplexity Computer) - The new middle ground: a cloud-hosted multi-model agent with persistent memory, scheduled tasks, and a companion browser (Comet) that can auto-fill applications. Covers most of Kestrel's workflow at a premium price ($200/month), but closed, US-centric, and has no structured scoring rubric or pipeline/kanban model.
 
 ## Comparison Table
 
-| Dimension | Huntr | Teal | Simplify | Career-Ops | JobSync | Kestrel | AI Assistants |
-|-----------|-------|------|----------|------------|---------|---------|---------------|
-| **Cost** | $40/mo | $29/mo | $25-39/mo | Free (needs Claude sub ~$20/mo) | Free | Free (AI: $0-3/mo) | $0-20/mo |
-| **Self-hosted** | No | No | No | Yes (terminal) | Yes (Docker) | Yes (Docker) | No |
-| **Data ownership** | Vendor-held | Vendor-held | Vendor-held | Local files | Local SQLite | Local SQLite | Session-only |
-| **Web UI** | Yes (polished) | Yes (polished) | Minimal | No (TUI only) | Yes (Shadcn) | Yes (React) | Chat interface |
-| **Mobile app** | Yes | No | No | No | No | No | Yes (chat) |
-| **Chrome extension** | Yes (1000+ ATS) | Yes | Yes (1000+ ATS) | No | No | No | No |
-| **Job discovery** | Manual clip | Manual clip | Curated board | Company pages only | Basic | Multi-board automated | Ad-hoc search |
-| **Daily auto-scan** | No | No | No | No | No | Yes (GitHub Actions) | No |
-| **AI scoring** | Resume-vs-JD | Job match score | No | A-F evaluation (6 blocks) | Job matching | Custom profile rubric | Conversational |
-| **Custom scoring rubric** | No | No | No | Yes (prompt-based) | No | Yes (profile YAML) | Sort of |
-| **Cover letter gen** | No | No | No | Yes | No | Yes | Yes (one-off) |
-| **CV tailoring** | AI resume builder | AI resume builder | AI resume (premium) | Yes (excellent) | Resume review | Yes | Yes (one-off) |
-| **Auto-fill/apply** | Yes (killer feature) | No | Yes (killer feature) | No | No | Experimental (Playwright) | No |
-| **Interview prep** | No | No | No | Yes | No | Yes | Yes (one-off) |
-| **EU job boards** | No | No | No (US-focused) | No | No | Yes (Arbeitsagentur) | No |
-| **REST API** | No | No | No | No | Yes | Yes | API exists but different |
-| **Setup effort** | 2 min | 2 min | 2 min | 15 min | 10 min (Docker) | 10 min (Docker) | 0 min |
-| **Community** | Large (commercial) | Large (commercial) | Large (commercial) | 23k GitHub stars | 499 stars | 0 stars (new) | Massive |
+| Dimension | Huntr | Teal | Simplify | Career-Ops | JobSync | Kestrel | Perplexity Computer | AI Assistants |
+|-----------|-------|------|----------|------------|---------|---------|---------------------|---------------|
+| **Cost** | $40/mo | $29/mo | $25-39/mo | Free (needs Claude sub ~$20/mo) | Free | Free (AI: $0-3/mo) | $200/mo (Max) | $0-20/mo |
+| **Self-hosted** | No | No | No | Yes (terminal) | Yes (Docker) | Yes (Docker) | No (cloud sandbox) | No |
+| **Data ownership** | Vendor-held | Vendor-held | Vendor-held | Local files | Local SQLite | Local SQLite | Vendor-held (no training) | Session-only |
+| **Web UI** | Yes (polished) | Yes (polished) | Minimal | No (TUI only) | Yes (Shadcn) | Yes (React) | Yes (Max app) | Chat interface |
+| **Mobile app** | Yes | No | No | No | No | No | Yes | Yes (chat) |
+| **Chrome extension** | Yes (1000+ ATS) | Yes | Yes (1000+ ATS) | No | No | No | Comet browser (integrated) | No |
+| **Job discovery** | Manual clip | Manual clip | Curated board | Company pages only | Basic | Multi-board automated | Ad-hoc (web + LinkedIn via Comet) | Ad-hoc search |
+| **Daily auto-scan** | No | No | No | No | No | Yes (GitHub Actions) | Yes (scheduled tasks) | No |
+| **AI scoring** | Resume-vs-JD | Job match score | No | A-F evaluation (6 blocks) | Job matching | Custom profile rubric | Conversational | Conversational |
+| **Custom scoring rubric** | No | No | No | Yes (prompt-based) | No | Yes (profile YAML) | No (prompt-based) | Sort of |
+| **Cover letter gen** | No | No | No | Yes | No | Yes | Yes | Yes (one-off) |
+| **CV tailoring** | AI resume builder | AI resume builder | AI resume (premium) | Yes (excellent) | Resume review | Yes | Yes | Yes (one-off) |
+| **Auto-fill/apply** | Yes (killer feature) | No | Yes (killer feature) | No | No | Experimental (Playwright) | Yes (Comet, killer feature) | No |
+| **Interview prep** | No | No | No | Yes | No | Yes | Yes | Yes (one-off) |
+| **EU job boards** | No | No | No (US-focused) | No | No | Yes (Arbeitsagentur) | No | No |
+| **REST API** | No | No | No | No | Yes | Yes | No (closed platform) | API exists but different |
+| **Setup effort** | 2 min | 2 min | 2 min | 15 min | 10 min (Docker) | 10 min (Docker) | 0 min | 0 min |
+| **Community** | Large (commercial) | Large (commercial) | Large (commercial) | 23k GitHub stars | 499 stars | 0 stars (new) | Massive (Perplexity) | Massive |
 
 ## "Can't ChatGPT/Perplexity Do This?"
 
 Honest answer: for any single task, yes. AI assistants are excellent at one-off work. Here is where they fall short for systematic job searching:
 
-| Capability | AI Assistant | Dedicated Tool (any) |
-|-----------|-------------|---------------------|
-| Evaluate one JD against your resume | Great | Great |
-| Draft a cover letter | Great | Good to great |
-| Search for jobs right now | Good (web search) | Good (board APIs) |
-| Remember your pipeline state tomorrow | No | Yes |
-| Run a daily scan while you sleep | No | Some (Kestrel yes) |
-| Track 50 applications across stages | No (resets each session) | Yes |
-| Score 20 new postings against your profile automatically | No | Some (Kestrel yes) |
-| Auto-fill application forms | No | Some (Huntr, Simplify) |
-| Export your history for analysis | No persistent history | Yes |
+| Capability | AI Chatbot (ChatGPT/Claude/vanilla Perplexity) | Perplexity Computer | Dedicated Tool (any) |
+|-----------|-----------------------------------------------|---------------------|---------------------|
+| Evaluate one JD against your resume | Great | Great | Great |
+| Draft a cover letter | Great | Great | Good to great |
+| Search for jobs right now | Good (web search) | Good (Comet + LinkedIn) | Good (board APIs) |
+| Remember your pipeline state tomorrow | No | Yes (persistent memory) | Yes |
+| Run a daily scan while you sleep | No | Yes (scheduled tasks) | Some (Kestrel yes) |
+| Track 50 applications across stages | No (resets each session) | Partial (memory, no kanban) | Yes |
+| Score 20 new postings against your profile automatically | No | Partial (no structured rubric) | Some (Kestrel yes) |
+| Auto-fill application forms | No | Yes (Comet browser) | Some (Huntr, Simplify) |
+| Export your history for analysis | No persistent history | No (closed sandbox) | Yes |
+| EU job board coverage (Arbeitsagentur) | No | No | Some (Kestrel yes) |
+| Monthly cost | $0-20 | $200 | $0-40 |
 
-The gap is not intelligence - it is persistence and automation. AI assistants are stateless. Job searching is a weeks-long stateful process.
+The gap is not intelligence - it is persistence, domain-specific rubrics, data ownership, and price. Vanilla AI chatbots are stateless. Perplexity Computer fixes persistence and even automates recurring tasks, but it runs in a vendor sandbox at $200/month, has no structured rubric scoring, no pipeline/kanban model, and no EU board coverage. Job searching is a weeks-long stateful process that rewards a tool shaped for it.
 
-If you are applying to fewer than 10 jobs total, ChatGPT is probably enough. If you are running a sustained search across dozens of positions over weeks, you need something that remembers and automates.
+If you are applying to fewer than 10 jobs total, ChatGPT is probably enough. If you are running a sustained search across dozens of positions over weeks and want a SaaS agent with zero setup, Perplexity Computer will cover most of the workflow at a premium. If you want ownership of your data, rubric-driven scoring, EU board support, or near-zero cost, a dedicated tool is the better fit.
 
 <details>
 <summary><strong>Want to try the Kestrel approach with just a chatbot?</strong></summary>
@@ -228,3 +232,4 @@ Not necessarily better - structurally different in ways that matter to some user
 | Applying to fewer than 10 jobs | **ChatGPT/Claude** | A dedicated tool is overkill - just use AI directly |
 | Want a proven tool with community support | **Huntr**, **Teal**, or **Career-Ops** | Established, documented, battle-tested |
 | Want maximum automation end-to-end | **Kestrel** (with caveats) | Discovery + scoring + tracking + apply in one pipeline, but auto-apply is experimental |
+| Willing to pay premium for an all-in-one cloud agent | **Perplexity Computer** ($200/mo) | Persistent memory, scheduled tasks, and Comet browser auto-fill in one product - closest SaaS analog to Kestrel's pipeline, minus the rubric, EU boards, and data ownership |

--- a/docs/market-research-apr2026.md
+++ b/docs/market-research-apr2026.md
@@ -36,6 +36,9 @@ Tools that automate job searching, scoring, and applying.
 | **Careery** | One-time purchase (varies) | Up to 250 apps/day within 1-3 hours of posting, smart matching, no subscription | Closed SaaS |
 | **JobHire.ai** | $19/wk (100 apps) / $49/mo | Auto-apply with AI, but **BBB rating of F**, billing disputes | Closed SaaS |
 | **JobCopilot** | ~$20-30/mo | Scans 500K+ company career pages directly, auto-apply | Closed SaaS |
+| **Perplexity Computer** (+ Comet) | $200/mo (Max) / $325/seat/mo (Enterprise) | Cloud agent orchestrating 19 models (Opus 4.6 core, Gemini, ChatGPT 5.2, etc.); persistent sandbox memory across sessions; scheduled/recurring tasks with condition triggers; Comet browser auto-fills LinkedIn and ATS forms from resume + LinkedIn profile; template tasks for job search (e.g. `/gen/computer/accounting-jobs`); "no training on your data" guarantee | Closed SaaS (launched Feb 25, 2026) |
+
+**Note on Perplexity Computer:** Unlike the other copilots in this section, Perplexity Computer is a general-purpose agentic platform that happens to cover the job-search workflow as one of many templates. It's the first mainstream tool to combine persistent memory, scheduled tasks, and browser-level auto-fill in one product — plugging the "AI assistants are stateless" gap that CareerOS's positioning has historically exploited against ChatGPT/Claude/vanilla Perplexity. At $200/month it's ~10× the price of dedicated copilots and ~50-200× CareerOS, it has no structured scoring rubric, no pipeline/kanban model, no EU board coverage (Arbeitsagentur, StepStone), and no data export — so it covers the workflow broadly but shallowly compared to a purpose-built tool. It should be treated as a serious competitor on the "premium SaaS agent" axis, distinct from both stateless chatbots and dedicated job-search tools.
 
 ### 1.4 Human-Assisted Services
 
@@ -198,7 +201,7 @@ CareerOS is not another auto-apply bot. It's a **career operations platform** - 
 
 | Capability | CareerOS | Closest Competitor |
 |-----------|----------|-------------------|
-| Multi-board scraping (python-jobspy) + AI scoring + SQLite tracking + browser auto-apply in one pipeline | Yes | ApplyPilot (partial) |
+| Multi-board scraping (python-jobspy) + AI scoring + SQLite tracking + browser auto-apply in one pipeline | Yes | ApplyPilot (partial); Perplexity Computer + Comet (cloud, $200/mo, no rubric/EU/export) |
 | Configurable AI scoring with explicit criteria (target-roles.md) | Yes | None - all are black boxes |
 | YAML-based CV with Git-tracked versions (RenderCV) | Yes | None |
 | Per-application tailored CVs (12 variants) | Yes | Massive (closed) |

--- a/docs/validation/perplexity-parallel-test.md
+++ b/docs/validation/perplexity-parallel-test.md
@@ -1,0 +1,178 @@
+# Perplexity Pro + Comet vs Kestrel — Parallel Test Log
+
+Structured template for running an empirical side-by-side between Kestrel and Perplexity Pro ($20/mo) + Comet browser. Fill this in while running the tests; publish the completed result as a blog post or gist and link it from `docs/COMPARISON.md` as empirical backing for the Perplexity Computer row.
+
+> **Why Pro, not Max?** Perplexity Computer lives on the $200/mo Max tier. Pro ($20/mo) gives you Comet and most of what a job seeker would actually touch day-to-day. The Computer-only capabilities (scheduled tasks, persistent sandbox, 19-model orchestration) are not testable on this plan — rely on primary sources for those claims in the PR.
+
+---
+
+## Metadata
+
+- **Tester:** <!-- your name / handle -->
+- **Date:** <!-- YYYY-MM-DD -->
+- **Kestrel version / commit:** <!-- git rev-parse HEAD -->
+- **Perplexity plan:** Pro ($20/mo)
+- **Comet version:** <!-- from About menu -->
+- **Browser:** <!-- Comet is the browser; note OS -->
+
+## Setup checklist
+
+Before starting, prepare a clean testing environment:
+
+- [ ] **Throwaway LinkedIn profile** created (burner email, fake-but-plausible work history)
+- [ ] **Throwaway resume PDF** saved to disk (matches the burner profile)
+- [ ] **Comet installed** and logged into the burner LinkedIn
+- [ ] **Kestrel running locally** (`docker compose up -d`, web UI reachable)
+- [ ] **Kestrel profile** configured with the same target role/skills as the burner resume, so scoring is comparable
+- [ ] **5 real job postings picked** (see table below) — mix of ATS types
+- [ ] **Screen recording or screenshot tool** ready (optional but recommended for the writeup)
+
+> **Safety note:** Comet auto-fill runs in a real browser session. Never point it at your real LinkedIn or your actual job applications while testing — you do not want a misfire submitting a half-filled application with your real name on it.
+
+## Test subjects
+
+Pick 5 real postings covering the ATS variety Kestrel claims to handle:
+
+| # | Company | Role | ATS type | URL | Why chosen |
+|---|---------|------|----------|-----|------------|
+| 1 | | | Greenhouse | | |
+| 2 | | | Lever | | |
+| 3 | | | Workday | | |
+| 4 | | | LinkedIn Easy Apply | | |
+| 5 | | | Direct company page | | |
+
+---
+
+## Per-job test protocol
+
+Run this exact script against **each** of the 5 jobs, logging results in both systems. Copy the result block below for each job.
+
+### Steps (run in order)
+
+1. **Discovery** — would the tool have surfaced this job without me specifying the URL?
+   - Kestrel: run `kestrel discovery run` with a query matching the role/location; check if the job appears
+   - Perplexity: ask Comet `"Find [role] jobs at [company]"` or `"Find recent [role] postings in [location]"`; check if it appears
+2. **Scoring** — feed the JD + resume/profile to each
+   - Kestrel: import the job and let it score against your profile
+   - Perplexity: paste JD + resume, ask `"Score this job against my resume 0-10 and explain the gaps"`
+3. **Cover letter** — generate one in each
+   - Kestrel: `kestrel apply cover-letter <id>`
+   - Perplexity: `"Draft a cover letter for this role using my resume"`
+4. **Auto-fill** — navigate to the application form, let each system fill it up to (NOT including) submit
+   - Kestrel: `kestrel apply <id>` (dry run / Playwright)
+   - Comet: navigate to the form in Comet, invoke the assistant, ask it to apply
+5. **Interview prep** — ask each for a company research dossier and likely interview questions
+   - Kestrel: `kestrel prep <id>`
+   - Perplexity: `"Research [company], predict interview format for a [role], and give me 10 likely questions"`
+
+### Result block (copy for each job)
+
+```
+## Job N: <Company> — <Role> (<ATS>)
+
+URL: <paste>
+Date tested: <YYYY-MM-DD>
+
+### 1. Discovery
+- Kestrel: [found / missed / partial] — <notes>
+- Perplexity Comet: [found / missed / partial] — <notes>
+- Winner: [Kestrel / Perplexity / tie]
+
+### 2. Scoring
+- Kestrel: <score>/10 — <one-sentence rationale from the tool>
+- Perplexity: <score>/10 — <one-sentence rationale from the tool>
+- Was the Kestrel rubric breakdown more useful than Perplexity's prose? [yes / no / about the same]
+- Winner: [Kestrel / Perplexity / tie]
+
+### 3. Cover letter
+- Kestrel output quality (1-5): <n>
+- Perplexity output quality (1-5): <n>
+- Which felt more tailored to the specific JD? [Kestrel / Perplexity / tie]
+- Which required less post-editing? [Kestrel / Perplexity / tie]
+- Winner: [Kestrel / Perplexity / tie]
+
+### 4. Auto-fill
+- Kestrel (Playwright): [completed / partial / failed] — fields filled: <count> / <total>, errors: <list>
+- Perplexity Comet: [completed / partial / failed] — fields filled: <count> / <total>, errors: <list>
+- Did either fumble multi-page forms, CAPTCHAs, or custom questions? <notes>
+- Winner: [Kestrel / Perplexity / tie]
+
+### 5. Interview prep
+- Kestrel output depth (1-5): <n>
+- Perplexity output depth (1-5): <n>
+- Which had more specific, verifiable company facts? [Kestrel / Perplexity / tie]
+- Which had more role-appropriate mock questions? [Kestrel / Perplexity / tie]
+- Winner: [Kestrel / Perplexity / tie]
+
+### Overall for this job
+- Kestrel wins: <count> / 5
+- Perplexity wins: <count> / 5
+- Ties: <count> / 5
+- Surprising observations: <free text>
+```
+
+---
+
+## Summary tally
+
+Fill this in after all 5 jobs are tested.
+
+| Dimension | Kestrel wins | Perplexity wins | Ties | Notes |
+|-----------|--------------|-----------------|------|-------|
+| Discovery | | | | |
+| Scoring | | | | |
+| Cover letter | | | | |
+| Auto-fill | | | | |
+| Interview prep | | | | |
+| **Total** | | | | |
+
+## Gaps not covered by this test
+
+The following Kestrel / Perplexity Computer claims **cannot** be verified on the Pro plan — flag them as "documented but not empirically tested" in the writeup:
+
+- [ ] Persistent memory across sessions (Computer-only)
+- [ ] Scheduled / recurring daily scans (Computer-only)
+- [ ] Multi-model orchestration (Computer-only)
+- [ ] Pipeline analytics across 50+ applications (Computer lacks; Kestrel has — but hard to test in one session)
+- [ ] EU job board coverage (Kestrel: Arbeitsagentur; Perplexity: no — Pro can confirm absence, not presence)
+- [ ] Data export / sovereignty (Kestrel: SQLite; Perplexity: closed sandbox — architectural, not behavioral)
+
+For these, the PR body already cites Perplexity's help center, the Semafor launch coverage, and Sentisight pricing — that's the defensible documentation trail.
+
+## Gotchas observed during testing
+
+<!-- Free-text section — log anything weird, fragile, or surprising. This is where the real value of the test lives. Examples: -->
+
+- <!-- "Comet asked for my resume every time — no persistent profile in Pro tier" -->
+- <!-- "Kestrel's Playwright auto-apply got stuck on a Cloudflare challenge on job 3" -->
+- <!-- "Perplexity scored 2 points higher than Kestrel on job 2, but couldn't explain why" -->
+- <!-- "Comet's LinkedIn discovery returned 3 roles from companies that don't actually have that opening listed publicly" -->
+
+## Writeup seed
+
+Use this to draft the public post / gist once the test is complete. Link it from `docs/COMPARISON.md` as empirical backing.
+
+### TL;DR
+<!-- One paragraph: who won per category, overall verdict, caveats -->
+
+### Methodology
+<!-- Reference this doc; note date, plan, sample size -->
+
+### Results per dimension
+<!-- For each of discovery / scoring / cover letter / auto-fill / interview prep: 1 paragraph + the relevant tally row -->
+
+### Where Perplexity Pro + Comet was better than expected
+<!-- Honest praise — don't slant this -->
+
+### Where Kestrel was better than expected
+<!-- Same — honest -->
+
+### What $200/mo Max (Computer) would additionally unlock
+<!-- Cite primary sources, don't speculate -->
+
+### Recommendation
+<!-- Who should use what -->
+
+---
+
+*Template version 1. Revise as needed. When a completed run is published, add a `Runs/` subdirectory under `docs/validation/` and archive completed test logs there so we build up empirical history across tool versions.*


### PR DESCRIPTION
## Summary

Adds **Perplexity Computer** (launched Feb 25, 2026) to our competitive docs. It's the first mainstream tool to close the "AI assistants are stateless" gap that our positioning has historically exploited against ChatGPT/Claude/vanilla Perplexity — it has persistent memory, scheduled tasks, and (via the Comet browser) real ATS form auto-fill. At $200/mo, vendor-held, no rubric, and no EU board support, it's still structurally distinct from Kestrel, but it's a real competitor and deserves its own row in the comparison tables.

Triggered by a user question pointing at `https://www.perplexity.ai/gen/computer/accounting-jobs` — a Perplexity Computer task template (the "accounting-jobs" slug is a pre-seeded example task, not a bookkeeping feature).

## Deep research: does Perplexity Computer cover Kestrel's use cases?

| Kestrel use case | Perplexity Computer coverage | Notes |
|---|---|---|
| Multi-board automated discovery | **Partial** — ad-hoc web + LinkedIn via Comet | No persistent multi-board scan spec; no Arbeitsagentur / EU board support |
| Daily / scheduled scans | **Yes** — scheduled jobs, recurring tasks, condition triggers | Cloud-run, not GitHub Actions / local cron |
| AI scoring against a custom profile | **Partial** — can reason over a JD + profile | No structured rubric artifact; no batch ranking table |
| Pipeline tracking (50+ apps, kanban stages) | **Partial** — sandbox memory persists state, but no kanban/stage model or analytics | Would be described in natural language only |
| Auto-fill / auto-apply | **Yes (strong)** — Comet browser pulls from resume + LinkedIn, fills ATS forms | The one area where Comet clearly beats Kestrel's experimental Playwright auto-apply |
| Interview prep | **Yes** — general agent strength, plus web research sub-agents | |
| Cover letter / CV tailoring | **Yes** | One-off; no reusable library |
| EU job boards (Arbeitsagentur) | **No** | |
| Self-hosted / data ownership | **No** — cloud sandbox, vendor-held ("no training on your data" guarantee) | |
| REST API / SQLite export | **No** — closed platform | |
| Cost | **$200/mo Max** ($2,000/yr); Enterprise $325/seat/mo | ~50–200× Kestrel's $0–3/mo |
| Setup effort | **0 min** (SaaS) | |

**Bottom line:** Computer plugs the "stateless" hole in our old comparison argument, and Comet auto-fill is genuinely a killer feature. But it's closed, cloud-only, US-centric, rubric-less, lacks pipeline analytics, and costs $200/mo — so Kestrel retains clear differentiators (data ownership, EU boards, structured rubric, near-zero cost). It belongs as its own comparison entry, distinct from both the stateless "AI Assistants" grouping and dedicated job-search tools.

## Changes

### `docs/COMPARISON.md` ([`4c00c6b`](https://github.com/pleasedodisturb/kestrel/commit/4c00c6b))

1. **Landscape section** — expanded from 4 to 5 categories; added *Agentic AI (Perplexity Computer)*; clarified that the "AI assistants" bullet now refers specifically to *vanilla* Perplexity
2. **Main comparison table** — added a new **Perplexity Computer** column (9 tool columns × 18 dimensions) positioned between Kestrel and AI Assistants
3. **"Can't ChatGPT/Perplexity Do This?" mini-table** — split into three columns (AI Chatbot / Perplexity Computer / Dedicated Tool); added rows for EU board coverage and monthly cost
4. **Closing paragraph of that section** — rewrote the "AI assistants are stateless" argument since it no longer applies to Computer; reframed around persistence *plus* rubric / data ownership / price
5. **"Who Should Use What"** — added a row recommending Perplexity Computer for users willing to pay premium for an all-in-one cloud agent

### `docs/market-research-apr2026.md` ([`38d5ec1`](https://github.com/pleasedodisturb/kestrel/commit/38d5ec1))

1. **§1.3 "AI Job Search Copilots"** — new table row for Perplexity Computer with pricing, features, and launch date; follow-up note explaining it's a general-purpose agentic platform (not a dedicated copilot) and spelling out the trade-offs
2. **§5.1 "Unique capabilities"** — the "multi-board scraping + scoring + tracking + auto-apply in one pipeline" row now lists Perplexity Computer alongside ApplyPilot as a partial competitor. Other rows (configurable scoring, YAML CV, open scoring logic, EU boards, MCP-native, self-hosted) remain "None" — Computer genuinely doesn't cover them.

## Deliberately not in this PR

- **Brand rename** — `docs/market-research-apr2026.md` and `docs/pricing-strategy.md` still use "CareerOS" in prose, and ~165 files across the repo reference the internal `career_os` Python package name. This PR preserves each file's existing naming convention so it stays scoped and mergeable. Tracked separately in #93 with a four-tier incremental plan.

## Test plan

Docs-only change, no runtime/test impact.

- [x] `docs/COMPARISON.md` main table renders with 9 tool columns and all 18 dimension rows aligned
- [x] `docs/COMPARISON.md` "Can't ChatGPT/Perplexity Do This?" mini-table renders with 3 value columns
- [x] Landscape section says "five categories" (not "four") and the new Agentic AI bullet reads cleanly
- [x] No remaining sentence claims "all AI assistants are stateless" without qualification
- [x] `docs/market-research-apr2026.md` §1.3 table renders with the new row
- [ ] Visually verify tables render correctly on github.com after merge (GitHub's markdown renderer is the ground truth)

## Sources

Research compiled from:

- [Introducing Perplexity Computer — Perplexity Blog](https://www.perplexity.ai/hub/blog/introducing-perplexity-computer)
- [Perplexity launches 'Computer' super agent — Semafor (Feb 25, 2026)](https://www.semafor.com/article/02/25/2026/perplexity-launches-computer-super-agent)
- [Perplexity Computer Cost: Pricing, Credits & Plans (2026) — Sentisight](https://www.sentisight.ai/how-much-perplexity-computer-cost/)
- [Computer for Enterprise — Perplexity Help Center](https://www.perplexity.ai/help-center/en/articles/13901210-computer-for-enterprise)
- [Can Perplexity's Comet Browser Help You Find a Job? — Built In](https://builtin.com/artificial-intelligence/perplexity-comet-job-search)
- [Perplexity's agent pivot is on the money — Rundown AI](https://www.rundown.ai/articles/perplexity-agent-pivot-is-on-the-money)

## Related

- Closes nothing (pure addition)
- Related: #93 — Rename `career_os` → `kestrel` throughout codebase and docs (surfaced while writing this PR; deferred to a separate tiered refactor)

https://claude.ai/code/session_01VQA3vsdNJhREZc8B56huXW