### PR TITLE
Security backend batch: loop bounds, log sanitization, pip-audit CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: |
+          # pip<26.0 is flagged by CVE-2026-1703 (pip-audit); ensure the
+          # installer itself is patched before auditing project deps.
+          python -m pip install --upgrade 'pip>=26.0'
+          pip install -e ".[dev]"
 
       - name: Setup test config
         run: |
@@ -37,7 +41,6 @@ jobs:
         run: pytest tests/ -v --tb=short --cov=src/career_os --cov-report=xml
 
       - name: Security audit (dependencies)
-        continue-on-error: true
         run: pip install pip-audit && pip-audit
 
       - name: PII leak check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
     "pandas>=2.2.0",
     "python-jobspy>=1.1.0",
     "fpdf2>=2.8.0",
+    # Override python-jobspy's transitive pin of markdownify<0.14 — that
+    # range contains CVE-2025-46656. jobspy's tests pass with 0.14.x on
+    # the code paths kestrel exercises; we stay in the 0.14.x line to
+    # minimize API drift from the 0.13 baseline jobspy expects.
+    "markdownify>=0.14.1,<0.15",
 ]
 
 [project.scripts]

--- a/src/career_os/api/timingsapp.py
+++ b/src/career_os/api/timingsapp.py
@@ -30,6 +30,7 @@ from career_os.schemas.timingsapp import (
 )
 from career_os.services.timingsapp import (
     ConcurrentSessionError,
+    InvalidAnalyticsRangeError,
     TimeSessionAlreadyStoppedError,
     TimeSessionNotFoundError,
     check_timingsapp_connection,
@@ -165,7 +166,10 @@ async def get_analytics(
     weeks: Annotated[int, Query(ge=1, le=52, description="Number of weeks to analyze")] = 4,
 ) -> TimeAnalyticsResponse:
     """Get time analytics with total hours, category breakdown, and weekly trend."""
-    return get_time_analytics(db, profile_id=profile_id, weeks=weeks)
+    try:
+        return get_time_analytics(db, profile_id=profile_id, weeks=weeks)
+    except InvalidAnalyticsRangeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/test")

--- a/src/career_os/services/role_intelligence.py
+++ b/src/career_os/services/role_intelligence.py
@@ -240,7 +240,11 @@ def _salary_fallback_from_market(
             sample_size=total_samples,
         )
     except Exception as exc:
-        logger.warning("Market salary fallback failed for '%s': %s", role, exc)
+        logger.warning(
+            "Market salary fallback failed for '%s': %s",
+            _sanitize_for_log(role),
+            _sanitize_for_log(exc),
+        )
         return None
 
 

--- a/src/career_os/services/timingsapp.py
+++ b/src/career_os/services/timingsapp.py
@@ -34,6 +34,11 @@ from career_os.services.timingsapp_client import (
 
 logger = logging.getLogger(__name__)
 
+# Upper bound for the `weeks` parameter on analytics endpoints. Beyond this,
+# the caller has almost certainly supplied a garbage/malicious value and the
+# service rejects the request instead of burning CPU on an oversized loop.
+MAX_ANALYTICS_WEEKS = 1000
+
 
 class TimingsAppNotConfiguredError(Exception):
     """Raised when TimingsApp integration is not configured or disabled."""
@@ -49,6 +54,10 @@ class TimeSessionAlreadyStoppedError(Exception):
 
 class ConcurrentSessionError(Exception):
     """Raised when trying to start a session while another is already running."""
+
+
+class InvalidAnalyticsRangeError(ValueError):
+    """Raised when the requested analytics window is out of bounds."""
 
 
 # ---------------------------------------------------------------------------
@@ -505,9 +514,14 @@ def get_time_analytics(
     """Compute time analytics for a profile.
 
     Returns total hours, category breakdown, and weekly trend.
+
+    Raises:
+        InvalidAnalyticsRangeError: If ``weeks`` is outside ``[1, MAX_ANALYTICS_WEEKS]``.
     """
-    _max_weeks = 1000
-    weeks = max(1, min(weeks, _max_weeks))
+    if weeks < 1 or weeks > MAX_ANALYTICS_WEEKS:
+        raise InvalidAnalyticsRangeError(
+            f"weeks must be between 1 and {MAX_ANALYTICS_WEEKS}, got {weeks}"
+        )
     now = datetime.now(UTC)
     start_of_period = now - timedelta(weeks=weeks)
 

--- a/tests/test_timingsapp.py
+++ b/tests/test_timingsapp.py
@@ -27,7 +27,9 @@ from career_os.schemas.timingsapp import (
     TimeSessionUpdate,
 )
 from career_os.services.timingsapp import (
+    MAX_ANALYTICS_WEEKS,
     ConcurrentSessionError,
+    InvalidAnalyticsRangeError,
     TimeSessionAlreadyStoppedError,
     TimeSessionNotFoundError,
     auto_categorize,
@@ -1144,19 +1146,39 @@ class TestConnectionTest:
 
 
 class TestWeeksLoopBounds:
-    """Verify that get_time_analytics clamps the weeks parameter."""
+    """Verify that get_time_analytics rejects out-of-bound weeks values.
 
-    def test_weeks_clamped_to_max(self, db_session, profile):
-        """Extremely large weeks value is clamped, no hang or OOM."""
-        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=999_999)
-        # Should succeed (clamped to 1000) and return a result
+    Protects against CPU/DoS via user-controlled loop iteration counts
+    (SonarCloud CRITICAL, issue #24).
+    """
+
+    def test_weeks_exceeding_max_raises(self, db_session, profile):
+        """A massive weeks value is rejected, not silently clamped."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=999_999)
+
+    def test_weeks_at_max_succeeds(self, db_session, profile):
+        """Boundary: MAX_ANALYTICS_WEEKS is accepted."""
+        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=MAX_ANALYTICS_WEEKS)
         assert analytics.total_hours == pytest.approx(0.0)
-        assert len(analytics.weekly_trend) == 1000
+        assert len(analytics.weekly_trend) == MAX_ANALYTICS_WEEKS
 
-    def test_weeks_clamped_to_min(self, db_session, profile):
-        """Zero or negative weeks is clamped to 1."""
-        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=0)
+    def test_weeks_one_over_max_raises(self, db_session, profile):
+        """Boundary: MAX_ANALYTICS_WEEKS + 1 is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=MAX_ANALYTICS_WEEKS + 1)
+
+    def test_weeks_zero_raises(self, db_session, profile):
+        """Zero weeks is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=0)
+
+    def test_weeks_negative_raises(self, db_session, profile):
+        """Negative weeks is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=-5)
+
+    def test_weeks_one_succeeds(self, db_session, profile):
+        """Boundary: weeks=1 is accepted."""
+        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=1)
         assert len(analytics.weekly_trend) == 1
-
-        analytics_neg = get_time_analytics(db_session, profile_id=profile.id, weeks=-5)
-        assert len(analytics_neg.weekly_trend) == 1


### PR DESCRIPTION
## Summary

Group A security backend batch — targeted fixes for the three source issues, no scope creep.

Closes #85. Refs #18, #24, #25.

## Changes

| File | Change | Issue |
|---|---|---|
| `.github/workflows/ci.yml` | Upgrade pip to `>=26.0` (patches CVE-2026-1703 in the installer itself), drop `continue-on-error: true` from the `pip-audit` step so it can actually fail the build | #18 |
| `pyproject.toml` | Override `python-jobspy`'s transitive `markdownify<0.14` pin (CVE-2025-46656) with `markdownify>=0.14.1,<0.15`. Kestrel's jobspy code paths pass on 0.14.x | #18 |
| `src/career_os/services/timingsapp.py` | Replace the silent `max(1, min(weeks, 1000))` clamp with a `MAX_ANALYTICS_WEEKS = 1000` constant + `InvalidAnalyticsRangeError` raise. Out-of-bounds input now returns a clear error instead of burning CPU on an oversized loop | #24 |
| `src/career_os/api/timingsapp.py` | Catch `InvalidAnalyticsRangeError` at the HTTP boundary → `HTTPException(status_code=400)` | #24 |
| `src/career_os/services/role_intelligence.py` | Route the user-controlled `role` and `exc` values in the salary-fallback log through the existing `_sanitize_for_log()` helper | #25 |
| `tests/test_timingsapp.py` | Rewrite `TestWeeksLoopBounds` for the reject-not-clamp contract: 6 boundary tests (over-max, at-max, one-over-max, zero, negative, one) | #24 |

## Why this PR replaces #95

PR #95 was originally opened from the same `claude/batch-security-backend-rzslI` branch but with a wildly off-scope body (full TimingsApp removal). After force-push surgery the branch now contains only the correct 6-file security fix. Rather than leave #95's body and review history attached to a diff it doesn't describe, this PR is a clean re-open from a fresh `claude/security-backend` branch pointing at the same commit (`8ea0781`). Contents are byte-identical to #95's current HEAD — this is a cosmetic re-packaging for clean git history, not a new change.

## Verification

All 7 CI checks already green on `8ea0781` (Backend Python, Frontend React, CodeQL Python, CodeQL JS/TS, CodeQL meta, SonarCloud, submit-pypi).

- [x] `ruff format src/ tests/ && ruff check src/ tests/` clean
- [x] `pytest tests/ -x --tb=short` — 2099 tests passing, including the 6 new boundary tests in `TestWeeksLoopBounds`
- [x] `pip-audit` reports clean (was the whole point of #18)
- [x] 3 logger calls in `role_intelligence.py` (company path L143, role path L243, salary-fallback path L524) all route user-controlled values through `_sanitize_for_log()`

## Acceptance criteria (from #85)

- [x] `timingsapp.py` rejects requests whose user-supplied N exceeds `MAX_ANALYTICS_WEEKS` with a clear 400
- [x] No user-controlled data flows unsanitized into `logger.*` in `role_intelligence.py`
- [x] pip-audit CI step passes without `continue-on-error`
- [x] `ruff format src/ tests/ && ruff check src/ tests/ && pytest tests/ -x --tb=short` clean
- [x] New unit tests cover the loop-bound rejection path

## Follow-up

Once this merges, the `claude/batch-cognitive-complexity` session (#62) is unblocked and can safely be fired.
