### PR TITLE
feat(G-275): dual-score architecture (fit vs desire)

### DIFF
--- a/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
+++ b/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
@@ -10,7 +10,7 @@ Adds columns for the dual-score architecture (G-275):
 All columns are nullable; existing rows get NULL and no backfill is required.
 
 Revision ID: l3m4n5o6p7q8
-Revises: d2e5a7f1b9c3
+Revises: n5o6p7q8r9s0
 Create Date: 2026-04-14 12:00:00.000000
 
 """
@@ -22,7 +22,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "l3m4n5o6p7q8"
-down_revision: str | Sequence[str] | None = "d2e5a7f1b9c3"
+down_revision: str | Sequence[str] | None = "n5o6p7q8r9s0"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
+++ b/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
@@ -10,7 +10,7 @@ Adds columns for the dual-score architecture (G-275):
 All columns are nullable; existing rows get NULL and no backfill is required.
 
 Revision ID: l3m4n5o6p7q8
-Revises: b8d3e7a2c914
+Revises: d2e5a7f1b9c3
 Create Date: 2026-04-14 12:00:00.000000
 
 """
@@ -22,7 +22,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "l3m4n5o6p7q8"
-down_revision: str | Sequence[str] | None = "b8d3e7a2c914"
+down_revision: str | Sequence[str] | None = "d2e5a7f1b9c3"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
+++ b/alembic/versions/l3m4n5o6p7q8_add_desire_score_columns.py
@@ -1,0 +1,43 @@
+"""add desire_score columns to scored_jobs
+
+Adds columns for the dual-score architecture (G-275):
+
+* ``desire_score`` — 0-10 float measuring "how much would the user want this job?"
+* ``desire_score_method`` — tracking which computation method was used
+  ("derived" or "ai_generated")
+* ``desire_reasoning`` — separate reasoning text for desire score (Option B only)
+
+All columns are nullable; existing rows get NULL and no backfill is required.
+
+Revision ID: l3m4n5o6p7q8
+Revises: b8d3e7a2c914
+Create Date: 2026-04-14 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "l3m4n5o6p7q8"
+down_revision: str | Sequence[str] | None = "b8d3e7a2c914"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add desire_score columns to scored_jobs."""
+    with op.batch_alter_table("scored_jobs") as batch_op:
+        batch_op.add_column(sa.Column("desire_score", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("desire_score_method", sa.String(20), nullable=True))
+        batch_op.add_column(sa.Column("desire_reasoning", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the desire_score columns."""
+    with op.batch_alter_table("scored_jobs") as batch_op:
+        batch_op.drop_column("desire_reasoning")
+        batch_op.drop_column("desire_score_method")
+        batch_op.drop_column("desire_score")

--- a/docs/desire-score-ab-recommendation.md
+++ b/docs/desire-score-ab-recommendation.md
@@ -1,3 +1,7 @@
+---
+title: Desire Score A/B Recommendation
+---
+
 # Desire Score A/B Recommendation
 
 ## Context

--- a/docs/desire-score-ab-recommendation.md
+++ b/docs/desire-score-ab-recommendation.md
@@ -1,0 +1,159 @@
+# Desire Score A/B Recommendation
+
+## Context
+
+The dual-score architecture (G-275) adds a second dimension to job scoring:
+**desire_score** measures "how much would the candidate want this job?" while
+**fit_score** measures "how qualified is the candidate?" Two computation
+approaches were implemented and evaluated.
+
+## Option A: Derived Score
+
+### How It Works
+
+Computes `desire_score` as a weighted average of three dimensional sub-scores
+that the AI already produces during fit scoring:
+
+```
+desire_score = (career_trajectory * w1) + (company_fit * w2) + (compensation_fit * w3)
+```
+
+**Default weights:** career_trajectory=0.35, company_fit=0.35, compensation_fit=0.30
+
+**Goal-aware adjustment:** If the user has active goals containing specific
+keywords, the weights shift to match their priorities:
+
+| Goal keyword      | career_trajectory | company_fit | compensation_fit |
+|-------------------|-------------------|-------------|------------------|
+| leadership/management | 0.50          | 0.25        | 0.25             |
+| compensation/salary   | 0.20          | 0.25        | 0.55             |
+| culture/remote        | 0.25          | 0.50        | 0.25             |
+| (no match)            | 0.35          | 0.35        | 0.30             |
+
+**Implementation:** `compute_derived_desire_score()` in `src/career_os/services/scoring.py`
+
+### Characteristics
+
+- **Cost:** Zero additional AI cost (reuses existing dimensional scores)
+- **Latency:** ~0ms (pure arithmetic)
+- **Determinism:** Fully deterministic given the same dimensional inputs
+- **Accuracy:** Limited by the quality of the dimensional scores and the
+  simplicity of the weighting model. Cannot capture nuances like "this company
+  is known for toxic culture" that aren't reflected in dimensions.
+
+## Option B: AI-Generated Score
+
+### How It Works
+
+Adds `desire_score` (0-10) and `desire_reasoning` (text) to the `ScoreResult`
+schema. The AI provider prompt is updated to request both fields alongside the
+existing scoring output:
+
+```
+desire_score (0-10, how much the candidate would WANT this job --
+considering company reputation, growth potential, culture signals,
+role excitement, compensation attractiveness, work-life balance),
+desire_reasoning (string explaining what makes this job desirable
+or undesirable from the candidate's perspective)
+```
+
+**Implementation:** Updated prompts in `anthropic_provider.py` and
+`openrouter_provider.py`. Mock provider returns deterministic values.
+
+### Characteristics
+
+- **Cost:** Zero *additional* cost per call, since the desire_score is
+  requested as part of the same prompt. However, adds ~50 tokens to the
+  prompt and ~50-100 tokens to the response, which slightly increases
+  per-call cost (~$0.0001-$0.0003 additional per scoring).
+- **Latency:** Zero additional latency (same API call)
+- **Determinism:** Non-deterministic (LLM temperature variation)
+- **Accuracy:** Can capture subtle signals: company reputation awareness,
+  industry trends, culture red flags, career trajectory nuances that
+  dimensional scores miss. The LLM has world knowledge about companies
+  and roles that a simple weighted average cannot replicate.
+
+## Trade-off Analysis
+
+| Dimension          | Option A (Derived)         | Option B (AI-Generated)    |
+|--------------------|----------------------------|----------------------------|
+| Additional cost    | $0                         | ~$0.0002/call (marginal)   |
+| Additional latency | 0ms                        | 0ms (same call)            |
+| Determinism        | Fully deterministic        | Non-deterministic          |
+| Accuracy           | Limited to 3 dimensions    | Full context + world knowledge |
+| Personalization    | Goal-keyword matching only | Understands goals semantically |
+| Explainability     | Weights are transparent    | Has desire_reasoning text  |
+| Offline capability | Works without AI           | Requires AI provider       |
+| Failure mode       | Always available if dims exist | Graceful: falls back to A |
+
+## Recommendation: Option B (AI-Generated) as Default, Option A as Fallback
+
+**Use Option B as the primary method** for the following reasons:
+
+1. **Near-zero marginal cost.** Since desire_score is requested in the same
+   API call as fit_score, the additional cost is negligible (~50 extra output
+   tokens). There is no second API call.
+
+2. **Superior accuracy.** The LLM can reason about company reputation, industry
+   trends, role excitement, and growth potential using world knowledge that a
+   3-dimension weighted average cannot capture. A job at a company known for
+   toxic culture will get a low AI desire_score but might get a high derived
+   score if its dimensional scores happen to be favorable.
+
+3. **Built-in explainability.** `desire_reasoning` provides a natural-language
+   explanation that users can read. Option A can only say "score based on
+   career_trajectory (0.35) + company_fit (0.35) + compensation_fit (0.30)."
+
+4. **Semantic goal understanding.** Option B understands "I want to transition
+   into product management" holistically. Option A only matches literal keywords
+   like "leadership" or "salary."
+
+**Keep Option A as a fallback** for:
+- Legacy rows where the AI didn't return desire_score
+- Offline/mock scoring scenarios
+- Cases where AI providers fail or are rate-limited
+- Quick re-estimation when only weights change (no re-scoring needed)
+
+The current implementation already uses this architecture: Option B is preferred
+when the AI returns a desire_score; Option A kicks in as automatic fallback.
+The `desire_score_method` column tracks which was used for every scored job.
+
+## 2D Quadrant Classification
+
+Jobs are classified into quadrants based on a threshold of 5.0:
+
+```
+                    desire_score
+                    high (>=5)     low (<5)
+                ┌──────────────┬──────────────┐
+fit_score       │              │              │
+high (>=5)      │  DREAM JOB   │  SAFE BET    │
+                │              │              │
+                ├──────────────┼──────────────┤
+                │              │              │
+low (<5)        │ STRETCH GOAL │    SKIP      │
+                │              │              │
+                └──────────────┴──────────────┘
+```
+
+- **Dream Job** (high fit, high desire): Qualified AND desirable. Apply immediately.
+- **Stretch Goal** (low fit, high desire): Desirable but underqualified. Invest in upskilling.
+- **Safe Bet** (high fit, low desire): Qualified but uninspiring. Good backup option.
+- **Skip** (low fit, low desire): Neither qualified nor interested. Deprioritize.
+
+**Implementation:** `classify_quadrant()` in `src/career_os/schemas/scoring.py`
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/career_os/models/scoring.py` | `desire_score`, `desire_score_method`, `desire_reasoning` columns |
+| `src/career_os/schemas/scoring.py` | `DesireScoreResponse`, `classify_quadrant()`, fields on `ScoreResponse` |
+| `src/career_os/schemas/ai.py` | `desire_score`, `desire_reasoning` on `ScoreResult` |
+| `src/career_os/services/scoring.py` | `compute_derived_desire_score()`, integration in `score_job()` |
+| `src/career_os/ai/anthropic_provider.py` | Updated scoring prompt |
+| `src/career_os/ai/openrouter_provider.py` | Updated scoring prompt |
+| `src/career_os/ai/mock_provider.py` | Mock desire_score generation |
+| `alembic/versions/l3m4n5o6p7q8_*.py` | Migration for new columns |
+| `frontend/src/api/types.ts` | `DesireScoreResponse`, `ScoreQuadrant`, fields on `ScoreResponseShape` |
+| `tests/test_desire_score.py` | 25 tests covering both options |

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -155,6 +155,9 @@ export interface ScoreContext {
  * `ScoreResponse` pydantic schema — only the fields we actively consume on
  * the application detail page are listed.
  */
+/** 2D quadrant classification based on fit_score and desire_score. */
+export type ScoreQuadrant = "dream_job" | "stretch_goal" | "safe_bet" | "skip";
+
 export interface ScoreResponseShape {
   fit_score: number;
   readiness_score: number;
@@ -165,6 +168,21 @@ export interface ScoreResponseShape {
   red_flags?: RedFlag[];
   reasoning: string;
   score_context?: ScoreContext | null;
+  /** Desirability score 0-10 (how much user would want this job). */
+  desire_score?: number | null;
+  /** Method used to compute desire_score: "derived" or "ai_generated". */
+  desire_score_method?: string | null;
+  /** Reasoning for the desire score (AI-generated only). */
+  desire_reasoning?: string | null;
+}
+
+/** Standalone desire score response from the dual-score API. */
+export interface DesireScoreResponse {
+  desire_score: number | null;
+  desire_score_method: string | null;
+  desire_reasoning: string | null;
+  quadrant: ScoreQuadrant | null;
+  fit_score: number | null;
 }
 
 export interface Application {

--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -138,7 +138,12 @@ class AnthropicProvider(AIProvider):
             f"company_fit), "
             f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
             f"category (one of technical/soft_skill/tool/certification/domain), "
-            f"matched (boolean -- true if the profile demonstrates this keyword)).\n\n"
+            f"matched (boolean -- true if the profile demonstrates this keyword)), "
+            f"desire_score (0-10, how much the candidate would WANT this job -- "
+            f"considering company reputation, growth potential, culture signals, "
+            f"role excitement, compensation attractiveness, work-life balance), "
+            f"desire_reasoning (string explaining what makes this job desirable "
+            f"or undesirable from the candidate's perspective).\n\n"
             f"Job Description:\n{job_description}\n\n"
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )

--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -240,6 +240,14 @@ def _handle_score(prompt: str, context: dict | None) -> AIResponse:
         for idx, (keyword, category) in enumerate(_MOCK_ATS_KEYWORDS)
     ]
 
+    # Desire score (Option B: AI-generated) — deterministic from seed
+    desire = round(1.0 + ((seed + 42) % 90) / 10.0, 1)
+    desire = min(desire, 10.0)
+    desire_reasoning = (
+        f"Company culture aligns well with candidate preferences. "
+        f"Growth potential rated {desire}/10 based on role trajectory and industry outlook."
+    )
+
     structured = ScoreResult(
         fit_score=fit,
         reasoning=reasoning,
@@ -254,6 +262,8 @@ def _handle_score(prompt: str, context: dict | None) -> AIResponse:
         score_breakdown=breakdown_factors,
         dimensional_scores=dimensional,
         ats_keywords=ats_keywords,
+        desire_score=desire,
+        desire_reasoning=desire_reasoning,
     )
     return AIResponse(
         content=structured.reasoning,

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -143,7 +143,12 @@ class OpenRouterProvider(AIProvider):
             f"company_fit), "
             f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
             f"category (one of technical/soft_skill/tool/certification/domain), "
-            f"matched (boolean — true if the profile demonstrates this keyword)).\n\n"
+            f"matched (boolean — true if the profile demonstrates this keyword)), "
+            f"desire_score (0-10, how much the candidate would WANT this job — "
+            f"considering company reputation, growth potential, culture signals, "
+            f"role excitement, compensation attractiveness, work-life balance), "
+            f"desire_reasoning (string explaining what makes this job desirable "
+            f"or undesirable from the candidate's perspective).\n\n"
             f"Job Description:\n{job_description}\n\n"
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )

--- a/src/career_os/models/scoring.py
+++ b/src/career_os/models/scoring.py
@@ -114,6 +114,11 @@ class ScoredJob(Base):
     # ATS keywords extracted by AI (JSON array of {keyword, category, matched})
     ats_keywords: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Desire score — measures "how much would the user want this job?" (0-10)
+    desire_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    desire_score_method: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    desire_reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Dimensional sub-scores (0-10, each may be null on legacy rows)
     dim_technical_fit: Mapped[float | None] = mapped_column(Float, nullable=True)
     dim_seniority_alignment: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -122,6 +122,16 @@ class ScoreResult(BaseModel):
         default_factory=list,
         description="10-15 ATS keywords extracted from the JD, categorized and matched",
     )
+    desire_score: float | None = Field(
+        default=None,
+        ge=0,
+        le=10,
+        description="Desirability score 0-10: how much would the candidate want this job?",
+    )
+    desire_reasoning: str | None = Field(
+        default=None,
+        description="Reasoning for the desire score (what makes this job desirable/undesirable)",
+    )
 
 
 class GapAnalysisResult(BaseModel):

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -136,6 +136,17 @@ class ScoreResponse(BaseModel):
     readiness_score: float = Field(..., ge=0, le=100, description="Skills readiness 0-100")
     career_alignment: float = Field(..., ge=0, le=10, description="Career alignment 0-10")
 
+    # Desire score (dual-score architecture, G-275)
+    desire_score: float | None = Field(
+        default=None, ge=0, le=10, description="Desirability score 0-10 (how much user wants job)"
+    )
+    desire_score_method: str | None = Field(
+        default=None, description="Method used: 'derived' or 'ai_generated'"
+    )
+    desire_reasoning: str | None = Field(
+        default=None, description="Reasoning for desire score (Option B only)"
+    )
+
     # Letter grade derived from fit_score (A, A-, B+, B, C+, C, D, F)
     letter_grade: str | None = Field(
         default=None,
@@ -280,6 +291,43 @@ class ScoreResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Scoring Weights
 # ---------------------------------------------------------------------------
+
+
+def classify_quadrant(fit_score: float | None, desire_score: float | None) -> str | None:
+    """Classify a job into a 2D quadrant based on fit and desire scores.
+
+    Quadrants (threshold = 5.0):
+        - "dream_job"   — high fit, high desire
+        - "stretch_goal" — low fit, high desire
+        - "safe_bet"    — high fit, low desire
+        - "skip"        — low fit, low desire
+
+    Returns None if either score is None.
+    """
+    if fit_score is None or desire_score is None:
+        return None
+    threshold = 5.0
+    if fit_score >= threshold and desire_score >= threshold:
+        return "dream_job"
+    if fit_score < threshold and desire_score >= threshold:
+        return "stretch_goal"
+    if fit_score >= threshold and desire_score < threshold:
+        return "safe_bet"
+    return "skip"
+
+
+class DesireScoreResponse(BaseModel):
+    """Standalone desire score response for the dual-score API."""
+
+    desire_score: float | None = Field(default=None, ge=0, le=10, description="Desirability 0-10")
+    desire_score_method: str | None = Field(default=None, description="'derived' or 'ai_generated'")
+    desire_reasoning: str | None = Field(default=None, description="Reasoning (ai_generated only)")
+    quadrant: str | None = Field(
+        default=None, description="2D quadrant: dream_job / stretch_goal / safe_bet / skip"
+    )
+    fit_score: float | None = Field(
+        default=None, ge=0, le=10, description="Corresponding fit_score for context"
+    )
 
 
 class ScoringWeightsResponse(BaseModel):

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -416,6 +416,83 @@ def _gather_red_flag_metadata(
     return rf
 
 
+# ---------------------------------------------------------------------------
+# Desire Score — Option A (Derived from dimensional scores + goals)
+# ---------------------------------------------------------------------------
+
+# Default weights for deriving desire_score from dimensional sub-scores.
+# career_trajectory = growth potential, company_fit = culture/reputation,
+# compensation_fit = salary attractiveness.
+DEFAULT_DESIRE_WEIGHTS: dict[str, float] = {
+    "career_trajectory": 0.35,
+    "company_fit": 0.35,
+    "compensation_fit": 0.30,
+}
+
+# Keywords in goal titles/descriptions that shift desire weights.
+_GOAL_WEIGHT_ADJUSTMENTS: dict[str, dict[str, float]] = {
+    "leadership": {"career_trajectory": 0.50, "company_fit": 0.25, "compensation_fit": 0.25},
+    "management": {"career_trajectory": 0.50, "company_fit": 0.25, "compensation_fit": 0.25},
+    "compensation": {"career_trajectory": 0.20, "company_fit": 0.25, "compensation_fit": 0.55},
+    "salary": {"career_trajectory": 0.20, "company_fit": 0.25, "compensation_fit": 0.55},
+    "culture": {"career_trajectory": 0.25, "company_fit": 0.50, "compensation_fit": 0.25},
+    "remote": {"career_trajectory": 0.25, "company_fit": 0.50, "compensation_fit": 0.25},
+}
+
+
+def _resolve_desire_weights(goals: list[dict]) -> dict[str, float]:
+    """Determine desire weights based on user's active goals.
+
+    If any goal title/description contains keywords like "leadership",
+    "compensation", etc., we shift the weights to match user priorities.
+    Falls back to DEFAULT_DESIRE_WEIGHTS if no keywords match.
+    """
+    if not goals:
+        return dict(DEFAULT_DESIRE_WEIGHTS)
+
+    all_goal_text = " ".join(
+        f"{g.get('title', '')} {g.get('description', '')}".lower() for g in goals
+    )
+
+    for keyword, weights in _GOAL_WEIGHT_ADJUSTMENTS.items():
+        if keyword in all_goal_text:
+            return dict(weights)
+
+    return dict(DEFAULT_DESIRE_WEIGHTS)
+
+
+def compute_derived_desire_score(
+    dimensional_scores: dict[str, float] | None,
+    goals: list[dict] | None = None,
+) -> float | None:
+    """Compute desire_score as a weighted average of dimensional sub-scores.
+
+    Option A: derived from existing dimensions — no additional AI call.
+
+    Args:
+        dimensional_scores: Dict with keys career_trajectory, company_fit,
+            compensation_fit (each 0-10). None → returns None.
+        goals: List of goal dicts with title/description for weight adjustment.
+
+    Returns:
+        Float 0-10 rounded to 1 decimal, or None if dimensions unavailable.
+    """
+    if dimensional_scores is None:
+        return None
+
+    # Check that the required dimensions are present
+    required = ("career_trajectory", "company_fit", "compensation_fit")
+    if not all(dimensional_scores.get(k) is not None for k in required):
+        return None
+
+    weights = _resolve_desire_weights(goals or [])
+
+    score = sum(dimensional_scores[dim] * weight for dim, weight in weights.items())
+
+    # Clamp to [0, 10]
+    return round(max(0.0, min(10.0, score)), 1)
+
+
 def _build_dim_columns(dim) -> dict[str, float | None]:
     """Build dimensional score columns dict from AI result."""
     if dim is None:
@@ -550,6 +627,28 @@ async def score_job(
         else None
     )
 
+    # Desire score computation (dual-score architecture, G-275)
+    desire_score = None
+    desire_score_method = None
+    desire_reasoning = None
+
+    # Option B: AI-generated desire_score (if the provider returned one)
+    if score_data.desire_score is not None:
+        desire_score = score_data.desire_score
+        desire_score_method = "ai_generated"
+        desire_reasoning = score_data.desire_reasoning
+
+    # Option A fallback: derive from dimensional scores + goals
+    if desire_score is None and score_data.dimensional_scores is not None:
+        dim_dict = {
+            "career_trajectory": score_data.dimensional_scores.career_trajectory,
+            "company_fit": score_data.dimensional_scores.company_fit,
+            "compensation_fit": score_data.dimensional_scores.compensation_fit,
+        }
+        desire_score = compute_derived_desire_score(dim_dict, profile_data.get("goals"))
+        if desire_score is not None:
+            desire_score_method = "derived"
+
     # Persist the score
     scored_job = ScoredJob(
         profile_id=profile_id,
@@ -568,6 +667,9 @@ async def score_job(
         ats_keywords=ats_keywords_json,
         is_stale=False,
         weights_snapshot=json.dumps({**profile_data["weights"], "rubric_version": RUBRIC_VERSION}),
+        desire_score=desire_score,
+        desire_score_method=desire_score_method,
+        desire_reasoning=desire_reasoning,
         **dim_columns,
     )
     db.add(scored_job)

--- a/tests/test_desire_score.py
+++ b/tests/test_desire_score.py
@@ -1,0 +1,429 @@
+"""Tests for the Dual-Score Architecture (G-275).
+
+Covers:
+- Option A: derived desire_score from dimensional sub-scores + goals
+- Option B: AI-generated desire_score via ScoreResult
+- Desire score bounds clamping
+- Null handling when dimensions are missing
+- Goal-based weight adjustment
+- desire_score_method tracking on ScoredJob
+- classify_quadrant() 2D classification
+- Integration: scoring produces both fit_score and desire_score
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from career_os.database import Base, get_db
+from career_os.main import app
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.models import Profile
+from career_os.models.scoring import ScoredJob
+from career_os.models.skills import Goal
+from career_os.schemas.scoring import classify_quadrant
+from career_os.services.scoring import (
+    DEFAULT_DESIRE_WEIGHTS,
+    _resolve_desire_weights,
+    compute_derived_desire_score,
+)
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def db_session():
+    """Create a fresh in-memory database for each test."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def set_sqlite_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+
+    connection = engine.connect()
+    test_session_cls = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = test_session_cls()
+
+    profile = Profile(
+        id=1,
+        name="Test User",
+        email="test@example.com",
+        location="Frankfurt",
+        job_family="TPM",
+    )
+    session.add(profile)
+    session.commit()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    connection.close()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Option A: Derived desire score
+# ---------------------------------------------------------------------------
+
+
+class TestDerivedDesireScore:
+    """Tests for compute_derived_desire_score (Option A)."""
+
+    def test_derived_desire_score_calculation(self):
+        """Derived score from dimensional scores with default weights."""
+        dims = {
+            "career_trajectory": 8.0,
+            "company_fit": 7.0,
+            "compensation_fit": 6.0,
+        }
+        result = compute_derived_desire_score(dims)
+        # 8.0*0.35 + 7.0*0.35 + 6.0*0.30 = 2.8 + 2.45 + 1.8 = 7.05
+        # Python's banker's rounding: round(7.05, 1) == 7.0
+        assert result == pytest.approx(7.0, abs=0.1)
+
+    def test_derived_desire_score_with_leadership_goals(self):
+        """Goals mentioning 'leadership' shift weight to career_trajectory."""
+        dims = {
+            "career_trajectory": 9.0,
+            "company_fit": 5.0,
+            "compensation_fit": 5.0,
+        }
+        goals = [{"title": "Grow into leadership role", "description": ""}]
+        result = compute_derived_desire_score(dims, goals)
+        # leadership weights: career_trajectory=0.50, company_fit=0.25, compensation_fit=0.25
+        # 9.0*0.50 + 5.0*0.25 + 5.0*0.25 = 4.5 + 1.25 + 1.25 = 7.0
+        assert result == 7.0
+
+    def test_derived_desire_score_with_compensation_goals(self):
+        """Goals mentioning 'salary' shift weight to compensation_fit."""
+        dims = {
+            "career_trajectory": 5.0,
+            "company_fit": 5.0,
+            "compensation_fit": 9.0,
+        }
+        goals = [{"title": "Increase salary", "description": "Target 150k+"}]
+        result = compute_derived_desire_score(dims, goals)
+        # salary weights: career_trajectory=0.20, company_fit=0.25, compensation_fit=0.55
+        # 5.0*0.20 + 5.0*0.25 + 9.0*0.55 = 1.0 + 1.25 + 4.95 = 7.2
+        assert result == 7.2
+
+    def test_derived_desire_score_with_culture_goals(self):
+        """Goals mentioning 'culture' shift weight to company_fit."""
+        dims = {
+            "career_trajectory": 5.0,
+            "company_fit": 9.0,
+            "compensation_fit": 5.0,
+        }
+        goals = [{"title": "Find great culture fit", "description": ""}]
+        result = compute_derived_desire_score(dims, goals)
+        # culture weights: career_trajectory=0.25, company_fit=0.50, compensation_fit=0.25
+        # 5.0*0.25 + 9.0*0.50 + 5.0*0.25 = 1.25 + 4.5 + 1.25 = 7.0
+        assert result == 7.0
+
+    def test_desire_score_bounds_high(self):
+        """Desire score is clamped to max 10."""
+        dims = {
+            "career_trajectory": 10.0,
+            "company_fit": 10.0,
+            "compensation_fit": 10.0,
+        }
+        result = compute_derived_desire_score(dims)
+        assert result == 10.0
+
+    def test_desire_score_bounds_low(self):
+        """Desire score is clamped to min 0."""
+        dims = {
+            "career_trajectory": 0.0,
+            "company_fit": 0.0,
+            "compensation_fit": 0.0,
+        }
+        result = compute_derived_desire_score(dims)
+        assert result == 0.0
+
+    def test_desire_score_null_without_dimensions(self):
+        """If dimensional_scores is None, desire_score is None."""
+        result = compute_derived_desire_score(None)
+        assert result is None
+
+    def test_desire_score_null_with_partial_dimensions(self):
+        """If required dimensions are missing, desire_score is None."""
+        dims = {
+            "career_trajectory": 8.0,
+            "company_fit": None,
+            "compensation_fit": 6.0,
+        }
+        result = compute_derived_desire_score(dims)
+        assert result is None
+
+    def test_default_weights_sum_to_one(self):
+        """Default desire weights must sum to 1.0."""
+        total = sum(DEFAULT_DESIRE_WEIGHTS.values())
+        assert abs(total - 1.0) < 1e-9
+
+    def test_no_matching_goals_uses_defaults(self):
+        """Goals with no matching keywords use default weights."""
+        goals = [{"title": "Learn Rust", "description": "Systems programming"}]
+        weights = _resolve_desire_weights(goals)
+        assert weights == DEFAULT_DESIRE_WEIGHTS
+
+
+# ---------------------------------------------------------------------------
+# Option B: AI-generated desire score
+# ---------------------------------------------------------------------------
+
+
+class TestAIGeneratedDesireScore:
+    """Tests for AI-generated desire_score via ScoreResult schema."""
+
+    def test_ai_generated_desire_score(self):
+        """AI provider returns desire_score in ScoreResult."""
+        from career_os.schemas.ai import ScoreBreakdownFactor, ScoreResult
+
+        result = ScoreResult(
+            fit_score=7.5,
+            reasoning="A" * 100,
+            estimated_salary="100k-130k",
+            effort_flag="medium",
+            prep_level="moderate",
+            prep_notes="Study the product",
+            readiness_score=75.0,
+            career_alignment=8.0,
+            score_breakdown=[
+                ScoreBreakdownFactor(factor="Skills", contribution=2.0, description="Good match"),
+                ScoreBreakdownFactor(
+                    factor="Culture", contribution=1.5, description="Strong culture"
+                ),
+                ScoreBreakdownFactor(factor="Location", contribution=1.0, description="Remote OK"),
+            ],
+            desire_score=8.5,
+            desire_reasoning="Great company with strong growth trajectory",
+        )
+        assert result.desire_score == 8.5
+        assert result.desire_reasoning == "Great company with strong growth trajectory"
+
+    def test_score_result_without_desire_score(self):
+        """ScoreResult without desire_score defaults to None."""
+        from career_os.schemas.ai import ScoreBreakdownFactor, ScoreResult
+
+        result = ScoreResult(
+            fit_score=7.0,
+            reasoning="B" * 100,
+            estimated_salary="90k-120k",
+            effort_flag="low",
+            prep_level="light",
+            prep_notes="Quick review",
+            readiness_score=80.0,
+            career_alignment=7.0,
+            score_breakdown=[
+                ScoreBreakdownFactor(factor="A", contribution=1.0, description="x"),
+                ScoreBreakdownFactor(factor="B", contribution=1.0, description="y"),
+                ScoreBreakdownFactor(factor="C", contribution=1.0, description="z"),
+            ],
+        )
+        assert result.desire_score is None
+        assert result.desire_reasoning is None
+
+
+# ---------------------------------------------------------------------------
+# Quadrant classification
+# ---------------------------------------------------------------------------
+
+
+class TestQuadrantClassification:
+    """Tests for classify_quadrant() 2D classification."""
+
+    def test_dream_job(self):
+        assert classify_quadrant(8.0, 8.0) == "dream_job"
+
+    def test_stretch_goal(self):
+        assert classify_quadrant(3.0, 7.0) == "stretch_goal"
+
+    def test_safe_bet(self):
+        assert classify_quadrant(7.0, 3.0) == "safe_bet"
+
+    def test_skip(self):
+        assert classify_quadrant(2.0, 2.0) == "skip"
+
+    def test_threshold_boundary_both_at_5(self):
+        """Both scores at threshold = dream_job (>=)."""
+        assert classify_quadrant(5.0, 5.0) == "dream_job"
+
+    def test_fit_at_threshold_desire_below(self):
+        assert classify_quadrant(5.0, 4.9) == "safe_bet"
+
+    def test_none_fit_score(self):
+        assert classify_quadrant(None, 7.0) is None
+
+    def test_none_desire_score(self):
+        assert classify_quadrant(7.0, None) is None
+
+    def test_both_none(self):
+        assert classify_quadrant(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# desire_score_method tracking
+# ---------------------------------------------------------------------------
+
+
+class TestDesireScoreMethodTracking:
+    """Tests that desire_score_method is correctly set on ScoredJob."""
+
+    def test_desire_score_method_tracked(self, db_session, client):
+        """ScoredJob.desire_score_method reflects which option was used."""
+        # Create a discovered job
+        dj = DiscoveredJob(
+            profile_id=1,
+            title="AI Product Manager",
+            company="TestCo",
+            location="Remote",
+            sources='["test"]',
+            url="https://example.com/job1",
+            description="Build AI products",
+            title_normalized="ai product manager",
+            company_normalized="testco",
+            location_normalized="remote",
+        )
+        db_session.add(dj)
+        db_session.commit()
+        db_session.refresh(dj)
+
+        # Score via API (mock provider returns desire_score → Option B)
+        resp = client.post(
+            "/api/score",
+            json={
+                "profile_id": 1,
+                "job_description": "AI Product Manager role at TestCo. Build ML platforms.",
+                "job_title": "AI Product Manager",
+                "job_company": "TestCo",
+                "discovered_job_id": dj.id,
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+
+        # Mock provider returns desire_score → method should be ai_generated
+        assert data["desire_score"] is not None
+        assert data["desire_score_method"] == "ai_generated"
+
+        # Verify it's persisted in DB
+        scored = db_session.query(ScoredJob).first()
+        assert scored.desire_score is not None
+        assert scored.desire_score_method == "ai_generated"
+
+
+# ---------------------------------------------------------------------------
+# Integration: scoring produces both fit_score and desire_score
+# ---------------------------------------------------------------------------
+
+
+class TestScoringIntegration:
+    """Integration tests for the dual-score architecture."""
+
+    def test_score_produces_fit_and_desire(self, db_session, client):
+        """Scoring a job produces both fit_score and desire_score."""
+        resp = client.post(
+            "/api/score",
+            json={
+                "profile_id": 1,
+                "job_description": (
+                    "Senior Technical Program Manager at Acme Corp. "
+                    "Lead cross-functional teams in AI product delivery."
+                ),
+                "job_title": "Senior TPM",
+                "job_company": "Acme Corp",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+
+        # Both scores present
+        assert "fit_score" in data
+        assert data["fit_score"] >= 0
+        assert data["fit_score"] <= 10
+
+        assert "desire_score" in data
+        assert data["desire_score"] is not None
+        assert data["desire_score"] >= 0
+        assert data["desire_score"] <= 10
+
+        # Method tracked
+        assert data["desire_score_method"] in ("derived", "ai_generated")
+
+    def test_score_with_goals_affects_desire(self, db_session, client):
+        """Goals influence the desire_score calculation."""
+        # Add a leadership goal
+        goal = Goal(
+            profile_id=1,
+            title="Move into engineering leadership",
+            goal_type="career",
+            description="Transition to VP of Engineering",
+            status="active",
+        )
+        db_session.add(goal)
+        db_session.commit()
+
+        resp = client.post(
+            "/api/score",
+            json={
+                "profile_id": 1,
+                "job_description": (
+                    "VP of Engineering at ScaleUp Inc. "
+                    "Lead 50+ engineers across multiple product lines."
+                ),
+                "job_title": "VP Engineering",
+                "job_company": "ScaleUp Inc",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["desire_score"] is not None
+
+    def test_batch_scoring_includes_desire(self, db_session, client):
+        """Batch scoring also produces desire_score for each job."""
+        # Seed discovered jobs
+        for i in range(3):
+            dj = DiscoveredJob(
+                profile_id=1,
+                title=f"Role {i}",
+                company=f"Company {i}",
+                location="Remote",
+                sources='["test"]',
+                url=f"https://example.com/job{i}",
+                description=f"Job description for role {i} with AI and ML focus.",
+                title_normalized=f"role {i}",
+                company_normalized=f"company {i}",
+                location_normalized="remote",
+            )
+            db_session.add(dj)
+        db_session.commit()
+
+        resp = client.post(
+            "/api/score/batch",
+            json={"profile_id": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scored_count"] == 3
+
+        for score in data["scores"]:
+            assert "desire_score" in score
+            assert score["desire_score"] is not None
+            assert score["desire_score_method"] in ("derived", "ai_generated")


### PR DESCRIPTION
## Summary
- Adds `desire_score` (0-10) measuring "how much would the user want this job?"
- **Option A (derived):** weighted average of career_trajectory + company_fit + compensation_fit, goal-aware weights. Free, deterministic.
- **Option B (AI-generated):** LLM generates desire_score + desire_reasoning in same API call. ~$0.0002 marginal cost.
- Smart fallback: Option B preferred, falls back to A if unavailable
- `desire_score_method` column tracks which option was used
- 2D quadrant classification: Dream Job / Stretch Goal / Safe Bet / Skip
- **Recommendation: Option B as default** (documented in docs/desire-score-ab-recommendation.md)

## Test plan
- [ ] 25 tests in `tests/test_desire_score.py`
- [ ] Derived calculation, goal-aware weights, bounds clamping
- [ ] AI-generated schema, quadrant classification
- [ ] Method tracking, integration with scoring pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)