### PR TITLE
fix: G-265 re-add BMAD/GSD gitignore entries dropped during merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,12 @@ htmlcov/
 frontend/coverage/
 lcov.info
 
+# BMAD output artifacts (branch-specific, not infrastructure)
+_bmad-output/
+
+# GSD state (per-session, not infrastructure)
+.planning/
+GSD-CLAUDE.md
+
 # Internal business docs
 docs/pricing-strategy.md


### PR DESCRIPTION
## Summary

- Re-add `_bmad-output/`, `.planning/`, and `GSD-CLAUDE.md` to `.gitignore`
- These entries were lost when PR #162 was squash-merged (conflict resolution kept only the coverage entries from main)

One-line fix, same ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)