### PR TITLE
feat(G-271): score context & percentiles

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -134,6 +134,23 @@ export interface ATSKeyword {
 }
 
 /**
+ * Percentile context for a score relative to a user's full scoring history.
+ * Only present when the profile has >= 5 non-stale scored jobs.
+ */
+export interface ScoreContext {
+  /** Percentage of scored jobs this score is higher than (0-100) */
+  percentile: number;
+  /** Rank among all scored jobs, 1 = highest */
+  rank: number;
+  /** Total number of non-stale scored jobs for this profile */
+  total_scored: number;
+  /** Average fit_score across all non-stale scored jobs */
+  avg_score: number;
+  /** Number of jobs in the same letter grade band as this score */
+  score_band_count: number;
+}
+
+/**
  * Shape of the /api/score/application/{id} response. Mirrors the backend
  * `ScoreResponse` pydantic schema — only the fields we actively consume on
  * the application detail page are listed.
@@ -147,6 +164,7 @@ export interface ScoreResponseShape {
   ats_keywords?: ATSKeyword[];
   red_flags?: RedFlag[];
   reasoning: string;
+  score_context?: ScoreContext | null;
 }
 
 export interface Application {

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -13,6 +13,7 @@ from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
     BatchScoreResponse,
+    ScoreContextResponse,
     ScoreRequest,
     ScoreResponse,
     ScoringWeightsResponse,
@@ -25,6 +26,7 @@ from career_os.services.scoring import (
     ProfileNotFoundError,
     ScoringError,
     batch_score_discovery,
+    compute_score_context,
     flag_stale_scores,
     get_or_create_weights,
     get_score_for_application,
@@ -193,6 +195,21 @@ async def batch_score_endpoint(
 
 
 # ---------------------------------------------------------------------------
+# Score Context Helper
+# ---------------------------------------------------------------------------
+
+
+def _build_score_context(
+    db: Session, profile_id: int, fit_score: float
+) -> ScoreContextResponse | None:
+    """Compute and return a ScoreContextResponse, or None when data is insufficient."""
+    ctx = compute_score_context(db, profile_id, fit_score)
+    if ctx is None:
+        return None
+    return ScoreContextResponse(**ctx)
+
+
+# ---------------------------------------------------------------------------
 # Score Retrieval
 # ---------------------------------------------------------------------------
 
@@ -203,11 +220,16 @@ async def get_job_score_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
-    """Get the latest score for a discovered job."""
+    """Get the latest score for a discovered job.
+
+    Includes ``score_context`` (percentile/rank) when the profile has >= 5 scored jobs.
+    """
     scored = get_score_for_job(db, profile_id, discovered_job_id)
     if not scored:
         raise HTTPException(status_code=404, detail="No score found for this job")
-    return ScoreResponse.model_validate(scored)
+    response = ScoreResponse.model_validate(scored)
+    response.score_context = _build_score_context(db, profile_id, scored.fit_score)
+    return response
 
 
 @router.get(
@@ -219,11 +241,16 @@ async def get_application_score_endpoint(
     profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
-    """Get the latest score for an application."""
+    """Get the latest score for an application.
+
+    Includes ``score_context`` (percentile/rank) when the profile has >= 5 scored jobs.
+    """
     scored = get_score_for_application(db, profile_id, application_id)
     if not scored:
         raise HTTPException(status_code=404, detail="No score found for this application")
-    return ScoreResponse.model_validate(scored)
+    response = ScoreResponse.model_validate(scored)
+    response.score_context = _build_score_context(db, profile_id, scored.fit_score)
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -99,6 +99,30 @@ class ATSKeywordItem(BaseModel):
     matched: bool
 
 
+class ScoreContextResponse(BaseModel):
+    """Percentile context for a score relative to a user's scoring history.
+
+    Only populated when the profile has >= 5 non-stale scored jobs.
+    """
+
+    percentile: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="Percentage of scored jobs this score is higher than",
+    )
+    rank: int = Field(..., ge=1, description="Rank among all scored jobs (1 = highest)")
+    total_scored: int = Field(..., ge=1, description="Total number of non-stale scored jobs")
+    avg_score: float = Field(
+        ..., ge=0, le=10, description="Average fit_score across all scored jobs"
+    )
+    score_band_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of jobs in the same letter grade band as this score",
+    )
+
+
 class ScoreResponse(BaseModel):
     """Full scoring breakdown response."""
 
@@ -153,6 +177,15 @@ class ScoreResponse(BaseModel):
     effort_flag: str = Field(..., description="Effort level: low / medium / high")
     prep_level: str = Field(..., description="Preparation level: light / moderate / intensive")
     prep_notes: str = Field(..., description="Prep recommendations")
+
+    # Score context — percentile/rank relative to this profile's history.
+    # Computed dynamically on GET; not stored in DB. None when < 5 scored jobs exist.
+    score_context: ScoreContextResponse | None = Field(
+        default=None,
+        description=(
+            "Percentile context relative to profile's scoring history (null when < 5 scores)"
+        ),
+    )
 
     is_stale: bool = False
     created_at: datetime | None = None

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -733,6 +733,102 @@ def flag_stale_scores(db: Session, profile_id: int) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Score Context (Percentile / Rank)
+# ---------------------------------------------------------------------------
+
+_SCORE_CONTEXT_MIN_SCORES = 5  # minimum non-stale scores required for meaningful context
+
+
+def compute_score_context(db: Session, profile_id: int, fit_score: float) -> dict | None:
+    """Return percentile context for a score relative to the user's scoring history.
+
+    Only computed when the profile has >= 5 non-stale scored jobs.  Returns
+    ``None`` when there is insufficient data.
+
+    The returned dict matches the ``ScoreContextResponse`` Pydantic schema:
+        {
+            "percentile": 82,       # score is higher than 82% of scored jobs
+            "rank": 3,              # 3rd highest score
+            "total_scored": 47,     # total non-stale scored jobs
+            "avg_score": 5.3,       # average fit_score
+            "score_band_count": 8,  # jobs in the same letter grade band
+        }
+    """
+    from career_os.schemas.scoring import score_to_letter_grade
+
+    # Count total non-stale scored jobs for this profile
+    total_scored: int = (
+        db.query(ScoredJob)
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.is_stale.is_(False),
+        )
+        .count()
+    )
+
+    if total_scored < _SCORE_CONTEXT_MIN_SCORES:
+        return None
+
+    # Count how many scores are strictly below this score (for percentile)
+    below_count: int = (
+        db.query(ScoredJob)
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.is_stale.is_(False),
+            ScoredJob.fit_score < fit_score,
+        )
+        .count()
+    )
+
+    percentile = int(below_count / total_scored * 100)
+
+    # Rank: count scores strictly above this score + 1
+    above_count: int = (
+        db.query(ScoredJob)
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.is_stale.is_(False),
+            ScoredJob.fit_score > fit_score,
+        )
+        .count()
+    )
+    rank = above_count + 1
+
+    # Average score across all non-stale jobs
+    from sqlalchemy import func as sa_func
+
+    avg_result = (
+        db.query(sa_func.avg(ScoredJob.fit_score))
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.is_stale.is_(False),
+        )
+        .scalar()
+    )
+    avg_score = round(float(avg_result), 2) if avg_result is not None else 0.0
+
+    # Jobs in the same letter grade band as fit_score
+    target_grade = score_to_letter_grade(fit_score)
+    all_scores = (
+        db.query(ScoredJob.fit_score)
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.is_stale.is_(False),
+        )
+        .all()
+    )
+    score_band_count = sum(1 for (s,) in all_scores if score_to_letter_grade(s) == target_grade)
+
+    return {
+        "percentile": percentile,
+        "rank": rank,
+        "total_scored": total_scored,
+        "avg_score": avg_score,
+        "score_band_count": score_band_count,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Score Retrieval
 # ---------------------------------------------------------------------------
 

--- a/tests/test_score_context.py
+++ b/tests/test_score_context.py
@@ -1,0 +1,313 @@
+"""Tests for score context / percentile calculation (G-271).
+
+Covers:
+- Percentile calculation with known score distributions
+- Rank calculation
+- Null when < 5 scored jobs exist
+- Stale scores excluded from calculation
+- Ties handled correctly
+- Single score returns None
+- API endpoints return score_context on GET
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from career_os.database import Base, get_db
+from career_os.main import app
+from career_os.models.models import Profile
+from career_os.models.scoring import ScoredJob
+from career_os.services.scoring import compute_score_context
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCORED_JOB_KWARGS = dict(
+    reasoning="A" * 100,
+    estimated_salary="100k",
+    effort_flag="low",
+    prep_level="light",
+    prep_notes="none",
+    readiness_score=80.0,
+    career_alignment=7.0,
+)
+
+
+@pytest.fixture()
+def db_session():
+    """Fresh in-memory database for each test."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def set_sqlite_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+
+    connection = engine.connect()
+    session_cls = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = session_cls()
+
+    profile = Profile(
+        id=1,
+        name="Test User",
+        email="test@example.com",
+        location="Berlin",
+        job_family="SWE",
+    )
+    session.add(profile)
+    session.commit()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client(db_session):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_scored_jobs(
+    session, profile_id: int, scores: list[float], stale: bool = False
+) -> list[ScoredJob]:
+    """Insert ScoredJob rows with given fit_scores and return them."""
+    jobs = []
+    for score in scores:
+        sj = ScoredJob(
+            profile_id=profile_id,
+            fit_score=score,
+            is_stale=stale,
+            **MINIMAL_SCORED_JOB_KWARGS,
+        )
+        session.add(sj)
+        jobs.append(sj)
+    session.commit()
+    for sj in jobs:
+        session.refresh(sj)
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: compute_score_context()
+# ---------------------------------------------------------------------------
+
+
+class TestPercentileCalculation:
+    def test_known_distribution(self, db_session):
+        """Spec validation: score 6.0 in [2.0, 4.0, 6.0, 8.0, 9.0] → percentile=40, rank=3, total=5."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+        assert ctx["percentile"] == 40  # 2 scores below 6.0 out of 5
+        assert ctx["rank"] == 3  # 2 scores above 6.0
+        assert ctx["total_scored"] == 5
+
+    def test_highest_score(self, db_session):
+        """The top-scoring job should have rank=1."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=9.0)
+        assert ctx is not None
+        assert ctx["rank"] == 1
+        assert ctx["percentile"] == 80  # 4 scores below 9.0 out of 5
+
+    def test_lowest_score(self, db_session):
+        """The bottom-scoring job should have rank=5 and percentile=0."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=2.0)
+        assert ctx is not None
+        assert ctx["rank"] == 5
+        assert ctx["percentile"] == 0
+
+
+class TestRankCalculation:
+    def test_rank_third_of_ten(self, db_session):
+        """3rd highest of 10 scores → rank=3."""
+        scores = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        _add_scored_jobs(db_session, profile_id=1, scores=scores)
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=8.0)
+        assert ctx is not None
+        assert ctx["rank"] == 3  # 9.0 and 10.0 are above
+        assert ctx["total_scored"] == 10
+
+
+class TestContextNullBelowThreshold:
+    def test_zero_scores_returns_none(self, db_session):
+        """With no scored jobs, context is None."""
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=7.0)
+        assert ctx is None
+
+    def test_four_scores_returns_none(self, db_session):
+        """With exactly 4 non-stale scored jobs, context is None (below threshold of 5)."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[3.0, 5.0, 7.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=7.0)
+        assert ctx is None
+
+    def test_five_scores_returns_context(self, db_session):
+        """With exactly 5 scores, context is populated."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+
+
+class TestSingleScore:
+    def test_single_score_returns_none(self, db_session):
+        """With exactly 1 scored job, context is None."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[7.5])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=7.5)
+        assert ctx is None
+
+
+class TestStaleScoresExcluded:
+    def test_stale_scores_not_counted(self, db_session):
+        """Stale scores don't count toward percentile or total."""
+        # 3 fresh + 10 stale = only 3 fresh should be counted → below threshold
+        _add_scored_jobs(db_session, profile_id=1, scores=[3.0, 5.0, 7.0])
+        _add_scored_jobs(db_session, profile_id=1, scores=[1.0] * 10, stale=True)
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=5.0)
+        assert ctx is None  # only 3 fresh scores, below threshold of 5
+
+    def test_stale_scores_excluded_from_percentile(self, db_session):
+        """Stale scores don't inflate percentile calculation."""
+        # 5 fresh scores [2,4,6,8,9], 5 stale at 10.0
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 9.0])
+        _add_scored_jobs(db_session, profile_id=1, scores=[10.0] * 5, stale=True)
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+        assert ctx["total_scored"] == 5  # only fresh scores
+        assert ctx["percentile"] == 40  # same as without stale
+
+
+class TestTiesHandled:
+    def test_ties_at_queried_score(self, db_session):
+        """Multiple scores at the same value: percentile counts only strictly-below scores."""
+        # Scores: [5.0, 5.0, 5.0, 7.0, 8.0] — querying at 5.0
+        _add_scored_jobs(db_session, profile_id=1, scores=[5.0, 5.0, 5.0, 7.0, 8.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=5.0)
+        assert ctx is not None
+        # 0 scores strictly below 5.0 out of 5 → percentile = 0
+        assert ctx["percentile"] == 0
+        # 2 scores strictly above 5.0 → rank = 3
+        assert ctx["rank"] == 3
+
+    def test_all_same_score(self, db_session):
+        """All scores equal → percentile=0, rank=1 for any score."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[6.0, 6.0, 6.0, 6.0, 6.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+        assert ctx["percentile"] == 0
+        assert ctx["rank"] == 1
+        assert ctx["total_scored"] == 5
+
+
+class TestAverageAndBandCount:
+    def test_avg_score_calculation(self, db_session):
+        """avg_score is the mean of all non-stale fit_scores."""
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 6.0, 8.0, 10.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+        assert ctx["avg_score"] == 6.0
+
+    def test_score_band_count(self, db_session):
+        """score_band_count counts jobs in the same letter grade band."""
+        # 6.0, 6.5 are both "B" (6.0-6.9), 8.0 is "A-", 9.0 is "A", 4.0 is "C"
+        _add_scored_jobs(db_session, profile_id=1, scores=[4.0, 6.0, 6.5, 8.0, 9.0])
+        ctx = compute_score_context(db_session, profile_id=1, fit_score=6.0)
+        assert ctx is not None
+        assert ctx["score_band_count"] == 2  # 6.0 and 6.5 are both "B"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: API GET endpoints populate score_context
+# ---------------------------------------------------------------------------
+
+
+class TestAPIScoreContext:
+    def test_get_job_score_includes_context_when_enough_data(self, db_session, client):
+        """GET /api/score/job/{id} includes score_context when >= 5 scores exist."""
+        from career_os.models.discovery import DiscoveredJob
+
+        # Create a discovered job
+        dj = DiscoveredJob(
+            profile_id=1,
+            title="Software Engineer",
+            title_normalized="software engineer",
+            company="Acme",
+            company_normalized="acme",
+            location="Berlin",
+            location_normalized="berlin",
+            remote=False,
+        )
+        db_session.add(dj)
+        db_session.commit()
+        db_session.refresh(dj)
+
+        # Score the discovered job + 4 additional standalone scores
+        target = ScoredJob(
+            profile_id=1,
+            discovered_job_id=dj.id,
+            fit_score=7.0,
+            **MINIMAL_SCORED_JOB_KWARGS,
+        )
+        db_session.add(target)
+        _add_scored_jobs(db_session, profile_id=1, scores=[2.0, 4.0, 5.0, 9.0])
+        db_session.commit()
+        db_session.refresh(target)
+
+        resp = client.get(f"/api/score/job/{dj.id}?profile_id=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["score_context"] is not None
+        ctx = data["score_context"]
+        assert "percentile" in ctx
+        assert "rank" in ctx
+        assert "total_scored" in ctx
+        assert ctx["total_scored"] == 5
+
+    def test_get_job_score_context_null_when_insufficient_data(self, db_session, client):
+        """GET /api/score/job/{id} returns score_context=null when < 5 scored jobs."""
+        from career_os.models.discovery import DiscoveredJob
+
+        dj = DiscoveredJob(
+            profile_id=1,
+            title="Data Scientist",
+            title_normalized="data scientist",
+            company="Corp",
+            company_normalized="corp",
+            location="Berlin",
+            location_normalized="berlin",
+            remote=True,
+        )
+        db_session.add(dj)
+        db_session.commit()
+        db_session.refresh(dj)
+
+        # Only the target score exists (1 total < 5)
+        target = ScoredJob(
+            profile_id=1,
+            discovered_job_id=dj.id,
+            fit_score=8.0,
+            **MINIMAL_SCORED_JOB_KWARGS,
+        )
+        db_session.add(target)
+        db_session.commit()
+
+        resp = client.get(f"/api/score/job/{dj.id}?profile_id=1")
+        assert resp.status_code == 200
+        assert resp.json()["score_context"] is None


### PR DESCRIPTION
## Summary
- Adds `compute_score_context()` — percentile, rank, total_scored, avg_score, score_band_count
- `ScoreContextResponse` Pydantic model, added to `ScoreResponse`
- Computed on API read (not stored in DB), null when <5 scores exist
- Frontend TypeScript `ScoreContext` interface

## Test plan
- [ ] 16 tests in `tests/test_score_context.py`
- [ ] Percentile math, ties, stale exclusion, threshold enforcement
- [ ] Integration test for job GET endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)