### PR TITLE
chore: enforce conventional commits and improve CI reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
+        continue-on-error: true  # Informational — don't block CI on scan failures
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Database (database.py, config.py)   → SQLite (WAL mode), async via aiosqlite
 ## Workflow Rules
 
 ### Commits
-- **Every commit references a Linear ticket** — prefix title with ticket ID (e.g., `G-97: add onboarding flow`)
+- **Every commit uses conventional commit format** — `type(scope): description` where the scope includes the Linear ticket ID (e.g., `feat(G-97): add onboarding flow`, `fix(G-265): re-add gitignore entries`). Valid types: `feat`, `fix`, `chore`, `ci`, `deps`, `docs`, `build`, `perf`, `refactor`, `revert`, `style`, `test`.
 - **Commit messages must have a body** — title + blank line + explanation of what changed and why
 - **Commit after every logical unit of work** — don't batch unrelated changes
 - **Push after committing on non-main branches** — work happens across multiple machines/sessions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.25.0",
     "pytest-cov>=6.1.0",
+    "pytest-timeout>=2.3.0",
     "ruff>=0.11.0",
     "httpx>=0.28.0",
     # pandas 3.0 evaluation (G-251): blocked by python-jobspy which pins
@@ -89,3 +90,4 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+timeout = 30


### PR DESCRIPTION
## Summary

Updates commit message conventions to use the conventional commit format with Linear ticket IDs in the scope, adds pytest timeout configuration to prevent hanging tests, and makes SonarCloud scan failures non-blocking in CI.

## Motivation

- Standardize on conventional commit format for better tooling compatibility and clearer commit history
- Prevent test suites from hanging indefinitely by enforcing a 30-second timeout
- Allow CI to complete even if SonarCloud scan fails, since it's informational

## Changes

- **CLAUDE.md**: Updated commit message convention from `G-97: description` to `type(scope): description` format (e.g., `feat(G-97): add onboarding flow`), with documented valid types
- **pyproject.toml**: Added `pytest-timeout>=2.3.0` dev dependency and configured 30-second test timeout in pytest options
- **.github/workflows/ci.yml**: Made SonarCloud scan step non-blocking with `continue-on-error: true` and explanatory comment

## Checklist

- [x] No code changes requiring tests
- [x] Documentation updated (CLAUDE.md)
- [x] No breaking changes
- [x] No new secrets or sensitive data

https://claude.ai/code/session_013P5vgBRzTWfwj2ViPXXCwJ