### PR TITLE
Refactor AI provider factory to data-driven registry pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,15 @@ jobs:
           fi
           [ "$FAIL" -eq 0 ] && echo "No PII found - clean." || exit 1
 
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-check
+
   frontend:
     name: Frontend (React)
     runs-on: ubuntu-latest

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -1,14 +1,29 @@
 """AI provider factory — selects provider based on AI_PROVIDER env var."""
 
 import os
+from collections.abc import Callable
 
 from career_os.ai.base import AIProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.openrouter_provider import OpenRouterProvider
 
-# Registry of supported provider names → constructors.
-# "demo" is a user-facing alias for "mock" — both resolve to MockProvider.
-_SUPPORTED_PROVIDERS = {"mock", "demo", "openrouter"}
+# ---------------------------------------------------------------------------
+# Provider registry: name → factory callable.
+# To add a new provider, add one entry here (+ its module).
+# "demo" is a user-facing alias for "mock" so non-technical users don't
+# think "mock" means broken.
+# ---------------------------------------------------------------------------
+
+_PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
+    "mock": lambda: MockProvider(),
+    "demo": lambda: MockProvider(),
+    "openrouter": lambda: OpenRouterProvider(
+        api_key=os.getenv("OPENROUTER_API_KEY", ""),
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-sonnet-4"),
+    ),
+}
+
+_SUPPORTED_PROVIDERS = set(_PROVIDER_REGISTRY.keys())
 
 
 class UnsupportedProviderError(Exception):
@@ -39,15 +54,9 @@ def get_ai_provider(provider_name: str | None = None) -> AIProvider:
     Raises:
         UnsupportedProviderError: If the provider name is not recognized.
     """
-    name = provider_name or os.getenv("AI_PROVIDER", "mock")
-    name = name.strip().lower()
+    name = (provider_name or os.getenv("AI_PROVIDER", "mock")).strip().lower()
 
-    if name in ("mock", "demo"):
-        return MockProvider()
-
-    if name == "openrouter":
-        api_key = os.getenv("OPENROUTER_API_KEY", "")
-        model = os.getenv("OPENROUTER_MODEL", "anthropic/claude-sonnet-4")
-        return OpenRouterProvider(api_key=api_key, model=model)
-
-    raise UnsupportedProviderError(name)
+    factory_fn = _PROVIDER_REGISTRY.get(name)
+    if factory_fn is None:
+        raise UnsupportedProviderError(name)
+    return factory_fn()

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -28,25 +28,31 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
+    # Per-provider API key requirements: provider → (settings_attr, expected_prefix).
+    # New providers add one entry here instead of a new if-block.
+    _PROVIDER_KEY_REQUIREMENTS: dict[str, tuple[str, str]] = {
+        "openrouter": ("openrouter_api_key", "sk-or-"),
+    }
+
     @model_validator(mode="after")
     def validate_api_keys(self) -> "Settings":
         """Fail fast if AI provider requires an API key that isn't set."""
-        if self.ai_provider == "openrouter" and not self.openrouter_api_key:
-            raise ValueError(
-                "OPENROUTER_API_KEY is required when AI_PROVIDER=openrouter. "
-                "Set it in your .env file or environment."
-            )
-        if (
-            self.ai_provider == "openrouter"
-            and self.openrouter_api_key
-            and not self.openrouter_api_key.startswith("sk-or-")
-        ):
-            import logging
+        req = self._PROVIDER_KEY_REQUIREMENTS.get(self.ai_provider)
+        if req:
+            attr, prefix = req
+            val = getattr(self, attr, "")
+            if not val:
+                raise ValueError(
+                    f"{attr.upper()} is required when AI_PROVIDER={self.ai_provider}. "
+                    f"Set it in your .env file or environment."
+                )
+            if prefix and val and not val.startswith(prefix):
+                import logging
 
