### PR TITLE
ci: add merge_group trigger + document merge workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,15 @@ cd frontend && npx eslint src/
 - All CI checks must pass
 - Tests are required for new features
 
+## Merging
+
+The `main` branch is protected with required status checks and a merge queue.
+
+- **PRs must be up-to-date with main** before merging. If main has moved since your last CI run, GitHub will ask you to update your branch and re-run checks. This prevents untested merge combinations from landing.
+- **Use the "Merge when ready" button** (not direct merge). This adds your PR to the merge queue, which tests the merge result before actually pushing to main.
+- **Squash merge only** — keeps the main branch history clean and bisectable.
+- If CI fails after an update, investigate before re-pushing. The failure likely means your changes conflict with something that landed while your PR was in review.
+
 ## AI Provider Changes
 
 If you add a new AI provider:


### PR DESCRIPTION
## Summary

Completes the code side of #114. Branch protection and merge queue are already configured in the GitHub UI.

## Changes

- **`.github/workflows/ci.yml`** — added `merge_group:` trigger so CI runs against the merge result when PRs enter the merge queue
- **`CONTRIBUTING.md`** — added "Merging" section documenting the up-to-date requirement, merge queue workflow, and squash-only policy

## Why

PR #103 + #105 demonstrated the risk: two independently-green PRs merged in rapid succession, producing a broken main (Alembic roundtrip failure) that was never CI-tested. The merge queue tests the merge result before pushing, preventing this class of bug.

## UI settings already configured

- Required checks: `Backend (Python 3.13)`, `Frontend (React)`, `actionlint`, `gitleaks`, `Analyze (python)`, `Analyze (javascript-typescript)`
- Require branches to be up-to-date before merging
- Merge queue enabled (squash, batch size 3)
- Block force pushes, restrict deletions
- Copilot review enabled (advisory, not blocking)

Closes #114

https://claude.ai/code/session_0162uQR39ZURNFUCy9Rj2bBC