### PR TITLE
fix: update markdownify to >=1.2.2 to resolve CVE-2025-46656

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,6 @@ dev = [
     "pandas>=2.2.0",
     "python-jobspy>=1.1.0",
     "fpdf2>=2.8.0",
-    # Override python-jobspy's transitive pin of markdownify<0.14 — that
-    # range contains CVE-2025-46656. jobspy's tests pass with 0.14.x on
-    # the code paths kestrel exercises; we stay in the 0.14.x line to
-    # minimize API drift from the 0.13 baseline jobspy expects.
-    "markdownify>=0.14.1,<0.15",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dev = [
     "pandas>=2.2.0",
     "python-jobspy>=1.1.0",
     "fpdf2>=2.8.0",
+    # Override python-jobspy's transitive pin — resolve CVE-2025-46656.
+    "markdownify>=1.2.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Update `markdownify>=0.14.1,<0.15` to `markdownify>=1.2.2` in pyproject.toml
- python-jobspy still depends on markdownify transitively, so removing it entirely caused CI failures (pip-audit flagged the vulnerable transitive version)
- Pinning to `>=1.2.2` overrides jobspy's constraint with the patched version
- Resolves Dependabot alert #20 (CVE-2025-46656 — DoS via large headline prefixes)

Closes #129

## Verification
- [x] `pip install -e ".[dev]"` resolves markdownify 1.2.2
- [x] `pip-audit` clean (0 vulnerabilities)
- [x] 2337 tests pass, 0 failures
- [x] No code in src/ or tests/ imports markdownify directly