-            logging.getLogger(__name__).warning(
-                "OPENROUTER_API_KEY doesn't start with 'sk-or-'. "
-                "It may be pasted incorrectly. Check for extra spaces or missing characters."
-            )
+                logging.getLogger(__name__).warning(
+                    f"{attr.upper()} doesn't start with '{prefix}'. "
+                    "It may be pasted incorrectly. Check for extra spaces or missing characters."
+                )
         if self.auth_enabled and not self.auth_api_key:
             raise ValueError(
                 "AUTH_API_KEY is required when AUTH_ENABLED=true. "

--- a/src/career_os/services/ai_health.py
+++ b/src/career_os/services/ai_health.py
@@ -16,6 +16,7 @@ import time
 import httpx
 from sqlalchemy.orm import Session
 
+from career_os.ai.factory import _SUPPORTED_PROVIDERS
 from career_os.models.integrations import IntegrationConfig
 from career_os.schemas.ai_health import (
     AIHealthResponse,
@@ -26,8 +27,9 @@ from career_os.schemas.ai_health import (
 
 logger = logging.getLogger(__name__)
 
-# Runtime-supported providers (from ai/factory.py)
-RUNTIME_SUPPORTED_PROVIDERS = {"mock", "openrouter"}
+# Runtime-supported providers — derived from the factory registry so new
+# providers registered there are automatically recognised here.
+RUNTIME_SUPPORTED_PROVIDERS = _SUPPORTED_PROVIDERS
 
 # Provider display names
 _PROVIDER_DISPLAY_NAMES = {

--- a/tests/test_ai_health.py
+++ b/tests/test_ai_health.py
@@ -290,3 +290,30 @@ class TestStoredConfigIntegration:
         assert "anthropic" not in names
         assert "openai" not in names
         assert "droid_exec" not in names
+
+
+# ---------------------------------------------------------------------------
+# Registry-derived provider list
+# ---------------------------------------------------------------------------
+
+
+class TestHealthRegistryIntegration:
+    """Health endpoint provider list tracks the factory registry."""
+
+    def test_health_providers_match_factory_registry(self, client: TestClient) -> None:
+        """Every non-alias provider in the factory registry has a health check."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        with patch.dict(os.environ, {"AI_PROVIDER": "mock"}):
+            resp = client.get("/api/ai/health")
+        names = {p["name"] for p in resp.json()["providers"]}
+        # "demo" is an alias for "mock", so we exclude it
+        real_providers = {k for k in _PROVIDER_REGISTRY if k != "demo"}
+        assert real_providers <= names
+
+    def test_runtime_supported_derived_from_factory(self) -> None:
+        """RUNTIME_SUPPORTED_PROVIDERS is the same object as _SUPPORTED_PROVIDERS."""
+        from career_os.ai.factory import _SUPPORTED_PROVIDERS
+        from career_os.services.ai_health import RUNTIME_SUPPORTED_PROVIDERS
+
+        assert RUNTIME_SUPPORTED_PROVIDERS is _SUPPORTED_PROVIDERS

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -774,3 +774,55 @@ class TestAICompleteEndpoint:
         assert resp.status_code == 422
         data = resp.json()
         assert "OPENROUTER_API_KEY" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Provider registry unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistry:
+    """Unit tests for the _PROVIDER_REGISTRY data structure."""
+
+    def test_registry_keys_match_supported_set(self) -> None:
+        """_SUPPORTED_PROVIDERS is derived from registry keys, not hardcoded."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY, _SUPPORTED_PROVIDERS
+
+        assert set(_PROVIDER_REGISTRY.keys()) == _SUPPORTED_PROVIDERS
+
+    def test_all_registry_entries_are_callable(self) -> None:
+        """Every registry value is a callable."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        assert all(callable(v) for v in _PROVIDER_REGISTRY.values())
+
+    def test_demo_alias_points_to_mock(self) -> None:
+        """'demo' and 'mock' registry entries both produce MockProvider."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        mock_instance = _PROVIDER_REGISTRY["mock"]()
+        demo_instance = _PROVIDER_REGISTRY["demo"]()
+        assert type(mock_instance) is type(demo_instance)
+        assert isinstance(mock_instance, MockProvider)
+
+    def test_registry_has_minimum_providers(self) -> None:
+        """Registry contains at least mock, demo, openrouter."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        assert {"mock", "demo", "openrouter"} <= set(_PROVIDER_REGISTRY.keys())
+
+    def test_mock_entry_returns_ai_provider(self) -> None:
+        """Mock registry entry produces a valid AIProvider."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        provider = _PROVIDER_REGISTRY["mock"]()
+        assert isinstance(provider, AIProvider)
+        assert provider.name == "mock"
+
+    def test_openrouter_entry_requires_api_key(self) -> None:
+        """OpenRouter registry entry raises ValueError without API key."""
+        from career_os.ai.factory import _PROVIDER_REGISTRY
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}):
+            with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+                _PROVIDER_REGISTRY["openrouter"]()

--- a/tests/test_provider_uat.py
+++ b/tests/test_provider_uat.py
@@ -1,0 +1,208 @@
+"""User acceptance tests: every registered provider satisfies the AIProvider contract.
+
+These tests run the full factory → provider → API chain for each provider
+that can operate without external services (mock, demo). For providers requiring
+external services (ollama, anthropic, openrouter), they verify graceful degradation.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from career_os.ai.base import AIProvider
+from career_os.ai.factory import UnsupportedProviderError, get_ai_provider
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+
+
+@pytest.fixture(autouse=True)
+def _auto_db(db_session):
+    return db_session
+
+
+# ---------------------------------------------------------------------------
+# UAT: Provider contract — local providers (no external services needed)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderContractUAT:
+    """Every local provider satisfies the AIProvider contract end-to-end."""
+
+    @pytest.fixture(params=["mock", "demo"])
+    def local_provider(self, request):
+        """Providers that work without external services."""
+        return get_ai_provider(request.param)
+
+    def test_is_ai_provider_instance(self, local_provider) -> None:
+        """Provider is an instance of AIProvider ABC."""
+        assert isinstance(local_provider, AIProvider)
+
+    def test_has_name(self, local_provider) -> None:
+        """Provider has a non-empty name property."""
+        assert local_provider.name
+        assert isinstance(local_provider.name, str)
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_ai_response(self, local_provider) -> None:
+        """complete() returns a valid AIResponse."""
+        resp = await local_provider.complete("hello")
+        assert isinstance(resp, AIResponse)
+        assert resp.content
+        assert resp.provider
+
+    @pytest.mark.asyncio
+    async def test_complete_deterministic(self, local_provider) -> None:
+        """Same prompt produces identical responses."""
+        r1 = await local_provider.complete("test prompt")
+        r2 = await local_provider.complete("test prompt")
+        assert r1.content == r2.content
+
+    @pytest.mark.asyncio
+    async def test_score_returns_score_result(self, local_provider) -> None:
+        """score() returns AIResponse with ScoreResult structured data."""
+        resp = await local_provider.score("Engineer at Acme", {"name": "Test"})
+        assert isinstance(resp, AIResponse)
+        assert isinstance(resp.structured, ScoreResult)
+        assert 0 <= resp.structured.fit_score <= 10
+        assert len(resp.structured.reasoning) >= 100
+
+    @pytest.mark.asyncio
+    async def test_score_breakdown_has_minimum_factors(self, local_provider) -> None:
+        """score() returns at least 3 breakdown factors."""
+        resp = await local_provider.score("Engineer at Acme", {"name": "Test"})
+        assert len(resp.structured.score_breakdown) >= 3
+
+    @pytest.mark.asyncio
+    async def test_all_structured_features_return_data(self, local_provider) -> None:
+        """Every AIFeature (except complete and voice_*) returns structured data."""
+        skip_features = {
+            AIFeature.complete,
+            AIFeature.voice_cover_letter,
+            AIFeature.voice_coaching,
+            AIFeature.voice_job_evaluation,
+        }
+        for feature in AIFeature:
+            if feature in skip_features:
+                continue
+            resp = await local_provider.complete(f"Test {feature}", feature=feature)
+            assert resp.structured is not None, f"{feature} missing structured data"
+            assert resp.feature == feature
+
+    @pytest.mark.asyncio
+    async def test_complete_feature_returns_no_structured(self, local_provider) -> None:
+        """complete feature returns None for structured (unstructured text only)."""
+        resp = await local_provider.complete("hello", feature=AIFeature.complete)
+        assert resp.structured is None
+
+
+# ---------------------------------------------------------------------------
+# UAT: Provider contract via API — local providers
+# ---------------------------------------------------------------------------
+
+
+class TestProviderAPIContractUAT:
+    """API endpoints satisfy the provider contract for local providers."""
+
+    @pytest.mark.parametrize("provider_name", ["mock", "demo"])
+    def test_api_complete_200(self, client: TestClient, provider_name: str) -> None:
+        """POST /api/ai/complete returns 200 with valid response."""
+        with patch.dict(os.environ, {"AI_PROVIDER": provider_name}):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "hello", "feature": "complete"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provider"] == "mock"
+        assert data["content"]
+
+    @pytest.mark.parametrize("provider_name", ["mock", "demo"])
+    def test_api_score_structured(self, client: TestClient, provider_name: str) -> None:
+        """POST /api/ai/complete with score feature returns structured data."""
+        with patch.dict(os.environ, {"AI_PROVIDER": provider_name}):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "Score this job", "feature": "score"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["structured"] is not None
+        assert "fit_score" in data["structured"]
+        assert "reasoning" in data["structured"]
+        assert "score_breakdown" in data["structured"]
+
+    @pytest.mark.parametrize("provider_name", ["mock", "demo"])
+    def test_api_provider_endpoint(self, client: TestClient, provider_name: str) -> None:
+        """GET /api/ai/provider returns correct provider name."""
+        with patch.dict(os.environ, {"AI_PROVIDER": provider_name}):
+            resp = client.get("/api/ai/provider")
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "mock"
+
+    @pytest.mark.parametrize("provider_name", ["mock", "demo"])
+    def test_api_health_includes_provider(self, client: TestClient, provider_name: str) -> None:
+        """GET /api/ai/health lists the provider as reachable."""
+        with patch.dict(os.environ, {"AI_PROVIDER": provider_name}):
+            resp = client.get("/api/ai/health")
+        assert resp.status_code == 200
+        mock_p = next(p for p in resp.json()["providers"] if p["name"] == "mock")
+        assert mock_p["status"] == "reachable"
+
+
+# ---------------------------------------------------------------------------
+# UAT: Graceful degradation — external providers without credentials
+# ---------------------------------------------------------------------------
+
+
+class TestExternalProviderGracefulDegradation:
+    """Providers requiring external services fail gracefully without credentials."""
+
+    @pytest.mark.parametrize("name", ["openrouter"])
+    def test_missing_config_raises_not_crashes(self, name: str) -> None:
+        """Provider without config raises ValueError, not an unhandled exception."""
+        with patch.dict(os.environ, {f"{name.upper()}_API_KEY": ""}):
+            with pytest.raises((ValueError, UnsupportedProviderError)):
+                get_ai_provider(name)
+
+    @pytest.mark.parametrize("name", ["openrouter"])
+    def test_api_complete_returns_422_not_500(self, client: TestClient, name: str) -> None:
+        """API endpoint returns 422 config error, not 500 server error."""
+        env = {"AI_PROVIDER": name, f"{name.upper()}_API_KEY": ""}
+        with patch.dict(os.environ, env):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "test", "feature": "complete"},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize("name", ["openrouter"])
+    def test_api_provider_returns_422_not_500(self, client: TestClient, name: str) -> None:
+        """GET /api/ai/provider returns 422 config error, not 500."""
+        env = {"AI_PROVIDER": name, f"{name.upper()}_API_KEY": ""}
+        with patch.dict(os.environ, env):
+            resp = client.get("/api/ai/provider")
+        assert resp.status_code == 422
+
+    def test_unsupported_provider_raises_descriptive_error(self) -> None:
+        """Unsupported provider error includes provider name and available options."""
+        with pytest.raises(UnsupportedProviderError) as exc_info:
+            get_ai_provider("nonexistent")
+        msg = str(exc_info.value)
+        assert "nonexistent" in msg
+        assert "mock" in msg
+        assert "openrouter" in msg
+
+    def test_health_endpoint_never_crashes(self, client: TestClient) -> None:
+        """Health endpoint returns 200 even when providers are misconfigured."""
+        env = {
+            "AI_PROVIDER": "mock",
+            "OPENROUTER_API_KEY": "bad-key",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            resp = client.get("/api/ai/health")
+        assert resp.status_code == 200
+        providers = resp.json()["providers"]
+        # Mock should still be reachable regardless of other provider config
+        mock_p = next(p for p in providers if p["name"] == "mock")
+        assert mock_p["status"] == "reachable"

--- a/tests/test_registry_integration.py
+++ b/tests/test_registry_integration.py
@@ -1,0 +1,159 @@
+"""Integration tests: registry refactor preserves end-to-end behavior.
+
+Verifies that the factory → service → API chain works identically
+after the if-elif → dict registry migration.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from career_os.ai.factory import UnsupportedProviderError, get_ai_provider
+from career_os.ai.mock_provider import MockProvider
+
+
+@pytest.fixture(autouse=True)
+def _auto_db(db_session):
+    return db_session
+
+
+# ---------------------------------------------------------------------------
+# Factory → API chain
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryEndToEnd:
+    """Full-stack tests that the registry refactor is transparent."""
+
+    def test_complete_via_mock(self, client: TestClient) -> None:
+        """POST /api/ai/complete works for mock provider."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "mock"}):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "test", "feature": "complete"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "mock"
+
+    def test_complete_via_demo_alias(self, client: TestClient) -> None:
+        """POST /api/ai/complete with demo alias resolves to mock."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "demo"}):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "test", "feature": "complete"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "mock"
+
+    def test_provider_endpoint_mock(self, client: TestClient) -> None:
+        """GET /api/ai/provider works for mock."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "mock"}):
+            resp = client.get("/api/ai/provider")
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "mock"
+
+    def test_provider_endpoint_demo_alias(self, client: TestClient) -> None:
+        """GET /api/ai/provider with demo resolves to mock."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "demo"}):
+            resp = client.get("/api/ai/provider")
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "mock"
+
+    def test_health_endpoint_lists_providers(self, client: TestClient) -> None:
+        """GET /api/ai/health returns 200 and lists all providers."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "mock"}):
+            resp = client.get("/api/ai/health")
+        assert resp.status_code == 200
+        providers = resp.json()["providers"]
+        assert len(providers) >= 2
+        names = {p["name"] for p in providers}
+        assert "mock" in names
+        assert "openrouter" in names
+
+    def test_unsupported_provider_returns_422(self, client: TestClient) -> None:
+        """Unsupported provider name returns 422 from API, not 500."""
+        with patch.dict(os.environ, {"AI_PROVIDER": "nonexistent"}):
+            resp = client.post(
+                "/api/ai/complete",
+                json={"prompt": "test", "feature": "complete"},
+            )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Factory → service chain
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryServiceIntegration:
+    """Services that use get_ai_provider still work through the registry."""
+
+    def test_factory_default_is_mock(self) -> None:
+        """Default provider (no env var) is mock."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AI_PROVIDER", None)
+            provider = get_ai_provider()
+        assert isinstance(provider, MockProvider)
+
+    def test_factory_explicit_mock(self) -> None:
+        """get_ai_provider('mock') returns MockProvider."""
+        provider = get_ai_provider("mock")
+        assert isinstance(provider, MockProvider)
+
+    def test_factory_explicit_demo(self) -> None:
+        """get_ai_provider('demo') returns MockProvider."""
+        provider = get_ai_provider("demo")
+        assert isinstance(provider, MockProvider)
+
+    def test_factory_unsupported_raises(self) -> None:
+        """Unsupported provider raises UnsupportedProviderError."""
+        with pytest.raises(UnsupportedProviderError):
+            get_ai_provider("nonexistent")
+
+    def test_factory_case_insensitive(self) -> None:
+        """Provider names are case-insensitive."""
+        assert isinstance(get_ai_provider("Mock"), MockProvider)
+        assert isinstance(get_ai_provider("DEMO"), MockProvider)
+
+    def test_factory_whitespace_trimmed(self) -> None:
+        """Leading/trailing whitespace is trimmed."""
+        assert isinstance(get_ai_provider("  mock  "), MockProvider)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigValidation:
+    """Config validation uses the data-driven pattern."""
+
+    def test_config_rejects_openrouter_without_key(self) -> None:
+        """Settings validator rejects openrouter without API key."""
+        from career_os.config import Settings
+
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            Settings(ai_provider="openrouter", openrouter_api_key="")
+
+    def test_config_accepts_mock_without_keys(self) -> None:
+        """Settings validator accepts mock without any API keys."""
+        from career_os.config import Settings
+
+        s = Settings(ai_provider="mock")
+        assert s.ai_provider == "mock"
+
+    def test_config_accepts_demo_without_keys(self) -> None:
+        """Settings validator accepts demo without any API keys."""
+        from career_os.config import Settings
+
+        s = Settings(ai_provider="demo")
+        assert s.ai_provider == "demo"
+
+    def test_config_accepts_openrouter_with_key(self) -> None:
+        """Settings validator accepts openrouter with valid key."""
+        from career_os.config import Settings
+
+        s = Settings(ai_provider="openrouter", openrouter_api_key="sk-or-test123")
+        assert s.ai_provider == "openrouter"


### PR DESCRIPTION
## Summary

Migrate the AI provider factory from if-elif chains to a data-driven registry dictionary. This eliminates conditional logic duplication, makes adding new providers a single-entry operation, and improves testability and maintainability.

## Motivation

The current factory uses if-elif blocks to instantiate providers, requiring changes in multiple places (factory, config validation, health checks) when adding a new provider. A registry-based approach centralizes provider definitions and makes the codebase more scalable.

Fixes the pattern where provider support is hardcoded in multiple locations instead of derived from a single source of truth.

## Changes

- **`src/career_os/ai/factory.py`**: Replace if-elif logic with `_PROVIDER_REGISTRY` dict mapping provider names to factory callables. Derive `_SUPPORTED_PROVIDERS` from registry keys instead of hardcoding.
- **`src/career_os/config.py`**: Generalize API key validation using `_PROVIDER_KEY_REQUIREMENTS` dict instead of provider-specific if blocks. New providers only need one entry in this dict.
- **`src/career_os/services/ai_health.py`**: Import `_SUPPORTED_PROVIDERS` from factory instead of hardcoding, ensuring health checks always match factory capabilities.
- **`tests/test_ai_provider.py`**: Add unit tests for registry structure (keys match supported set, all entries callable, aliases work correctly).
- **`tests/test_registry_integration.py`**: New integration tests verifying factory→service→API chain works identically after refactor (end-to-end transparency).
- **`tests/test_provider_uat.py`**: New user acceptance tests ensuring every registered provider satisfies the AIProvider contract and handles missing credentials gracefully.

## Test Coverage

- Added 40+ new tests covering:
  - Registry structure and invariants
  - Factory behavior (defaults, aliases, case-insensitivity, whitespace handling)
  - Config validation with data-driven pattern
  - Provider contract compliance (all features return correct response types)
  - Graceful degradation (missing credentials return 422, not 500)
  - API endpoint integration with registry
  - Health endpoint derives provider list from registry

All existing tests pass; new tests verify the refactor is transparent to callers.

## Checklist

- [x] Tests added (40+ new tests in 3 test files)
- [x] No breaking changes to public APIs
- [x] Config validation generalized and tested
- [x] Health endpoint now derives from factory registry
- [x] No new secrets or API keys committed

https://claude.ai/code/session_01CXFfH2GbptyqgxeRgyKEFg