### PR TITLE
Lower minimum Python version requirement to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 | Component | Location | Stack | Dev Port |
 |-----------|----------|-------|----------|
-| Backend API | `src/career_os/` | Python 3.13, FastAPI, SQLAlchemy, SQLite | 8100 |
+| Backend API | `src/career_os/` | Python 3.11+, FastAPI, SQLAlchemy, SQLite | 8100 |
 | Web Frontend | `frontend/` | React 19, Vite, TypeScript, Tailwind CSS | 8101 |
 | Mobile App | `mobile/` | React Native 0.81, Expo 54, Tamagui 2.0 RC | Expo DevTools |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 # Stage 2: Python runtime — FastAPI + static frontend
 # ---------------------------------------------------------------------------
-FROM python:3.13-slim AS runtime
+FROM python:3.11-slim AS runtime
 
 # Prevent Python from writing .pyc files and enable unbuffered output
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pick whichever feels right. They all give you the same app.
 curl -fsSL https://raw.githubusercontent.com/pleasedodisturb/kestrel/main/install.sh | bash
 ```
 
-Detects your OS, checks for Python 3.12+, installs Kestrel, and opens it in your browser.
+Detects your OS, checks for Python 3.11+, installs Kestrel, and opens it in your browser.
 
 Or if you have Node.js:
 ```bash
@@ -54,7 +54,7 @@ kestrel start
 
 Opens your browser automatically. Data stored in `~/.kestrel/`.
 
-Requires Python 3.12+. Don't have Python? Install it from [python.org/downloads](https://www.python.org/downloads/) (Mac/Windows installer, takes 2 minutes). Or use Option 2 or 3 below instead.
+Requires Python 3.11+. Don't have Python? Install it from [python.org/downloads](https://www.python.org/downloads/) (Mac/Windows installer, takes 2 minutes). Or use Option 2 or 3 below instead.
 
 ### Option 2: Docker (isolated, nothing touches your system)
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -16,7 +16,7 @@ title: Features and API Reference
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Python-3.12+-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+">
+  <img src="https://img.shields.io/badge/Python-3.11+-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React 19">
   <img src="https://img.shields.io/badge/FastAPI-0.115+-009688?style=flat-square&logo=fastapi&logoColor=white" alt="FastAPI">
   <img src="https://img.shields.io/badge/SQLite-3-003B57?style=flat-square&logo=sqlite&logoColor=white" alt="SQLite">

--- a/docs/ux-persona-testing.md
+++ b/docs/ux-persona-testing.md
@@ -65,7 +65,7 @@ Someone posted on r/jobsearchhacks: "I built an open-source tool that scores job
 ### Step 1: Landing on the GitHub Repository
 
 **What Alex sees:**
-A page that looks like... a document? There's a green button that says "Code," a bunch of folders with weird names like `src/` and `alembic/`, some colored badges that say "Python 3.13+" and "Docker Ready." The main content is a formatted document (the README).
+A page that looks like... a document? There's a green button that says "Code," a bunch of folders with weird names like `src/` and `alembic/`, some colored badges that say "Python 3.11+" and "Docker Ready." The main content is a formatted document (the README).
 
 **What Alex thinks:**
 "Okay this looks like a developer website. I see a logo and description - 'A self-hosted job search platform. Precision over volume.' That sounds cool. But what is all this other stuff? Why are there folders? Is this the app? Where do I click to start?"

--- a/homebrew/kestrel.rb
+++ b/homebrew/kestrel.rb
@@ -8,7 +8,7 @@ class Kestrel < Formula
   license "MIT"
   head "https://github.com/pleasedodisturb/kestrel.git", branch: "main"
 
-  depends_on "python@3.13"
+  depends_on "python@3.11"
 
   def install
     virtualenv_install_with_resources

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/pleasedodisturb/kestrel/main/install.sh | bash
 
 KESTREL_VENV="$HOME/.kestrel/venv"
-KESTREL_MIN_PYTHON="3.12"
+KESTREL_MIN_PYTHON="3.11"
 
 # ──────────────────────────────────────────────
 
@@ -111,7 +111,7 @@ else
         Darwin)
             if command_exists brew; then
                 echo "  Install with Homebrew:"
-                echo "    brew install python@3.12"
+                echo "    brew install python@3.11"
                 echo ""
                 echo "  Then run this installer again."
             else
@@ -119,7 +119,7 @@ else
                 echo "    https://www.python.org/downloads/"
                 echo ""
                 echo "  Or install Homebrew first (https://brew.sh), then:"
-                echo "    brew install python@3.12"
+                echo "    brew install python@3.11"
             fi
             ;;
         Linux)
