### PR TITLE
revert: undo CI paths-ignore for docs (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/pii-patterns.txt'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/pii-patterns.txt'
   merge_group:
 
 permissions:


### PR DESCRIPTION
## Summary
- Reverts #174 which added `paths-ignore` to CI triggers
- Restores CI to run on all pushes/PRs to main regardless of file type

## Why
The bypass approach was flagged as problematic — reverting to keep CI consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)