### PR TITLE
Security: backend batch fixes (loop bound, log sanitization, pip-audit CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: |
+          # pip<26.0 is flagged by CVE-2026-1703 (pip-audit); ensure the
+          # installer itself is patched before auditing project deps.
+          python -m pip install --upgrade 'pip>=26.0'
+          pip install -e ".[dev]"
 
       - name: Setup test config
         run: |
@@ -37,7 +41,6 @@ jobs:
         run: pytest tests/ -v --tb=short --cov=src/career_os --cov-report=xml
 
       - name: Security audit (dependencies)
-        continue-on-error: true
         run: pip install pip-audit && pip-audit
 
       - name: PII leak check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
     "pandas>=2.2.0",
     "python-jobspy>=1.1.0",
     "fpdf2>=2.8.0",
+    # Override python-jobspy's transitive pin of markdownify<0.14 — that
+    # range contains CVE-2025-46656. jobspy's tests pass with 0.14.x on
+    # the code paths kestrel exercises; we stay in the 0.14.x line to
+    # minimize API drift from the 0.13 baseline jobspy expects.
+    "markdownify>=0.14.1,<0.15",
 ]
 
 [project.scripts]

--- a/src/career_os/api/timingsapp.py
+++ b/src/career_os/api/timingsapp.py
@@ -30,6 +30,7 @@ from career_os.schemas.timingsapp import (
 )
 from career_os.services.timingsapp import (
     ConcurrentSessionError,
+    InvalidAnalyticsRangeError,
     TimeSessionAlreadyStoppedError,
     TimeSessionNotFoundError,
     check_timingsapp_connection,
@@ -165,7 +166,10 @@ async def get_analytics(
     weeks: Annotated[int, Query(ge=1, le=52, description="Number of weeks to analyze")] = 4,
 ) -> TimeAnalyticsResponse:
     """Get time analytics with total hours, category breakdown, and weekly trend."""
-    return get_time_analytics(db, profile_id=profile_id, weeks=weeks)
+    try:
+        return get_time_analytics(db, profile_id=profile_id, weeks=weeks)
+    except InvalidAnalyticsRangeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/test")

--- a/src/career_os/services/role_intelligence.py
+++ b/src/career_os/services/role_intelligence.py
@@ -240,7 +240,11 @@ def _salary_fallback_from_market(
             sample_size=total_samples,
         )
     except Exception as exc:
-        logger.warning("Market salary fallback failed for '%s': %s", role, exc)
+        logger.warning(
+            "Market salary fallback failed for '%s': %s",
+            _sanitize_for_log(role),
+            _sanitize_for_log(exc),
+        )
         return None
 
 

--- a/src/career_os/services/timingsapp.py
+++ b/src/career_os/services/timingsapp.py
@@ -34,6 +34,11 @@ from career_os.services.timingsapp_client import (
 
 logger = logging.getLogger(__name__)
 
+# Upper bound for the `weeks` parameter on analytics endpoints. Beyond this,
+# the caller has almost certainly supplied a garbage/malicious value and the
+# service rejects the request instead of burning CPU on an oversized loop.
+MAX_ANALYTICS_WEEKS = 1000
+
 
 class TimingsAppNotConfiguredError(Exception):
     """Raised when TimingsApp integration is not configured or disabled."""
@@ -49,6 +54,10 @@ class TimeSessionAlreadyStoppedError(Exception):
 
 class ConcurrentSessionError(Exception):
     """Raised when trying to start a session while another is already running."""
+
+
+class InvalidAnalyticsRangeError(ValueError):
+    """Raised when the requested analytics window is out of bounds."""
 
 
 # ---------------------------------------------------------------------------
@@ -505,9 +514,14 @@ def get_time_analytics(
     """Compute time analytics for a profile.
 
     Returns total hours, category breakdown, and weekly trend.
+
+    Raises:
+        InvalidAnalyticsRangeError: If ``weeks`` is outside ``[1, MAX_ANALYTICS_WEEKS]``.
     """
-    _max_weeks = 1000
-    weeks = max(1, min(weeks, _max_weeks))
+    if weeks < 1 or weeks > MAX_ANALYTICS_WEEKS:
+        raise InvalidAnalyticsRangeError(
+            f"weeks must be between 1 and {MAX_ANALYTICS_WEEKS}, got {weeks}"
+        )
     now = datetime.now(UTC)
     start_of_period = now - timedelta(weeks=weeks)
 

--- a/tests/test_role_intelligence.py
+++ b/tests/test_role_intelligence.py
@@ -1051,3 +1051,96 @@ class TestSanitizeForLog:
         result = _sanitize_for_log(RuntimeError("boom\ninjected"))
         assert "\n" not in result
         assert "boom\\ninjected" in result
+
+
+# ===========================================================================
+# Log injection wiring regression tests (#25)
+# ===========================================================================
+
+
+class TestLogInjectionWiring:
+    """Verify that each user-data logger call site actually funnels its input
+    through ``_sanitize_for_log`` — not just that the helper exists and works
+    in isolation.
+
+    Each test mocks ``logger.warning`` on the module, triggers the exception
+    branch that logs user input, and asserts no raw CR/LF reaches the logger.
+    A regression (e.g. someone removes ``_sanitize_for_log(...)`` while
+    refactoring) would show up here.
+    """
+
+    INJECTION = "Evil\nFAKE LOG ENTRY\rtail"
+
+    @pytest.mark.asyncio
+    async def test_interview_format_sanitizes_company(
+        self, test_db: Session, test_profile: Profile
+    ):
+        from career_os.services import role_intelligence
+
+        with (
+            patch.object(role_intelligence, "get_ai_provider") as mock_factory,
+            patch.object(role_intelligence, "logger") as mock_logger,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = RuntimeError("boom\ninjected-exc")
+            mock_factory.return_value = mock_provider
+
+            await role_intelligence.get_interview_format(
+                test_db,
+                company=self.INJECTION,
+                role=None,
+                profile_id=test_profile.id,
+            )
+
+        mock_logger.warning.assert_called_once()
+        args = mock_logger.warning.call_args.args
+        # args = (fmt, sanitized_company, sanitized_exc)
+        assert "\n" not in args[1] and "\r" not in args[1]
+        assert args[1] == "Evil\\nFAKE LOG ENTRY\\rtail"
+        assert "\n" not in args[2] and "\r" not in args[2]
+
+    def test_market_salary_fallback_sanitizes_role(self, test_db: Session, test_profile: Profile):
+        from career_os.services import role_intelligence
+
+        with (
+            patch.object(role_intelligence, "get_salary_trends") as mock_trends,
+            patch.object(role_intelligence, "logger") as mock_logger,
+        ):
+            mock_trends.side_effect = RuntimeError("db\rexploded")
+
+            result = role_intelligence._salary_fallback_from_market(
+                test_db,
+                role=self.INJECTION,
+                profile_id=test_profile.id,
+            )
+
+        assert result is None
+        mock_logger.warning.assert_called_once()
+        args = mock_logger.warning.call_args.args
+        assert "\n" not in args[1] and "\r" not in args[1]
+        assert args[1] == "Evil\\nFAKE LOG ENTRY\\rtail"
+        assert "\n" not in args[2] and "\r" not in args[2]
+
+    @pytest.mark.asyncio
+    async def test_interview_patterns_sanitizes_role(self, test_db: Session, test_profile: Profile):
+        from career_os.services import role_intelligence
+
+        with (
+            patch.object(role_intelligence, "get_ai_provider") as mock_factory,
+            patch.object(role_intelligence, "logger") as mock_logger,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = RuntimeError("boom\ninjected-exc")
+            mock_factory.return_value = mock_provider
+
+            await role_intelligence.get_interview_patterns(
+                test_db,
+                role=self.INJECTION,
+                profile_id=test_profile.id,
+            )
+
+        mock_logger.warning.assert_called_once()
+        args = mock_logger.warning.call_args.args
+        assert "\n" not in args[1] and "\r" not in args[1]
+        assert args[1] == "Evil\\nFAKE LOG ENTRY\\rtail"
+        assert "\n" not in args[2] and "\r" not in args[2]

--- a/tests/test_timingsapp.py
+++ b/tests/test_timingsapp.py
@@ -27,7 +27,9 @@ from career_os.schemas.timingsapp import (
     TimeSessionUpdate,
 )
 from career_os.services.timingsapp import (
+    MAX_ANALYTICS_WEEKS,
     ConcurrentSessionError,
+    InvalidAnalyticsRangeError,
     TimeSessionAlreadyStoppedError,
     TimeSessionNotFoundError,
     auto_categorize,
@@ -1144,19 +1146,39 @@ class TestConnectionTest:
 
 
 class TestWeeksLoopBounds:
-    """Verify that get_time_analytics clamps the weeks parameter."""
+    """Verify that get_time_analytics rejects out-of-bound weeks values.
 
-    def test_weeks_clamped_to_max(self, db_session, profile):
-        """Extremely large weeks value is clamped, no hang or OOM."""
-        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=999_999)
-        # Should succeed (clamped to 1000) and return a result
+    Protects against CPU/DoS via user-controlled loop iteration counts
+    (SonarCloud CRITICAL, issue #24).
+    """
+
+    def test_weeks_exceeding_max_raises(self, db_session, profile):
+        """A massive weeks value is rejected, not silently clamped."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=999_999)
+
+    def test_weeks_at_max_succeeds(self, db_session, profile):
+        """Boundary: MAX_ANALYTICS_WEEKS is accepted."""
+        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=MAX_ANALYTICS_WEEKS)
         assert analytics.total_hours == pytest.approx(0.0)
-        assert len(analytics.weekly_trend) == 1000
+        assert len(analytics.weekly_trend) == MAX_ANALYTICS_WEEKS
 
-    def test_weeks_clamped_to_min(self, db_session, profile):
-        """Zero or negative weeks is clamped to 1."""
-        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=0)
+    def test_weeks_one_over_max_raises(self, db_session, profile):
+        """Boundary: MAX_ANALYTICS_WEEKS + 1 is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=MAX_ANALYTICS_WEEKS + 1)
+
+    def test_weeks_zero_raises(self, db_session, profile):
+        """Zero weeks is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=0)
+
+    def test_weeks_negative_raises(self, db_session, profile):
+        """Negative weeks is rejected."""
+        with pytest.raises(InvalidAnalyticsRangeError):
+            get_time_analytics(db_session, profile_id=profile.id, weeks=-5)
+
+    def test_weeks_one_succeeds(self, db_session, profile):
+        """Boundary: weeks=1 is accepted."""
+        analytics = get_time_analytics(db_session, profile_id=profile.id, weeks=1)
         assert len(analytics.weekly_trend) == 1
-
-        analytics_neg = get_time_analytics(db_session, profile_id=profile.id, weeks=-5)
-        assert len(analytics_neg.weekly_trend) == 1


### PR DESCRIPTION
## Summary

Three small, isolated security backend fixes bundled together per the scope of #85 (SonarCloud findings + upstream CVE in CI).

### 1. `#24` — loop bound from user data in `timingsapp.py`
- Added module-level constant `MAX_ANALYTICS_WEEKS = 1000` and `InvalidAnalyticsRangeError(ValueError)` in `src/career_os/services/timingsapp.py`
- Replaced the silent `max(1, min(weeks, 1000))` clamp in `get_time_analytics()` with an explicit bounds check that raises `InvalidAnalyticsRangeError` when `weeks` is out of `[1, MAX_ANALYTICS_WEEKS]`
- Wired the service exception to HTTP 400 in `src/career_os/api/timingsapp.py` (`GET /api/timingsapp/analytics`), mirroring the existing `TimeSessionAlreadyStoppedError → HTTPException(400)` idiom
- Defence-in-depth: `Query(ge=1, le=52)` at the API layer still catches normal abusive requests with 422; the service-layer bound protects non-HTTP callers (CLI, internal)
- Verified the inner helper `_build_weekly_trends` is only called from `get_time_analytics`, so the bound propagates cleanly

### 2. `#25` — user data in log statements in `role_intelligence.py`
SonarCloud MINOR flagged lines 135 and 487 (file has drifted since scan — actual logger sites are 143, 243, 524). All three now funnel user input through the existing `_sanitize_for_log()` helper:
- L143-147 (`get_interview_format`, `company`) — already sanitized
- L243-247 (`_salary_fallback_from_market`, `role`) — **newly sanitized**
- L524-528 (`get_interview_patterns`, `role`) — already sanitized

No new sanitizer written — issue #85 specifies "Do not hand-roll escaping — use the same approach already used in other services".

### 3. `#18` — pip-audit CI step fails on upstream CVE
Two CVEs surfaced when running pip-audit locally:
- **`pip 25.3` → CVE-2026-1703** (fix: 26.0) — added `python -m pip install --upgrade 'pip>=26.0'` to the `Install dependencies` step in `.github/workflows/ci.yml`
- **`markdownify 0.13.1` → CVE-2025-46656** (fix: 0.14.1), pulled in transitively via `python-jobspy`. Pinned `markdownify>=0.14.1,<0.15` in `pyproject.toml` dev-deps to override jobspy's conservative upper-bound. Stayed on the 0.14.x line to minimize API drift from the 0.13.x baseline jobspy expects.

Removed `continue-on-error: true` from the pip-audit step.

## Tests

### New
- `TestWeeksLoopBounds` (6 cases) in `tests/test_timingsapp.py`:
  - `weeks=999_999` → raises `InvalidAnalyticsRangeError`
  - `weeks=MAX_ANALYTICS_WEEKS` → succeeds (upper boundary)
  - `weeks=MAX_ANALYTICS_WEEKS + 1` → raises
  - `weeks=0` / `weeks=-5` → raises
  - `weeks=1` → succeeds (lower boundary)
- `TestLogInjectionWiring` (3 cases) in `tests/test_role_intelligence.py` — **new**, mocks `logger.warning` and triggers each of the 3 exception branches with a CR/LF injection payload to verify each call site actually funnels its input through `_sanitize_for_log`. Guards against a regression where someone removes the sanitizer call during refactoring.

### Updated
- Existing `test_weeks_clamped_to_max` / `test_weeks_clamped_to_min` in `tests/test_timingsapp.py` were rewritten; they asserted silent-clamp behavior that's now a rejection.

## Verification

```
ruff format src/ tests/          # clean (215 files)
ruff check  src/ tests/          # All checks passed!
pytest     tests/                # 2168 passed, 31 skipped
pip-audit                        # No known vulnerabilities found
```

Alembic chain walks cleanly; no schema changes in this PR.

## Scope notes

- **Isolated to `services/`, `api/`, `tests/`, `pyproject.toml`, `.github/workflows/ci.yml`** — matches #85's "isolated to services/ and CI workflow" scope.
- **Does not touch `role_intelligence.py` cognitive complexity** — #85 explicitly says #62 should run *after* this merges; that refactor is intentionally deferred.
- **Does not remove TimingsApp** — #85 is a security fix, not a removal. The removal is tracked separately in #95 / #98 and has no overlap with this branch.

Closes #85
Closes #24
Closes #25
Closes #18

https://claude.ai/code/session_012wTwBNumEFZaLD6UheYNRw