### PR TITLE
feat: wire illustrations into all docs + GitHub Pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="assets/illustrations/hero-bauhaus.webp" alt="Kestrel" width="300"></p>
+
 # Contributing to Kestrel
 
 Note: The Python package is internally named `career_os` (from the original project). The PyPI package name is `kestrel-app`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/illustrations/hero-navy.webp" alt="Kestrel" width="280">
+</p>
+
 <h1 align="center">Kestrel</h1>
 
 <p align="center">

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+title: Kestrel
+description: A job search system that runs on your computer. Finds jobs. Scores them. Tracks your pipeline. Your data stays yours.
+theme: jekyll-theme-minimal
+logo: assets/illustrations/logo-icon.webp
+show_downloads: false

--- a/docs/AI-PROVIDERS.md
+++ b/docs/AI-PROVIDERS.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="../assets/illustrations/hero-tropical.webp" alt="Kestrel" width="300"></p>
+
 # AI Provider Guide
 
 Kestrel uses AI for job scoring, skills analysis, interview prep, company research, and coaching. This guide explains your options.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="../assets/illustrations/hero-sky.webp" alt="Kestrel" width="300"></p>
+
 # Competitive Landscape
 
 ## TL;DR

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="../assets/illustrations/hero-yellow.webp" alt="Kestrel" width="300"></p>
+
 # Frequently Asked Questions
 
 ---

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="../assets/illustrations/hero-closeup.webp" alt="Kestrel" width="300"></p>
+
 # Help - Troubleshooting Kestrel
 
 ## Quick diagnosis

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="../assets/illustrations/hero-coral.webp" alt="Kestrel" width="300"></p>
+
 # Getting Started with Kestrel
 
 This guide assumes you have never used a terminal before. Every step is explained. If you get stuck, check the [Common Problems](#common-problems) section at the bottom or the [FAQ](FAQ.md).

--- a/index.md
+++ b/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Kestrel - AI-Powered Job Search
+---
+
+{% include_relative README.md %}


### PR DESCRIPTION
Every doc now has a kestrel illustration header. GitHub Pages config added - enable in repo Settings > Pages > Source: main branch.