@@ -127,12 +127,12 @@ else
                 echo "  Install on Ubuntu/Debian:"
                 echo "    sudo add-apt-repository ppa:deadsnakes/ppa"
                 echo "    sudo apt-get update"
-                echo "    sudo apt-get install python3.12 python3.12-venv"
+                echo "    sudo apt-get install python3.11 python3.11-venv"
                 echo ""
                 echo "  Then run this installer again."
             elif command_exists dnf; then
                 echo "  Install on Fedora/RHEL:"
-                echo "    sudo dnf install python3.12"
+                echo "    sudo dnf install python3.11"
                 echo ""
                 echo "  Then run this installer again."
             elif command_exists pacman; then

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -10,7 +10,7 @@ npx kestrel-app
 
 This will:
 
-1. Check for Python 3.13+ (required)
+1. Check for Python 3.11+ (required)
 2. Install Kestrel via pip/pipx
 3. Launch the web interface in your browser
 
@@ -24,7 +24,7 @@ Kestrel discovers jobs, scores them with AI, tracks your pipeline, and preps you
 # curl one-liner
 curl -fsSL https://raw.githubusercontent.com/pleasedodisturb/kestrel/main/install.sh | bash
 
-# pip (if you have Python 3.13+)
+# pip (if you have Python 3.11+)
 pip install kestrel-app && kestrel start
 
 # Homebrew (macOS)

--- a/npm-package/index.js
+++ b/npm-package/index.js
@@ -8,7 +8,7 @@
 const { execSync, spawn } = require("child_process");
 const os = require("os");
 
-const MIN_PYTHON = [3, 13];
+const MIN_PYTHON = [3, 11];
 
 // ── Helpers ──
 
@@ -68,17 +68,17 @@ function printPythonHelp() {
   const platform = os.platform();
   if (platform === "darwin") {
     print("  Install with Homebrew:");
-    print("    brew install python@3.13");
+    print("    brew install python@3.11");
     print("");
     print("  Or download from: https://www.python.org/downloads/");
   } else if (platform === "linux") {
     print("  On Ubuntu/Debian:");
     print("    sudo add-apt-repository ppa:deadsnakes/ppa");
     print("    sudo apt-get update");
-    print("    sudo apt-get install python3.13 python3.13-venv");
+    print("    sudo apt-get install python3.11 python3.11-venv");
     print("");
     print("  On Fedora:");
-    print("    sudo dnf install python3.13");
+    print("    sudo dnf install python3.11");
     print("");
     print("  Or download from: https://www.python.org/downloads/");
   } else {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "AI-powered job search platform. Self-hosted, open-source, privacy
 readme = "README.md"
 license = {text = "MIT"}
 authors = [{name = "Kestrel Contributors"}]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
@@ -63,7 +63,7 @@ career_os = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 100
 src = ["src", "tests"]
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,6 +23,8 @@ sonar.exclusions=\
   **/*.min.css,\
   tools/**
 
+sonar.python.version=3.11
+
 sonar.test.inclusions=tests/**,frontend/src/__tests__/**
 
 # Treat `config/personal.yaml.example` as a template, not real config.


### PR DESCRIPTION
## Summary

Lowers the minimum Python version requirement from 3.12/3.13 to 3.11 across all installation methods and documentation.

## Motivation

Broadens compatibility and accessibility by supporting Python 3.11, making Kestrel installable on more systems and reducing friction for users who haven't upgraded to the latest Python versions yet.

## Changes

- Updated `pyproject.toml` to require Python 3.11+ (was 3.12+)
- Updated Ruff target version to `py311` (was `py312`)
- Updated CI matrix to test against Python 3.11, 3.12, and 3.13
- Updated `install.sh` to check for and document Python 3.11+ installation instructions for macOS (Homebrew), Ubuntu/Debian, and Fedora
- Updated `npm-package/index.js` to check for Python 3.11+ (was 3.13+)
- Updated npm package README to reflect Python 3.11+ requirement
- Updated main README to reflect Python 3.11+ requirement
- Updated Dockerfile to use `python:3.11-slim` base image (was 3.13)
- Updated Homebrew formula to depend on `python@3.11` (was 3.13)
- Updated documentation badges and references to show Python 3.11+
- Added `sonar.python.version=3.11` to SonarQube configuration

## Checklist

- [x] No tests needed (configuration and documentation changes only)
- [x] Docs updated (README, installation scripts, badges)
- [x] No breaking changes (backwards compatible, only expands support)

https://claude.ai/code/session_01EZUE1L9Vu6Wav8P34RodP7