### PR TITLE
fix(G-266): resolve 28 new-code SonarCloud blocker/critical issues

### DIFF
--- a/frontend/src/api/discovery.ts
+++ b/frontend/src/api/discovery.ts
@@ -42,21 +42,28 @@ export async function searchJobs(
 ): Promise<JobSearchResponse> {
   const searchParams = new URLSearchParams();
   searchParams.set("profile_id", String(params.profile_id));
-  if (params.q) searchParams.set("q", params.q);
-  if (params.source) searchParams.set("source", params.source);
-  if (params.remote != null) searchParams.set("remote", String(params.remote));
-  if (params.salary_min != null) searchParams.set("salary_min", String(params.salary_min));
-  if (params.salary_max != null) searchParams.set("salary_max", String(params.salary_max));
-  if (params.score_min != null) searchParams.set("score_min", String(params.score_min));
-  if (params.score_max != null) searchParams.set("score_max", String(params.score_max));
-  if (params.date_from) searchParams.set("date_from", params.date_from);
-  if (params.date_to) searchParams.set("date_to", params.date_to);
-  if (params.company) searchParams.set("company", params.company);
-  if (params.location) searchParams.set("location", params.location);
-  if (params.sort) searchParams.set("sort", params.sort);
-  if (params.order) searchParams.set("order", params.order);
-  if (params.page != null) searchParams.set("page", String(params.page));
-  if (params.page_size != null) searchParams.set("page_size", String(params.page_size));
+
+  const optionalParams: [string, string | number | boolean | null | undefined][] = [
+    ["q", params.q],
+    ["source", params.source],
+    ["remote", params.remote],
+    ["salary_min", params.salary_min],
+    ["salary_max", params.salary_max],
+    ["score_min", params.score_min],
+    ["score_max", params.score_max],
+    ["date_from", params.date_from],
+    ["date_to", params.date_to],
+    ["company", params.company],
+    ["location", params.location],
+    ["sort", params.sort],
+    ["order", params.order],
+    ["page", params.page],
+    ["page_size", params.page_size],
+  ];
+
+  for (const [key, value] of optionalParams) {
+    if (value != null) searchParams.set(key, String(value));
+  }
 
   const resp = await fetch(`${JOBS_API}?${searchParams}`);
   if (!resp.ok) throw new Error(`Failed to search jobs: ${resp.status}`);

--- a/frontend/src/pages/ApplicationDetail.tsx
+++ b/frontend/src/pages/ApplicationDetail.tsx
@@ -37,6 +37,59 @@ import { InterviewPrepSection } from "@/components/InterviewPrepSection";
 import { StarStoriesSection } from "@/components/StarStoriesSection";
 import { getApplicationScore } from "@/api/scoring";
 
+type ApplicationData = {
+  company: string;
+  role: string;
+  url: string | null;
+  source: string | null;
+  salary_range: string | null;
+  contact: string | null;
+  next_step: string | null;
+  notes: string | null;
+  fit_score: number | null;
+};
+
+function buildEditData(data: ApplicationData): ApplicationUpdate {
+  return {
+    company: data.company,
+    role: data.role,
+    url: data.url ?? "",
+    source: data.source ?? "",
+    salary_range: data.salary_range ?? "",
+    contact: data.contact ?? "",
+    next_step: data.next_step ?? "",
+    notes: data.notes ?? "",
+    fit_score: data.fit_score ?? undefined,
+  };
+}
+
+function computeChanges(
+  editData: ApplicationUpdate,
+  data: ApplicationData,
+): ApplicationUpdate {
+  const changes: ApplicationUpdate = {};
+  if (editData.company !== data.company) changes.company = editData.company;
+  if (editData.role !== data.role) changes.role = editData.role;
+
+  const nullableFields = [
+    "url",
+    "source",
+    "salary_range",
+    "contact",
+    "next_step",
+    "notes",
+  ] as const;
+  for (const field of nullableFields) {
+    if ((editData[field] ?? "") !== (data[field] ?? "")) {
+      changes[field] = editData[field];
+    }
+  }
+
+  if (editData.fit_score !== data.fit_score)
+    changes.fit_score = editData.fit_score;
+  return changes;
+}
+
 export function ApplicationDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -82,40 +135,13 @@ export function ApplicationDetail() {
   useEffect(() => {
     if (!data) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: sync server data to form state
-    setEditData({
-      company: data.company,
-      role: data.role,
-      url: data.url ?? "",
-      source: data.source ?? "",
-      salary_range: data.salary_range ?? "",
-      contact: data.contact ?? "",
-      next_step: data.next_step ?? "",
-      notes: data.notes ?? "",
-      fit_score: data.fit_score ?? undefined,
-    });
+    setEditData(buildEditData(data));
   }, [data]);
 
   const handleSave = useCallback(() => {
     if (!data) return;
 
-    // Only send fields that actually changed
-    const changes: ApplicationUpdate = {};
-    if (editData.company !== data.company) changes.company = editData.company;
-    if (editData.role !== data.role) changes.role = editData.role;
-    if ((editData.url ?? "") !== (data.url ?? ""))
-      changes.url = editData.url;
-    if ((editData.source ?? "") !== (data.source ?? ""))
-      changes.source = editData.source;
-    if ((editData.salary_range ?? "") !== (data.salary_range ?? ""))
-      changes.salary_range = editData.salary_range;
-    if ((editData.contact ?? "") !== (data.contact ?? ""))
-      changes.contact = editData.contact;
-    if ((editData.next_step ?? "") !== (data.next_step ?? ""))
-      changes.next_step = editData.next_step;
-    if ((editData.notes ?? "") !== (data.notes ?? ""))
-      changes.notes = editData.notes;
-    if (editData.fit_score !== data.fit_score)
-      changes.fit_score = editData.fit_score;
+    const changes = computeChanges(editData, data);
 
     if (Object.keys(changes).length === 0) {
       setIsEditing(false);
@@ -230,19 +256,8 @@ export function ApplicationDetail() {
                 data-testid="cancel-edit-button"
                 onClick={() => {
                   setIsEditing(false);
-                  // Reset edit data
                   if (data) {
-                    setEditData({
-                      company: data.company,
-                      role: data.role,
-                      url: data.url ?? "",
-                      source: data.source ?? "",
-                      salary_range: data.salary_range ?? "",
-                      contact: data.contact ?? "",
-                      next_step: data.next_step ?? "",
-                      notes: data.notes ?? "",
-                      fit_score: data.fit_score ?? undefined,
-                    });
+                    setEditData(buildEditData(data));
                   }
                 }}
                 className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"

--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -24,6 +24,9 @@ from career_os.schemas.ai import (
     ScoreResult,
 )
 
+_PROGRAM_MANAGEMENT = "program management"
+_SYSTEM_DESIGN = "System Design"
+
 # Static pool of 12 keywords used by the mock provider to build a deterministic
 # ATS checklist. Distinct categories so the UI checklist has variety to show.
 _MOCK_ATS_KEYWORDS: tuple[tuple[str, str], ...] = (
@@ -530,8 +533,8 @@ def _build_topic_pool(
     _add_gap_or_keyword_topics(topic_pool, gap_data, unresolved_gaps, prompt_lower)
 
     role_lower = role.lower()
-    if ("program management" in prompt_lower or "tpm" in role_lower) and (
-        not gap_data or "program management" in unresolved_skill_names
+    if (_PROGRAM_MANAGEMENT in prompt_lower or "tpm" in role_lower) and (
+        not gap_data or _PROGRAM_MANAGEMENT in unresolved_skill_names
     ):
         topic_pool.append(
             {
@@ -658,7 +661,7 @@ def _build_mock_questions(
                     "difficulty": "high",
                 }
             )
-        if "program management" in prompt_lower:
+        if _PROGRAM_MANAGEMENT in prompt_lower:
             questions.append(
                 {
                     "question": (
@@ -1312,7 +1315,7 @@ def _handle_interview_format(prompt: str, context: dict | None) -> AIResponse:
         "Phone Screen",
         "Technical Interview",
         "Behavioral Interview",
-        "System Design",
+        _SYSTEM_DESIGN,
         "Hiring Manager",
         "Panel Interview",
         "Take-Home Assignment",
@@ -1432,7 +1435,7 @@ def _handle_interview_patterns(prompt: str, context: dict | None) -> AIResponse:
                 "Risk Management",
                 "Technical Communication",
                 "Cross-functional Leadership",
-                "System Design",
+                _SYSTEM_DESIGN,
             ],
         )
     elif "product engineer" in prompt_lower:
@@ -1447,7 +1450,7 @@ def _handle_interview_patterns(prompt: str, context: dict | None) -> AIResponse:
                     ],
                 },
                 {
-                    "name": "System Design",
+                    "name": _SYSTEM_DESIGN,
                     "description": "Large-scale system architecture discussions.",
                     "example_questions": [
                         "Design a real-time collaboration feature like Google Docs.",
@@ -1498,7 +1501,7 @@ def _handle_interview_patterns(prompt: str, context: dict | None) -> AIResponse:
             frequently_tested_skills=[
                 "JavaScript/TypeScript",
                 "React",
-                "System Design",
+                _SYSTEM_DESIGN,
                 "API Design",
                 "Database Design",
                 "Product Thinking",

--- a/src/career_os/cli/contacts.py
+++ b/src/career_os/cli/contacts.py
@@ -41,6 +41,7 @@ contacts_app = typer.Typer(
 )
 
 DEFAULT_PROFILE_ID = 1
+_HELP_CONTACT_ID = "Contact ID"
 
 
 @contacts_app.command("add")
@@ -181,7 +182,7 @@ def _build_contact_info(contact) -> str:  # noqa: ANN001
 
 @contacts_app.command("show")
 def show(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     profile_id: int = typer.Option(DEFAULT_PROFILE_ID, "--profile-id", hidden=True),
 ) -> None:
     """Show contact details."""
@@ -199,7 +200,7 @@ def show(
 
 @contacts_app.command("update")
 def update_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     name: str | None = typer.Option(None, "--name"),
     company: str | None = typer.Option(None, "--company"),
     role: str | None = typer.Option(None, "--role"),
@@ -244,7 +245,7 @@ def update_cmd(
 
 @contacts_app.command("archive")
 def archive_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     profile_id: int = typer.Option(DEFAULT_PROFILE_ID, "--profile-id", hidden=True),
 ) -> None:
     """Archive (soft-delete) a contact."""
@@ -261,7 +262,7 @@ def archive_cmd(
 
 @contacts_app.command("log")
 def log_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     type_: str = typer.Option(
         ...,
         "--type",
@@ -298,7 +299,7 @@ def log_cmd(
 
 @contacts_app.command("history")
 def history_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     profile_id: int = typer.Option(DEFAULT_PROFILE_ID, "--profile-id", hidden=True),
 ) -> None:
     """Show interaction history for a contact."""
@@ -335,7 +336,7 @@ def history_cmd(
 
 @contacts_app.command("link")
 def link_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     application_id: int = typer.Argument(..., help="Application ID"),
     role: str = typer.Option(
         "referrer",
@@ -368,7 +369,7 @@ def link_cmd(
 
 @contacts_app.command("unlink")
 def unlink_cmd(
-    contact_id: int = typer.Argument(..., help="Contact ID"),
+    contact_id: int = typer.Argument(..., help=_HELP_CONTACT_ID),
     application_id: int = typer.Argument(..., help="Application ID"),
 ) -> None:
     """Unlink a contact from an application."""

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -25,6 +25,8 @@ from career_os.schemas.applications import ApplicationStatus, is_valid_transitio
 
 console = Console()
 
+_HELP_OUTPUT_FORMAT = "Output format: table or json"
+
 app = typer.Typer(
     name="career",
     help="Career OS — AI-Powered Job Search & Career Strategy Platform",
@@ -1018,7 +1020,7 @@ def discover(
         "table",
         "--output",
         "-o",
-        help="Output format: table or json",
+        help=_HELP_OUTPUT_FORMAT,
     ),
 ) -> None:
     """Run a job discovery sweep or configure scheduled runs."""
@@ -1260,7 +1262,7 @@ def score(
         "table",
         "--output",
         "-o",
-        help="Output format: table or json",
+        help=_HELP_OUTPUT_FORMAT,
     ),
 ) -> None:
     """Score a single job posting against your profile."""
@@ -1439,7 +1441,7 @@ def market(
         "table",
         "--output",
         "-o",
-        help="Output format: table or json",
+        help=_HELP_OUTPUT_FORMAT,
     ),
 ) -> None:
     """Show market intelligence summary (salary trends, skills, hiring, positioning)."""

--- a/src/career_os/migration/link_packages.py
+++ b/src/career_os/migration/link_packages.py
@@ -15,14 +15,16 @@ logger = logging.getLogger(__name__)
 
 # Mapping from package directory names to (company_substring, role_substring) patterns
 # These map the 14 known package directories to their CSV counterparts
+_MISTRAL_AI = "Mistral AI"
+
 PACKAGE_MAPPINGS: dict[str, tuple[str, str]] = {
     "ashby-sr-swe-product-eng": ("Ashby", "Senior Software Engineer"),
     "attio-product-engineer": ("Attio", "Product Engineer"),
     "deepl-sr-technical-pm-ai": ("DeepL", "Senior Technical Product Manager"),
     "jetbrains-pm-bonsai": ("JetBrains", "Product Manager for Bonsai"),
-    "mistral-ai-deployment-strategist": ("Mistral AI", "AI Deployment Strategist"),
-    "mistral-tpm-engineering": ("Mistral AI", "Technical Program Manager - Engineering"),
-    "mistral-tpm-science-ops": ("Mistral AI", "Technical Program Manager - Science"),
+    "mistral-ai-deployment-strategist": (_MISTRAL_AI, "AI Deployment Strategist"),
+    "mistral-tpm-engineering": (_MISTRAL_AI, "Technical Program Manager - Engineering"),
+    "mistral-tpm-science-ops": (_MISTRAL_AI, "Technical Program Manager - Science"),
     "mongodb-technical-project-manager": ("MongoDB", "Technical Project Manager"),
     "n8n-sr-developer-advocate": ("n8n", "Senior Developer Advocate"),
     "oxide-computer": ("Oxide Computer", ""),

--- a/src/career_os/models/contacts.py
+++ b/src/career_os/models/contacts.py
@@ -6,7 +6,7 @@ from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from career_os.database import Base
-from career_os.models.models import _utcnow
+from career_os.models.models import CASCADE_ALL_DELETE_ORPHAN, FK_PROFILES_ID, _utcnow
 
 
 class Contact(Base):
@@ -16,7 +16,7 @@ class Contact(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     company: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -45,10 +45,10 @@ class Contact(Base):
     # Relationships
     profile: Mapped["Profile"] = relationship()  # noqa: F821
     interactions: Mapped[list["ContactInteraction"]] = relationship(
-        back_populates="contact", cascade="all, delete-orphan"
+        back_populates="contact", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     contact_applications: Mapped[list["ContactApplication"]] = relationship(
-        back_populates="contact", cascade="all, delete-orphan"
+        back_populates="contact", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
 
     def __repr__(self) -> str:
@@ -68,7 +68,7 @@ class ContactInteraction(Base):
         index=True,
     )
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     interaction_type: Mapped[str] = mapped_column(String(50), nullable=False)
     direction: Mapped[str] = mapped_column(String(20), nullable=False)
@@ -107,7 +107,7 @@ class ContactApplication(Base):
         index=True,
     )
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     role: Mapped[str] = mapped_column(String(50), nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/career_os/models/discovery.py
+++ b/src/career_os/models/discovery.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column
 
 from career_os.database import Base
+from career_os.models.models import FK_PROFILES_ID
 
 
 def _utcnow() -> datetime:
@@ -43,7 +44,7 @@ class DiscoveredJob(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
 
     # Raw fields from scraping
@@ -92,7 +93,7 @@ class SearchProfile(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     keywords: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON array
@@ -125,7 +126,7 @@ class DiscoveryRun(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     search_profile_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("search_profiles.id", ondelete="SET NULL"), nullable=True
@@ -161,7 +162,7 @@ class SavedSearch(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     # All filter state stored as JSON for flexibility

--- a/src/career_os/models/models.py
+++ b/src/career_os/models/models.py
@@ -14,6 +14,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from career_os.database import Base
 
+FK_PROFILES_ID = "profiles.id"
+FK_APPLICATIONS_ID = "applications.id"
+CASCADE_ALL_DELETE_ORPHAN = "all, delete-orphan"
+
 
 def _utcnow() -> datetime:
     """Return timezone-aware UTC now."""
@@ -43,32 +47,32 @@ class Profile(Base):
 
     # Relationships — M1 tables
     applications: Mapped[list["Application"]] = relationship(
-        back_populates="profile", cascade="all, delete-orphan"
+        back_populates="profile", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(
-        back_populates="profile", cascade="all, delete-orphan"
+        back_populates="profile", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     follow_ups: Mapped[list["FollowUp"]] = relationship(
-        back_populates="profile", cascade="all, delete-orphan"
+        back_populates="profile", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
 
     # Relationships — M2 tables (Skills Intelligence)
     # These forward-reference models defined in career_os.models.skills
     skills: Mapped[list["Skill"]] = relationship(  # noqa: F821
-        cascade="all, delete-orphan"
+        cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     goals: Mapped[list["Goal"]] = relationship(  # noqa: F821
-        cascade="all, delete-orphan"
+        cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     coaching_suggestions: Mapped[list["CoachingSuggestion"]] = relationship(  # noqa: F821
-        cascade="all, delete-orphan"
+        cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     # Note: skill_history cascades through Skill.history,
     # job_requirements cascade through Application.job_requirements,
     # learning_resources cascade through Profile (below) and also
     # via Skill/JobRequirement for FK ordering.
     learning_resources: Mapped[list["LearningResource"]] = relationship(  # noqa: F821
-        cascade="all, delete-orphan"
+        cascade=CASCADE_ALL_DELETE_ORPHAN
     )
 
     def __repr__(self) -> str:
@@ -82,7 +86,7 @@ class Application(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     company: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[str] = mapped_column(String(500), nullable=False)
@@ -106,17 +110,17 @@ class Application(Base):
     # Relationships
     profile: Mapped["Profile"] = relationship(back_populates="applications")
     activity_logs: Mapped[list["ActivityLog"]] = relationship(
-        back_populates="application", cascade="all, delete-orphan"
+        back_populates="application", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     follow_ups: Mapped[list["FollowUp"]] = relationship(
-        back_populates="application", cascade="all, delete-orphan"
+        back_populates="application", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     packages: Mapped[list["ApplicationPackage"]] = relationship(
-        back_populates="application", cascade="all, delete-orphan"
+        back_populates="application", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
     # M2: job requirements parsed from this application's JD
     job_requirements: Mapped[list["JobRequirement"]] = relationship(  # noqa: F821
-        cascade="all, delete-orphan"
+        cascade=CASCADE_ALL_DELETE_ORPHAN
     )
 
     def __repr__(self) -> str:
@@ -134,10 +138,10 @@ class ActivityLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     application_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("applications.id"), nullable=True, index=True
+        Integer, ForeignKey(FK_APPLICATIONS_ID), nullable=True, index=True
     )
     action: Mapped[str] = mapped_column(String(100), nullable=False)
     details: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -169,10 +173,10 @@ class FollowUp(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     application_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("applications.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_APPLICATIONS_ID), nullable=False, index=True
     )
     due_date: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     follow_up_type: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -197,10 +201,10 @@ class ApplicationPackage(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     application_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("applications.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_APPLICATIONS_ID), nullable=False, index=True
     )
     package_dir: Mapped[str] = mapped_column(Text, nullable=False)
     cover_letter_path: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/career_os/models/skills.py
+++ b/src/career_os/models/skills.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from career_os.database import Base
+from career_os.models.models import CASCADE_ALL_DELETE_ORPHAN, FK_PROFILES_ID
 
 
 def _utcnow() -> datetime:
@@ -27,7 +28,7 @@ class Skill(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     category: Mapped[str] = mapped_column(
@@ -49,7 +50,7 @@ class Skill(Base):
 
     # Relationships
     history: Mapped[list["SkillHistory"]] = relationship(
-        back_populates="skill", cascade="all, delete-orphan"
+        back_populates="skill", cascade=CASCADE_ALL_DELETE_ORPHAN
     )
 
     def __repr__(self) -> str:
@@ -66,7 +67,7 @@ class SkillHistory(Base):
         Integer, ForeignKey("skills.id"), nullable=False, index=True
     )
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     previous_proficiency: Mapped[str | None] = mapped_column(String(50), nullable=True)
     new_proficiency: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -92,7 +93,7 @@ class LearningResource(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     skill_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("skills.id"), nullable=True, index=True
@@ -131,7 +132,7 @@ class Goal(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     title: Mapped[str] = mapped_column(String(500), nullable=False)
     goal_type: Mapped[str] = mapped_column(String(50), nullable=False)  # realistic, aspirational
@@ -161,7 +162,7 @@ class JobRequirement(Base):
         Integer, ForeignKey("applications.id"), nullable=False, index=True
     )
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     skill_name: Mapped[str] = mapped_column(String(255), nullable=False)
     required_level: Mapped[str] = mapped_column(
@@ -187,7 +188,7 @@ class CoachingSuggestion(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     profile_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+        Integer, ForeignKey(FK_PROFILES_ID), nullable=False, index=True
     )
     action: Mapped[str] = mapped_column(Text, nullable=False)
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/src/career_os/services/ai_health.py
+++ b/src/career_os/services/ai_health.py
@@ -55,7 +55,7 @@ async def _check_mock() -> ProviderHealthStatus:
     """Mock provider is always reachable."""
     return ProviderHealthStatus(
         name="mock",
-        display_name="Demo Mode",
+        display_name=_PROVIDER_DISPLAY_NAMES["mock"],
         status="reachable",
         is_default=False,
         error_message=None,
@@ -326,7 +326,7 @@ async def check_all_providers(db: Session | None = None) -> AIHealthResponse:
     except Exception as exc:
         status = ProviderHealthStatus(
             name="mock",
-            display_name="Demo Mode",
+            display_name=_PROVIDER_DISPLAY_NAMES["mock"],
             status="error",
             error_message=str(exc),
         )

--- a/src/career_os/services/discovery.py
+++ b/src/career_os/services/discovery.py
@@ -392,6 +392,22 @@ def _collect_unique(items: list, existing: list) -> list:
     return existing
 
 
+def _pick_earliest(current: datetime | None, candidate: datetime | None) -> datetime | None:
+    """Return the earliest of two optional datetimes."""
+    if candidate is None:
+        return current
+    if current is None:
+        return candidate
+    return min(current, candidate)
+
+
+def _pick_longest(current: str, candidate: str | None) -> str:
+    """Return the longer of two strings, preferring non-empty."""
+    if candidate and len(candidate) > len(current):
+        return candidate
+    return current
+
+
 def _merge_raw_jobs(group: list[RawJobResult]) -> dict:
     """Merge multiple raw jobs (same dedup key) keeping richest data."""
     sources: list[str] = []
@@ -405,14 +421,11 @@ def _merge_raw_jobs(group: list[RawJobResult]) -> dict:
     for job in group:
         _collect_unique([job.source], sources)
         _collect_unique([job.url], source_urls)
-        if len(job.description or "") > len(best_description):
-            best_description = job.description or ""
+        best_description = _pick_longest(best_description, job.description)
         if not best_url and job.url:
             best_url = job.url
-        if job.posted_at and (earliest_posted is None or job.posted_at < earliest_posted):
-            earliest_posted = job.posted_at
-        if job.salary_range and len(job.salary_range) > len(salary_range):
-            salary_range = job.salary_range
+        earliest_posted = _pick_earliest(earliest_posted, job.posted_at)
+        salary_range = _pick_longest(salary_range, job.salary_range)
         remote = remote or job.remote
 
     first = group[0]

--- a/src/career_os/services/pushover.py
+++ b/src/career_os/services/pushover.py
@@ -34,6 +34,8 @@ from career_os.services.pushover_client import (
 
 logger = logging.getLogger(__name__)
 
+_URL_TITLE_VIEW_APPLICATION = "View Application"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -426,7 +428,7 @@ def trigger_follow_up_reminders(db: Session, profile_id: int) -> dict:
             message=message,
             application_id=fu.application_id,
             url=f"http://localhost:8101/applications/{fu.application_id}",
-            url_title="View Application",
+            url_title=_URL_TITLE_VIEW_APPLICATION,
         )
 
         if send_result["status"] in ("sent", "queued"):
@@ -527,7 +529,7 @@ def _send_ghost_notification(
         message=message,
         application_id=app_obj.id,
         url=url,
-        url_title="View Application",
+        url_title=_URL_TITLE_VIEW_APPLICATION,
         priority=PRIORITY_HIGH,
     )
 
@@ -786,7 +788,7 @@ def _process_interview_event(
         if event.application_id
         else None
     )
-    url_title = "Join Interview" if event.meeting_link else "View Application"
+    url_title = "Join Interview" if event.meeting_link else _URL_TITLE_VIEW_APPLICATION
 
     return _send_or_queue_notification(
         db,

--- a/src/career_os/services/role_intelligence.py
+++ b/src/career_os/services/role_intelligence.py
@@ -37,6 +37,14 @@ from career_os.services.salary import parse_salary_range
 
 logger = logging.getLogger(__name__)
 
+_ROLE_PROGRAM_MANAGER = "program manager"
+_ROLE_PRODUCT_ENGINEER = "product engineer"
+_ROLE_PRODUCT_MANAGER = "product manager"
+_ROLE_TPM = "technical program manager"
+_ROLE_SOFTWARE_ENGINEER = "software engineer"
+_ROLE_DEVELOPER_ADVOCATE = "developer advocate"
+_ROLE_DEVELOPER_RELATIONS = "developer relations"
+
 
 def _sanitize_for_log(value: object, max_length: int = 200) -> str:
     """Sanitize user-controlled data before logging to prevent log injection."""
@@ -74,15 +82,15 @@ def _normalize_role_type(title: str) -> str:
 
     if "tpm" in title_lower or "technical program" in title_lower:
         return "TPM"
-    if "program lead" in title_lower or "program manager" in title_lower:
+    if "program lead" in title_lower or _ROLE_PROGRAM_MANAGER in title_lower:
         return "Program Lead"
-    if "product engineer" in title_lower:
+    if _ROLE_PRODUCT_ENGINEER in title_lower:
         return "Product Engineer"
     if "devrel" in title_lower or "developer relation" in title_lower:
         return "DevRel"
     if "engineer" in title_lower:
         return "Engineer"
-    if "product manager" in title_lower:
+    if _ROLE_PRODUCT_MANAGER in title_lower:
         return "Product Manager"
     if "lead" in title_lower:
         return "Lead"
@@ -185,17 +193,17 @@ def _normalize_role_for_matching(role: str) -> list[str]:
     "TPM" also matches "Technical Program Manager" and vice versa.
     """
     role_aliases: dict[str, list[str]] = {
-        "tpm": ["tpm", "technical program manager"],
-        "technical program manager": ["tpm", "technical program manager"],
-        "pm": ["pm", "program manager", "project manager"],
-        "program manager": ["pm", "program manager"],
-        "product manager": ["product manager"],
-        "swe": ["swe", "software engineer"],
-        "software engineer": ["swe", "software engineer"],
-        "devrel": ["devrel", "developer relations", "developer advocate"],
-        "developer relations": ["devrel", "developer relations", "developer advocate"],
-        "developer advocate": ["devrel", "developer relations", "developer advocate"],
-        "product engineer": ["product engineer"],
+        "tpm": ["tpm", _ROLE_TPM],
+        _ROLE_TPM: ["tpm", _ROLE_TPM],
+        "pm": ["pm", _ROLE_PROGRAM_MANAGER, "project manager"],
+        _ROLE_PROGRAM_MANAGER: ["pm", _ROLE_PROGRAM_MANAGER],
+        _ROLE_PRODUCT_MANAGER: [_ROLE_PRODUCT_MANAGER],
+        "swe": ["swe", _ROLE_SOFTWARE_ENGINEER],
+        _ROLE_SOFTWARE_ENGINEER: ["swe", _ROLE_SOFTWARE_ENGINEER],
+        "devrel": ["devrel", _ROLE_DEVELOPER_RELATIONS, _ROLE_DEVELOPER_ADVOCATE],
+        _ROLE_DEVELOPER_RELATIONS: ["devrel", _ROLE_DEVELOPER_RELATIONS, _ROLE_DEVELOPER_ADVOCATE],
+        _ROLE_DEVELOPER_ADVOCATE: ["devrel", _ROLE_DEVELOPER_RELATIONS, _ROLE_DEVELOPER_ADVOCATE],
+        _ROLE_PRODUCT_ENGINEER: [_ROLE_PRODUCT_ENGINEER],
     }
 
     role_lower = role.strip().lower()
@@ -261,14 +269,14 @@ def _salary_fallback_from_ai(
     # Role-based salary estimate heuristics (EUR)
     _role_salary_estimates: dict[str, tuple[float, float, float]] = {
         "tpm": (110_000.0, 135_000.0, 165_000.0),
-        "technical program manager": (110_000.0, 135_000.0, 165_000.0),
-        "program manager": (95_000.0, 115_000.0, 140_000.0),
-        "product engineer": (90_000.0, 115_000.0, 145_000.0),
-        "software engineer": (85_000.0, 110_000.0, 140_000.0),
+        _ROLE_TPM: (110_000.0, 135_000.0, 165_000.0),
+        _ROLE_PROGRAM_MANAGER: (95_000.0, 115_000.0, 140_000.0),
+        _ROLE_PRODUCT_ENGINEER: (90_000.0, 115_000.0, 145_000.0),
+        _ROLE_SOFTWARE_ENGINEER: (85_000.0, 110_000.0, 140_000.0),
         "senior engineer": (100_000.0, 125_000.0, 155_000.0),
         "devrel": (85_000.0, 105_000.0, 130_000.0),
-        "developer relations": (85_000.0, 105_000.0, 130_000.0),
-        "product manager": (95_000.0, 120_000.0, 150_000.0),
+        _ROLE_DEVELOPER_RELATIONS: (85_000.0, 105_000.0, 130_000.0),
+        _ROLE_PRODUCT_MANAGER: (95_000.0, 120_000.0, 150_000.0),
         "engineering manager": (110_000.0, 135_000.0, 170_000.0),
         "ai program lead": (115_000.0, 140_000.0, 175_000.0),
     }

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -556,6 +556,50 @@ def _build_scoring_prompt(
 # ---------------------------------------------------------------------------
 
 
+def _query_jobs_to_score(
+    db: Session,
+    profile_id: int,
+    discovered_job_ids: list[int] | None,
+    rescore_stale: bool,
+) -> list:
+    """Return the list of DiscoveredJob rows to score."""
+    if discovered_job_ids:
+        return (
+            db.query(DiscoveredJob)
+            .filter(
+                DiscoveredJob.profile_id == profile_id,
+                DiscoveredJob.id.in_(discovered_job_ids),
+            )
+            .all()
+        )
+    if rescore_stale:
+        fresh_scored_ids = db.query(ScoredJob.discovered_job_id).filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.discovered_job_id.isnot(None),
+            ScoredJob.is_stale.is_(False),
+        )
+        return (
+            db.query(DiscoveredJob)
+            .filter(
+                DiscoveredJob.profile_id == profile_id,
+                DiscoveredJob.id.notin_(fresh_scored_ids),
+            )
+            .all()
+        )
+    any_scored_ids = db.query(ScoredJob.discovered_job_id).filter(
+        ScoredJob.profile_id == profile_id,
+        ScoredJob.discovered_job_id.isnot(None),
+    )
+    return (
+        db.query(DiscoveredJob)
+        .filter(
+            DiscoveredJob.profile_id == profile_id,
+            DiscoveredJob.id.notin_(any_scored_ids),
+        )
+        .all()
+    )
+
+
 async def batch_score_discovery(
     db: Session,
     profile_id: int,
@@ -585,46 +629,7 @@ async def batch_score_discovery(
 
     start_time = time.monotonic()
 
-    # Determine which jobs to score
-    if discovered_job_ids:
-        jobs = (
-            db.query(DiscoveredJob)
-            .filter(
-                DiscoveredJob.profile_id == profile_id,
-                DiscoveredJob.id.in_(discovered_job_ids),
-            )
-            .all()
-        )
-    else:
-        if rescore_stale:
-            # Score jobs with no non-stale score (includes never-scored + stale-only)
-            fresh_scored_ids = db.query(ScoredJob.discovered_job_id).filter(
-                ScoredJob.profile_id == profile_id,
-                ScoredJob.discovered_job_id.isnot(None),
-                ScoredJob.is_stale.is_(False),
-            )
-            jobs = (
-                db.query(DiscoveredJob)
-                .filter(
-                    DiscoveredJob.profile_id == profile_id,
-                    DiscoveredJob.id.notin_(fresh_scored_ids),
-                )
-                .all()
-            )
-        else:
-            # Score only never-scored jobs (no ScoredJob record at all)
-            any_scored_ids = db.query(ScoredJob.discovered_job_id).filter(
-                ScoredJob.profile_id == profile_id,
-                ScoredJob.discovered_job_id.isnot(None),
-            )
-            jobs = (
-                db.query(DiscoveredJob)
-                .filter(
-                    DiscoveredJob.profile_id == profile_id,
-                    DiscoveredJob.id.notin_(any_scored_ids),
-                )
-                .all()
-            )
+    jobs = _query_jobs_to_score(db, profile_id, discovered_job_ids, rescore_stale)
 
     scores: list[ScoredJob] = []
     errors: list[dict[str, str]] = []

--- a/src/career_os/services/skills_parsing.py
+++ b/src/career_os/services/skills_parsing.py
@@ -33,6 +33,10 @@ class ParsedSkill:
 
 PROFICIENCY_ORDER = ["beginner", "intermediate", "advanced", "expert"]
 
+_SOURCE_CV_YAML = "cv.yaml"
+_SOURCE_CCAT = "assessment:ccat"
+_SOURCE_WORKPLACE_INSIGHTS = "assessment:workplace-insights"
+
 
 def _proficiency_from_source_count(count: int) -> str:
     """Derive proficiency from number of evidence sources.
@@ -98,7 +102,7 @@ def parse_cv_yaml(cv_path: Path) -> list[ParsedSkill]:
                     name=skill_name,
                     category=category,
                     proficiency="intermediate",
-                    evidence_source="cv.yaml",
+                    evidence_source=_SOURCE_CV_YAML,
                     evidence_detail=f"CV skills section: {label}",
                 )
             )
@@ -212,7 +216,7 @@ def _extract_skills_from_experience(experience: list[dict]) -> list[ParsedSkill]
                             name=skill_name,
                             category=category,
                             proficiency="advanced",
-                            evidence_source="cv.yaml",
+                            evidence_source=_SOURCE_CV_YAML,
                             evidence_detail=(
                                 f"Experience at {company} ({position}): {highlight[:120]}"
                             ),
@@ -389,7 +393,7 @@ def parse_ccat(file_path: Path) -> list[ParsedSkill]:
                 name=skill_name,
                 category=skill_category,
                 proficiency=proficiency,
-                evidence_source="assessment:ccat",
+                evidence_source=_SOURCE_CCAT,
                 evidence_detail=f"CCAT {percentile}th percentile: {description[:120]}",
             )
         )
@@ -408,7 +412,7 @@ def parse_ccat(file_path: Path) -> list[ParsedSkill]:
                 name="Cognitive Aptitude",
                 category="soft",
                 proficiency=prof,
-                evidence_source="assessment:ccat",
+                evidence_source=_SOURCE_CCAT,
                 evidence_detail=f"CCAT Overall: {overall_pct}th percentile",
             )
         )
@@ -462,7 +466,7 @@ def parse_workplace_insights(file_path: Path) -> list[ParsedSkill]:
                     name=trait_map[trait],
                     category="soft",
                     proficiency="advanced",
-                    evidence_source="assessment:workplace-insights",
+                    evidence_source=_SOURCE_WORKPLACE_INSIGHTS,
                     evidence_detail=f"Workplace Insights: {description[:120]}",
                 )
             )
@@ -479,7 +483,7 @@ def parse_workplace_insights(file_path: Path) -> list[ParsedSkill]:
                         name=matched,
                         category="soft",
                         proficiency="advanced",
-                        evidence_source="assessment:workplace-insights",
+                        evidence_source=_SOURCE_WORKPLACE_INSIGHTS,
                         evidence_detail=f"Workplace Insights strength: {line[:120]}",
                     )
                 )


### PR DESCRIPTION
## Summary
- Fix all 28 blocker/critical issues flagged by SonarCloud in the new code period
- 23 duplicate literal extractions (S1192) across models, services, CLI, and frontend
- 4 cognitive complexity reductions (S3776) via helper function extraction
- 1 bug review (S6466) — confirmed safe, no change needed

## Changes by category

**Models (5 files):** Extract `FK_PROFILES_ID`, `FK_APPLICATIONS_ID`, `CASCADE_ALL_DELETE_ORPHAN` constants in `models.py`, import in `contacts.py`, `discovery.py`, `skills.py`

**Services (6 files):** Extract role name constants in `role_intelligence.py`, scoring helper in `scoring.py`, merge helpers in `discovery.py`, plus constant extraction in `ai_health.py`, `pushover.py`, `skills_parsing.py`

**Frontend (2 files):** Param loop in `discovery.ts`, extracted helpers in `ApplicationDetail.tsx`

**CLI + other (3 files):** Constants in `contacts.py`, `main.py`, `link_packages.py`, `mock_provider.py`

## Test plan
- [x] Ruff lint clean
- [x] ESLint clean
- [x] Pre-existing test failures confirmed on main (Discovery.test.tsx, KanbanBoard.test.tsx)
- [ ] CI passes
- [ ] SonarCloud quality gate re-evaluated

🤖 Generated with [Claude Code](https://claude.com/claude-code)