### PR TITLE
feat(G-274): user feedback loop for score correction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,8 @@ GOOGLE_SHEET_ID=
 # -- Pipeline (optional) ---------------------------------------------------
 # Default location for job search (used by daily scan CI)
 PIPELINE_LOCATION=Remote
+
+# -- Feedback Calibration (Epic 6 / G-274) ---------------------------------
+# Inject the top feedback corrections into scoring prompts (Epic 11 bridge).
+# Only enable once you have ≥10 explicit user corrections ("too_high"/"too_low").
+FEEDBACK_CALIBRATION_ENABLED=false

--- a/alembic/versions/l3g4h5i6j7k8_add_scoring_feedback.py
+++ b/alembic/versions/l3g4h5i6j7k8_add_scoring_feedback.py
@@ -1,0 +1,50 @@
+"""Add scoring_feedback table for user feedback loop (Epic 6 / G-274).
+
+Revision ID: l3g4h5i6j7k8
+Revises: k2f3g4h5i6j7
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "l3g4h5i6j7k8"
+down_revision: Union[str, None] = "k2f3g4h5i6j7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scoring_feedback",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scored_job_id", sa.Integer(), nullable=False),
+        sa.Column("profile_id", sa.Integer(), nullable=False),
+        sa.Column("direction", sa.String(length=50), nullable=False),
+        sa.Column("user_score", sa.Float(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("original_fit_score", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["profile_id"], ["profiles.id"]),
+        sa.ForeignKeyConstraint(["scored_job_id"], ["scored_jobs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_scoring_feedback_profile_id"), "scoring_feedback", ["profile_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_scoring_feedback_scored_job_id"),
+        "scoring_feedback",
+        ["scored_job_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_scoring_feedback_scored_job_id"), table_name="scoring_feedback")
+    op.drop_index(op.f("ix_scoring_feedback_profile_id"), table_name="scoring_feedback")
+    op.drop_table("scoring_feedback")

--- a/alembic/versions/n5o6p7q8r9s0_add_scoring_feedback.py
+++ b/alembic/versions/n5o6p7q8r9s0_add_scoring_feedback.py
@@ -1,7 +1,7 @@
 """Add scoring_feedback table for user feedback loop (Epic 6 / G-274).
 
-Revision ID: l3g4h5i6j7k8
-Revises: k2f3g4h5i6j7
+Revision ID: n5o6p7q8r9s0
+Revises: d2e5a7f1b9c3
 Create Date: 2026-04-14 00:00:00.000000
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "l3g4h5i6j7k8"
-down_revision: Union[str, None] = "k2f3g4h5i6j7"
+revision: str = "n5o6p7q8r9s0"
+down_revision: Union[str, None] = "d2e5a7f1b9c3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -775,3 +775,52 @@ export interface ContactDetailResponse extends Contact {
   interactions: ContactInteraction[];
   linked_applications: ContactApplicationLink[];
 }
+
+// ---------------------------------------------------------------------------
+// Scoring Feedback types (Epic 6 / G-274)
+// ---------------------------------------------------------------------------
+
+export type FeedbackDirection =
+  | "too_high"
+  | "too_low"
+  | "correct"
+  | "implicit_positive"
+  | "implicit_negative"
+  | "implicit_strong_positive";
+
+export interface FeedbackCreate {
+  direction: FeedbackDirection;
+  /** Optional: what the user thinks the score should be (0–10) */
+  user_score?: number | null;
+  /** Optional: free-text explanation */
+  reason?: string | null;
+}
+
+export interface FeedbackResponse {
+  id: number;
+  scored_job_id: number;
+  profile_id: number;
+  direction: FeedbackDirection;
+  user_score: number | null;
+  reason: string | null;
+  original_fit_score: number;
+  created_at: string;
+}
+
+export interface FeedbackStats {
+  total_count: number;
+  explicit_count: number;
+  implicit_count: number;
+  /** Average |user_score - original_fit_score|. Null if no records with user_score. */
+  avg_deviation: number | null;
+  direction_counts: Record<FeedbackDirection, number>;
+}
+
+export interface CalibrationExample {
+  job_title: string | null;
+  company: string | null;
+  ai_score: number;
+  user_score: number;
+  reason: string | null;
+  deviation: number;
+}

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -13,6 +13,9 @@ from career_os.database import get_db
 from career_os.schemas.scoring import (
     BatchScoreRequest,
     BatchScoreResponse,
+    FeedbackCreate,
+    FeedbackResponse,
+    FeedbackStats,
     ScoreContextResponse,
     ScoreRequest,
     ScoreResponse,
@@ -21,6 +24,8 @@ from career_os.schemas.scoring import (
 )
 from career_os.services.pushover import send_credits_exhausted_alert
 from career_os.services.scoring import (
+    FeedbackNotFoundError,
+    InvalidFeedbackError,
     JobNotFoundError,
     ProfileIncompleteError,
     ProfileNotFoundError,
@@ -28,10 +33,13 @@ from career_os.services.scoring import (
     batch_score_discovery,
     compute_score_context,
     flag_stale_scores,
+    get_feedback_stats,
     get_or_create_weights,
     get_score_for_application,
     get_score_for_job,
+    list_feedback,
     score_job,
+    submit_feedback,
     update_weights,
 )
 
@@ -270,3 +278,69 @@ async def flag_stale_endpoint(
     """
     count = flag_stale_scores(db, profile_id)
     return {"stale_count": count}
+
+
+# ---------------------------------------------------------------------------
+# Scoring Feedback (Epic 6 / G-274)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/score/{scored_job_id}/feedback",
+    status_code=201,
+    responses={
+        **RESP_404,
+        400: {"description": "Invalid feedback data"},
+    },
+)
+async def submit_feedback_endpoint(
+    scored_job_id: int,
+    payload: FeedbackCreate,
+    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    db: Annotated[Session, Depends(get_db)],
+) -> FeedbackResponse:
+    """Submit user feedback on an AI-generated score.
+
+    Accepts explicit corrections (too_high, too_low, correct) with an optional
+    user_score (0-10) and free-text reason. Records a snapshot of the original
+    AI score for calibration purposes.
+    """
+    try:
+        feedback = submit_feedback(
+            db,
+            scored_job_id=scored_job_id,
+            profile_id=profile_id,
+            direction=payload.direction.value,
+            user_score=payload.user_score,
+            reason=payload.reason,
+        )
+    except FeedbackNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InvalidFeedbackError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return FeedbackResponse.model_validate(feedback)
+
+
+@router.get("/api/score/feedback")
+async def list_feedback_endpoint(
+    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[FeedbackResponse]:
+    """List all feedback records for a profile, newest first."""
+    records = list_feedback(db, profile_id)
+    return [FeedbackResponse.model_validate(r) for r in records]
+
+
+@router.get("/api/score/feedback/stats")
+async def feedback_stats_endpoint(
+    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    db: Annotated[Session, Depends(get_db)],
+) -> FeedbackStats:
+    """Return summary statistics for feedback submitted by a profile.
+
+    Includes total count, explicit vs implicit breakdown, average deviation,
+    and per-direction counts.
+    """
+    stats = get_feedback_stats(db, profile_id)
+    return FeedbackStats(**stats)

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
     cache_enabled: bool = True
     cache_encryption_key: str = ""  # User-provided Fernet key; auto-generated if empty
 
+    # Feedback calibration (Epic 6 / G-274) — inject top feedback examples into
+    # scoring prompts. Disabled by default until ≥10 explicit corrections exist.
+    # Epic 11 (Bayesian Learning) will leverage this when enabled.
+    feedback_calibration_enabled: bool = False
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     # Per-provider API key requirements: provider → (settings_attr, expected_prefix).

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -35,9 +35,10 @@ class Settings(BaseSettings):
     cache_encryption_key: str = ""  # User-provided Fernet key; auto-generated if empty
 
     # Feedback calibration (Epic 6 / G-274) — inject top feedback examples into
-    # scoring prompts. Disabled by default until ≥10 explicit corrections exist.
-    # Epic 11 (Bayesian Learning) will leverage this when enabled.
-    feedback_calibration_enabled: bool = False
+    # scoring prompts. Self-gating: get_feedback_calibration() returns [] when
+    # fewer than 10 explicit corrections exist, so no data leaks into prompts
+    # until the user has provided enough feedback. Can be disabled via env var.
+    feedback_calibration_enabled: bool = True
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/src/career_os/models/scoring.py
+++ b/src/career_os/models/scoring.py
@@ -133,3 +133,46 @@ class ScoredJob(Base):
         return (
             f"<ScoredJob(id={self.id}, fit_score={self.fit_score}, profile_id={self.profile_id})>"
         )
+
+
+class ScoringFeedback(Base):
+    """User feedback on an AI-generated score.
+
+    Captures explicit corrections ("too high" / "too low") and implicit
+    signals (promoted to application, reached interview stage).
+
+    Referenced by Epic 11 (Bayesian Learning) to calibrate scoring behavior.
+    """
+
+    __tablename__ = "scoring_feedback"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    scored_job_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("scored_jobs.id"), nullable=False, index=True
+    )
+    profile_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+    )
+
+    # "too_high", "too_low", "correct", "implicit_positive",
+    # "implicit_negative", "implicit_strong_positive"
+    direction: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    # Optional: what the user thinks the score should be (0-10 scale)
+    user_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Optional: free-text explanation from the user
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Snapshot of the AI-generated score at the time feedback was submitted
+    original_fit_score: Mapped[float] = mapped_column(Float, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ScoringFeedback(id={self.id}, scored_job_id={self.scored_job_id}, "
+            f"direction='{self.direction}')>"
+        )

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -2,6 +2,7 @@
 
 import json as json_mod
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -348,3 +349,83 @@ class BatchScoreResponse(BaseModel):
         default=False,
         description="True if scoring stopped due to AI provider credits being exhausted",
     )
+
+
+# ---------------------------------------------------------------------------
+# Scoring Feedback
+# ---------------------------------------------------------------------------
+
+
+class FeedbackDirection(StrEnum):
+    """Valid directions for scoring feedback."""
+
+    TOO_HIGH = "too_high"
+    TOO_LOW = "too_low"
+    CORRECT = "correct"
+    IMPLICIT_POSITIVE = "implicit_positive"
+    IMPLICIT_NEGATIVE = "implicit_negative"
+    IMPLICIT_STRONG_POSITIVE = "implicit_strong_positive"
+
+
+class FeedbackCreate(BaseModel):
+    """Request body for POST /api/score/{scored_job_id}/feedback."""
+
+    direction: FeedbackDirection = Field(..., description="Feedback direction")
+    user_score: float | None = Field(
+        default=None,
+        ge=0,
+        le=10,
+        description="Optional: what the user thinks the score should be (0–10)",
+    )
+    reason: str | None = Field(
+        default=None,
+        max_length=1000,
+        description="Optional: free-text explanation",
+    )
+
+
+class FeedbackResponse(BaseModel):
+    """Response schema for a single feedback record."""
+
+    id: int
+    scored_job_id: int
+    profile_id: int
+    direction: str
+    user_score: float | None = None
+    reason: str | None = None
+    original_fit_score: float
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _ensure_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
+
+
+class FeedbackStats(BaseModel):
+    """Summary statistics for feedback submitted by a profile."""
+
+    total_count: int = Field(..., description="Total number of feedback records")
+    explicit_count: int = Field(..., description="Explicit corrections (too_high/too_low/correct)")
+    implicit_count: int = Field(..., description="Implicit signals (promoted/dismissed/interview)")
+    avg_deviation: float | None = Field(
+        default=None,
+        description="Average |user_score - original_fit_score| for records with user_score",
+    )
+    direction_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of feedback records per direction",
+    )
+
+
+class CalibrationExample(BaseModel):
+    """A single calibration example for the scoring prompt."""
+
+    job_title: str | None = None
+    company: str | None = None
+    ai_score: float
+    user_score: float
+    reason: str | None = None
+    deviation: float

--- a/src/career_os/services/applications.py
+++ b/src/career_os/services/applications.py
@@ -121,7 +121,32 @@ def create_application(db: Session, payload: ApplicationCreate) -> Application:
 
     try_auto_push_pipeline_action(db, app_obj, "Application created")
 
+    # Record implicit positive feedback when a discovered job is promoted to application
+    # (no-op if no ScoredJob exists for this application)
+    _record_implicit_on_create(db, app_obj)
+
     return app_obj
+
+
+def _record_implicit_on_create(db: Session, app_obj: Application) -> None:
+    """Record implicit_positive feedback when an application is created.
+
+    Looks for a ScoredJob linked to the application's discovered_job_id (if
+    the application was promoted from a DiscoveredJob) or to application_id.
+    Silently skipped when no scored job exists.
+    """
+    try:
+        from career_os.services.scoring import record_implicit_feedback
+
+        # Try linking via the application itself (application_id FK on ScoredJob)
+        record_implicit_feedback(
+            db,
+            profile_id=app_obj.profile_id,
+            direction="implicit_positive",
+            application_id=app_obj.id,
+        )
+    except Exception:
+        pass  # Never block application creation due to feedback side-effects
 
 
 def get_application(
@@ -249,6 +274,7 @@ def update_application(
     _handle_status_transition(db, app_obj, update_data)
     _apply_field_updates(db, app_obj, update_data)
 
+    new_status = update_data.get("status")
     status_changed = "status" in update_data
     db.commit()
     db.refresh(app_obj)
@@ -258,7 +284,29 @@ def update_application(
 
         try_auto_push_pipeline_action(db, app_obj, f"Status changed to {app_obj.status}")
 
+        # Record implicit strong positive when application reaches interview stage
+        if new_status == "interview":
+            _record_implicit_on_interview(db, app_obj)
+
     return app_obj
+
+
+def _record_implicit_on_interview(db: Session, app_obj: Application) -> None:
+    """Record implicit_strong_positive feedback when an application reaches interview.
+
+    Silently skipped when no scored job exists for this application.
+    """
+    try:
+        from career_os.services.scoring import record_implicit_feedback
+
+        record_implicit_feedback(
+            db,
+            profile_id=app_obj.profile_id,
+            direction="implicit_strong_positive",
+            application_id=app_obj.id,
+        )
+    except Exception:
+        pass  # Never block status updates due to feedback side-effects
 
 
 def delete_application(

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -18,7 +18,7 @@ from career_os.ai.factory import get_ai_provider
 from career_os.ai.openrouter_provider import CreditsExhaustedError
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
-from career_os.models.scoring import ScoredJob, ScoringWeights
+from career_os.models.scoring import ScoredJob, ScoringFeedback, ScoringWeights
 from career_os.models.skills import Goal, Skill
 from career_os.schemas.ai import ScoreResult
 from career_os.services.red_flags import detect_data_driven_red_flags, detect_red_flags
@@ -966,3 +966,259 @@ def get_score_for_application(
         .order_by(ScoredJob.created_at.desc())
         .first()
     )
+
+
+# ---------------------------------------------------------------------------
+# Feedback CRUD
+# ---------------------------------------------------------------------------
+
+#: Directions considered explicit user corrections
+EXPLICIT_DIRECTIONS = {"too_high", "too_low", "correct"}
+
+#: Directions considered implicit signals
+IMPLICIT_DIRECTIONS = {"implicit_positive", "implicit_negative", "implicit_strong_positive"}
+
+#: All valid feedback directions
+VALID_DIRECTIONS = EXPLICIT_DIRECTIONS | IMPLICIT_DIRECTIONS
+
+
+class FeedbackNotFoundError(Exception):
+    """Raised when a scored_job is not found when submitting feedback."""
+
+
+class InvalidFeedbackError(Exception):
+    """Raised when feedback data is invalid."""
+
+
+def submit_feedback(
+    db: Session,
+    *,
+    scored_job_id: int,
+    profile_id: int,
+    direction: str,
+    user_score: float | None = None,
+    reason: str | None = None,
+) -> ScoringFeedback:
+    """Submit feedback on an AI-generated score.
+
+    Validates that the scored_job exists and belongs to the profile, then
+    creates a ScoringFeedback record snapshotting the original fit_score.
+
+    Raises FeedbackNotFoundError if the scored_job does not exist.
+    Raises InvalidFeedbackError if direction or user_score are invalid.
+    """
+    if direction not in VALID_DIRECTIONS:
+        raise InvalidFeedbackError(
+            f"Invalid direction '{direction}'. Must be one of: {sorted(VALID_DIRECTIONS)}"
+        )
+    if user_score is not None and not (0.0 <= user_score <= 10.0):
+        raise InvalidFeedbackError("user_score must be between 0 and 10")
+
+    scored_job = (
+        db.query(ScoredJob)
+        .filter(ScoredJob.id == scored_job_id, ScoredJob.profile_id == profile_id)
+        .first()
+    )
+    if scored_job is None:
+        raise FeedbackNotFoundError(f"ScoredJob {scored_job_id} not found for profile {profile_id}")
+
+    feedback = ScoringFeedback(
+        scored_job_id=scored_job_id,
+        profile_id=profile_id,
+        direction=direction,
+        user_score=user_score,
+        reason=reason,
+        original_fit_score=scored_job.fit_score,
+    )
+    db.add(feedback)
+    db.commit()
+    db.refresh(feedback)
+    return feedback
+
+
+def record_implicit_feedback(
+    db: Session,
+    *,
+    profile_id: int,
+    direction: str,
+    scored_job_id: int | None = None,
+    discovered_job_id: int | None = None,
+    application_id: int | None = None,
+) -> ScoringFeedback | None:
+    """Record an implicit feedback signal.
+
+    Looks up the most recent ScoredJob linked to the given discovered_job_id
+    or application_id, then creates a ScoringFeedback record. Returns None
+    if no ScoredJob can be found (gracefully skipped).
+
+    Called from service hooks — never fails loudly.
+    """
+    if direction not in IMPLICIT_DIRECTIONS:
+        logger.warning("record_implicit_feedback: invalid direction '%s', skipping", direction)
+        return None
+
+    # Resolve scored_job_id from the linked entity if not supplied directly
+    if scored_job_id is None:
+        query = db.query(ScoredJob).filter(ScoredJob.profile_id == profile_id)
+        if discovered_job_id is not None:
+            query = query.filter(ScoredJob.discovered_job_id == discovered_job_id)
+        elif application_id is not None:
+            query = query.filter(ScoredJob.application_id == application_id)
+        else:
+            return None
+        scored_job = query.order_by(ScoredJob.created_at.desc()).first()
+        if scored_job is None:
+            return None
+        scored_job_id = scored_job.id
+    else:
+        scored_job = db.query(ScoredJob).filter(ScoredJob.id == scored_job_id).first()
+        if scored_job is None:
+            return None
+
+    try:
+        feedback = ScoringFeedback(
+            scored_job_id=scored_job_id,
+            profile_id=profile_id,
+            direction=direction,
+            user_score=None,
+            reason=None,
+            original_fit_score=scored_job.fit_score,
+        )
+        db.add(feedback)
+        db.commit()
+        db.refresh(feedback)
+        return feedback
+    except Exception:
+        logger.warning(
+            "record_implicit_feedback: failed to record signal '%s' for scored_job %d",
+            direction,
+            scored_job_id,
+            exc_info=True,
+        )
+        db.rollback()
+        return None
+
+
+def list_feedback(db: Session, profile_id: int) -> list[ScoringFeedback]:
+    """List all feedback records for a profile, newest first."""
+    return (
+        db.query(ScoringFeedback)
+        .filter(ScoringFeedback.profile_id == profile_id)
+        .order_by(ScoringFeedback.created_at.desc())
+        .all()
+    )
+
+
+def get_feedback_stats(db: Session, profile_id: int) -> dict:
+    """Return summary statistics for feedback submitted by a profile.
+
+    Returns:
+        total_count, explicit_count, implicit_count,
+        avg_deviation (or None), direction_counts.
+    """
+    records = list_feedback(db, profile_id)
+
+    direction_counts: dict[str, int] = {}
+    explicit_count = 0
+    implicit_count = 0
+    deviations: list[float] = []
+
+    for r in records:
+        direction_counts[r.direction] = direction_counts.get(r.direction, 0) + 1
+        if r.direction in EXPLICIT_DIRECTIONS:
+            explicit_count += 1
+        else:
+            implicit_count += 1
+        if r.user_score is not None:
+            deviations.append(abs(r.user_score - r.original_fit_score))
+
+    avg_deviation = sum(deviations) / len(deviations) if deviations else None
+
+    return {
+        "total_count": len(records),
+        "explicit_count": explicit_count,
+        "implicit_count": implicit_count,
+        "avg_deviation": avg_deviation,
+        "direction_counts": direction_counts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Calibration Summary (foundation for Epic 11 / Bayesian Learning)
+# ---------------------------------------------------------------------------
+
+#: Minimum number of explicit feedback records required before calibration is
+#: returned. Below this threshold the data is too sparse to be meaningful.
+CALIBRATION_MIN_FEEDBACK = 10
+
+#: Maximum number of calibration examples injected into the scoring prompt.
+CALIBRATION_MAX_EXAMPLES = 5
+
+
+def get_feedback_calibration(db: Session, profile_id: int) -> list[dict]:
+    """Return the most informative calibration examples for the scoring prompt.
+
+    "Most informative" = largest absolute deviation between the user's score
+    and the AI's original score. Only explicit corrections (too_high / too_low)
+    with a user_score are considered.
+
+    Returns an empty list when fewer than CALIBRATION_MIN_FEEDBACK explicit
+    feedback records exist (data too sparse to calibrate).
+
+    Each returned dict has keys:
+        job_title, company, ai_score, user_score, reason, deviation
+    """
+    explicit_records = (
+        db.query(ScoringFeedback)
+        .filter(
+            ScoringFeedback.profile_id == profile_id,
+            ScoringFeedback.direction.in_(["too_high", "too_low"]),
+            ScoringFeedback.user_score.isnot(None),
+        )
+        .all()
+    )
+
+    if len(explicit_records) < CALIBRATION_MIN_FEEDBACK:
+        return []
+
+    # Enrich with job metadata from the linked ScoredJob → DiscoveredJob/Application
+    enriched: list[dict] = []
+    for record in explicit_records:
+        scored_job = db.query(ScoredJob).filter(ScoredJob.id == record.scored_job_id).first()
+        job_title: str | None = None
+        company: str | None = None
+        if scored_job is not None:
+            if scored_job.discovered_job_id is not None:
+                dj = (
+                    db.query(DiscoveredJob)
+                    .filter(DiscoveredJob.id == scored_job.discovered_job_id)
+                    .first()
+                )
+                if dj:
+                    job_title = dj.title
+                    company = dj.company
+            elif scored_job.application_id is not None:
+                app_rec = (
+                    db.query(Application)
+                    .filter(Application.id == scored_job.application_id)
+                    .first()
+                )
+                if app_rec:
+                    job_title = app_rec.role
+                    company = app_rec.company
+
+        deviation = abs(record.user_score - record.original_fit_score)  # type: ignore[operator]
+        enriched.append(
+            {
+                "job_title": job_title,
+                "company": company,
+                "ai_score": record.original_fit_score,
+                "user_score": record.user_score,
+                "reason": record.reason,
+                "deviation": deviation,
+            }
+        )
+
+    # Sort by deviation descending, take top N
+    enriched.sort(key=lambda x: x["deviation"], reverse=True)
+    return enriched[:CALIBRATION_MAX_EXAMPLES]

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -485,6 +485,13 @@ async def score_job(
     # Gather profile data and weights for scoring
     profile_data = _gather_scoring_context(db, profile, profile_id)
 
+    # Fetch calibration examples when feature flag is enabled
+    calibration_examples: list[dict] = []
+    from career_os.config import settings
+
+    if settings.feedback_calibration_enabled:
+        calibration_examples = get_feedback_calibration(db, profile_id)
+
     # Build scoring prompt with job context
     prompt = _build_scoring_prompt(
         job_description=job_description,
@@ -492,6 +499,7 @@ async def score_job(
         job_company=job_company,
         job_url=job_url,
         profile_data=profile_data,
+        calibration_examples=calibration_examples,
     )
 
     # Score via AI provider
@@ -615,6 +623,28 @@ def _format_market_section(market: dict) -> list[str]:
     return lines
 
 
+def _format_calibration_section(calibration_examples: list[dict]) -> list[str]:
+    """Format feedback calibration examples into prompt lines.
+
+    Tells the AI how the user previously corrected scores so it can adjust
+    its scoring tendencies for this profile.
+    """
+    if not calibration_examples:
+        return []
+    lines = ["\nScoring Calibration (user corrections on past scores — adjust accordingly):"]
+    for ex in calibration_examples:
+        title = ex.get("job_title") or "Unknown role"
+        company = ex.get("company") or "Unknown company"
+        ai = ex.get("ai_score", "?")
+        user = ex.get("user_score", "?")
+        reason = ex.get("reason")
+        line = f"  - {title} @ {company}: AI scored {ai}, user corrected to {user}"
+        if reason:
+            line += f" (reason: {reason})"
+        lines.append(line)
+    return lines
+
+
 def _build_scoring_prompt(
     *,
     job_description: str,
@@ -622,6 +652,7 @@ def _build_scoring_prompt(
     job_company: str | None = None,
     job_url: str | None = None,
     profile_data: dict,
+    calibration_examples: list[dict] | None = None,
 ) -> str:
     """Build a scoring prompt combining job info and profile context."""
     parts = ["Score this job against the candidate profile.\n"]
@@ -652,6 +683,8 @@ def _build_scoring_prompt(
 
     if profile_data.get("weights"):
         parts.append(f"\nScoring Weights: {json.dumps(profile_data['weights'])}")
+
+    parts.extend(_format_calibration_section(calibration_examples or []))
 
     return "\n".join(parts)
 

--- a/tests/test_scoring_feedback.py
+++ b/tests/test_scoring_feedback.py
@@ -21,15 +21,14 @@ from sqlalchemy.orm import Session, sessionmaker
 from career_os.database import Base, get_db
 from career_os.main import app
 from career_os.models.models import Application, Profile
-from career_os.models.scoring import ScoredJob, ScoringFeedback
-from career_os.schemas.applications import ApplicationCreate, ApplicationUpdate
+from career_os.models.scoring import ScoredJob
 from career_os.services.scoring import (
     CALIBRATION_MIN_FEEDBACK,
     FeedbackNotFoundError,
     InvalidFeedbackError,
+    _build_scoring_prompt,
+    _format_calibration_section,
     get_feedback_calibration,
-    get_feedback_stats,
-    list_feedback,
     record_implicit_feedback,
     submit_feedback,
 )
@@ -53,8 +52,9 @@ def db_session():
     Session_ = sessionmaker(bind=connection, autocommit=False, autoflush=False)
     session = Session_()
 
-    profile = Profile(id=1, name="Test User", email="test@example.com", location="Berlin",
-                      job_family="SWE")
+    profile = Profile(
+        id=1, name="Test User", email="test@example.com", location="Berlin", job_family="SWE"
+    )
     session.add(profile)
     session.commit()
 
@@ -188,8 +188,9 @@ def test_submit_feedback_scored_job_not_found(client, db_session):
 def test_submit_feedback_wrong_profile(client, db_session):
     """404 when scored_job belongs to a different profile."""
     # Create second profile
-    p2 = Profile(id=2, name="Other User", email="other@example.com",
-                 location="Munich", job_family="TPM")
+    p2 = Profile(
+        id=2, name="Other User", email="other@example.com", location="Munich", job_family="TPM"
+    )
     db_session.add(p2)
     db_session.commit()
 
@@ -238,12 +239,13 @@ def test_list_feedback_empty(client, db_session):
 def test_feedback_stats(client, db_session):
     """Stats endpoint returns count, avg deviation, most common direction."""
     sj = _make_scored_job(db_session, fit_score=8.0)
-    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
-                    direction="too_high", user_score=6.0)
-    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
-                    direction="too_low", user_score=9.0)
-    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
-                    direction="correct")
+    submit_feedback(
+        db_session, scored_job_id=sj.id, profile_id=1, direction="too_high", user_score=6.0
+    )
+    submit_feedback(
+        db_session, scored_job_id=sj.id, profile_id=1, direction="too_low", user_score=9.0
+    )
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1, direction="correct")
 
     resp = client.get("/api/score/feedback/stats", params={"profile_id": 1})
     assert resp.status_code == 200
@@ -555,3 +557,96 @@ def test_integration_submit_retrieve_stats(client, db_session):
     assert stats["implicit_count"] == 0
     # Deviations: |5.0-7.0|=2.0, |9.0-7.0|=2.0 → avg=2.0
     assert stats["avg_deviation"] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Calibration prompt injection (G-274 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationFormatting:
+    """Tests for _format_calibration_section and prompt injection."""
+
+    def test_empty_calibration_returns_empty(self):
+        """No calibration examples → no lines added."""
+        assert _format_calibration_section([]) == []
+
+    def test_calibration_section_includes_header(self):
+        """Calibration section starts with an explanatory header."""
+        examples = [
+            {
+                "job_title": "SWE",
+                "company": "Acme",
+                "ai_score": 8.0,
+                "user_score": 5.0,
+                "reason": None,
+                "deviation": 3.0,
+            }
+        ]
+        lines = _format_calibration_section(examples)
+        assert any("Scoring Calibration" in line for line in lines)
+
+    def test_calibration_section_formats_example(self):
+        """Each example shows job, company, AI score, user score."""
+        examples = [
+            {
+                "job_title": "Backend Engineer",
+                "company": "BigCo",
+                "ai_score": 9.0,
+                "user_score": 6.0,
+                "reason": "Too senior",
+                "deviation": 3.0,
+            }
+        ]
+        lines = _format_calibration_section(examples)
+        detail_line = lines[1]
+        assert "Backend Engineer" in detail_line
+        assert "BigCo" in detail_line
+        assert "9.0" in detail_line
+        assert "6.0" in detail_line
+        assert "Too senior" in detail_line
+
+    def test_calibration_section_handles_missing_metadata(self):
+        """None job_title/company gracefully becomes 'Unknown'."""
+        examples = [
+            {
+                "job_title": None,
+                "company": None,
+                "ai_score": 7.0,
+                "user_score": 4.0,
+                "reason": None,
+                "deviation": 3.0,
+            }
+        ]
+        lines = _format_calibration_section(examples)
+        detail_line = lines[1]
+        assert "Unknown role" in detail_line
+        assert "Unknown company" in detail_line
+
+    def test_build_prompt_includes_calibration(self):
+        """When calibration_examples are passed, they appear in the prompt."""
+        examples = [
+            {
+                "job_title": "SRE",
+                "company": "CloudCo",
+                "ai_score": 8.5,
+                "user_score": 5.5,
+                "reason": None,
+                "deviation": 3.0,
+            }
+        ]
+        prompt = _build_scoring_prompt(
+            job_description="Test JD",
+            profile_data={"name": "Test", "location": "Berlin", "job_family": "SWE"},
+            calibration_examples=examples,
+        )
+        assert "Scoring Calibration" in prompt
+        assert "SRE @ CloudCo" in prompt
+
+    def test_build_prompt_without_calibration(self):
+        """When no calibration_examples, section is absent from prompt."""
+        prompt = _build_scoring_prompt(
+            job_description="Test JD",
+            profile_data={"name": "Test", "location": "Berlin", "job_family": "SWE"},
+        )
+        assert "Scoring Calibration" not in prompt

--- a/tests/test_scoring_feedback.py
+++ b/tests/test_scoring_feedback.py
@@ -1,0 +1,557 @@
+"""Tests for Epic 6 — User Feedback Loop (G-274).
+
+Covers:
+- POST /api/score/{id}/feedback — submit explicit feedback
+- GET /api/score/feedback — list feedback for a profile
+- GET /api/score/feedback/stats — summary statistics
+- Implicit feedback on application creation
+- Implicit feedback when application reaches interview stage
+- get_feedback_calibration() — top deviation examples
+- Feature flag threshold (< 10 records → empty calibration)
+- Feedback references correct original_fit_score snapshot
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.database import Base, get_db
+from career_os.main import app
+from career_os.models.models import Application, Profile
+from career_os.models.scoring import ScoredJob, ScoringFeedback
+from career_os.schemas.applications import ApplicationCreate, ApplicationUpdate
+from career_os.services.scoring import (
+    CALIBRATION_MIN_FEEDBACK,
+    FeedbackNotFoundError,
+    InvalidFeedbackError,
+    get_feedback_calibration,
+    get_feedback_stats,
+    list_feedback,
+    record_implicit_feedback,
+    submit_feedback,
+)
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session():
+    """Fresh in-memory database for each test."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):
+        dbapi_conn.cursor().execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    Session_ = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = Session_()
+
+    profile = Profile(id=1, name="Test User", email="test@example.com", location="Berlin",
+                      job_family="SWE")
+    session.add(profile)
+    session.commit()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client(db_session):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scored_job(db: Session, *, profile_id: int = 1, fit_score: float = 7.5) -> ScoredJob:
+    """Insert a minimal ScoredJob and return it."""
+    sj = ScoredJob(
+        profile_id=profile_id,
+        fit_score=fit_score,
+        readiness_score=60.0,
+        career_alignment=7.0,
+        reasoning="Test reasoning " * 10,
+        estimated_salary="$120k–$150k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Prep notes here.",
+    )
+    db.add(sj)
+    db.commit()
+    db.refresh(sj)
+    return sj
+
+
+def _make_application(db: Session, *, profile_id: int = 1) -> Application:
+    """Insert a minimal Application and return it."""
+    app_obj = Application(
+        profile_id=profile_id,
+        company="Acme Corp",
+        role="Backend Engineer",
+        status="discovered",
+    )
+    db.add(app_obj)
+    db.commit()
+    db.refresh(app_obj)
+    return app_obj
+
+
+# ---------------------------------------------------------------------------
+# POST /api/score/{id}/feedback
+# ---------------------------------------------------------------------------
+
+
+def test_submit_feedback(client, db_session):
+    """Submit feedback with direction and reason — stored correctly."""
+    sj = _make_scored_job(db_session, fit_score=8.0)
+
+    resp = client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "too_high", "reason": "Role is too senior for my experience"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["direction"] == "too_high"
+    assert data["reason"] == "Role is too senior for my experience"
+    assert data["user_score"] is None
+    assert data["original_fit_score"] == 8.0
+    assert data["scored_job_id"] == sj.id
+    assert data["profile_id"] == 1
+
+
+def test_submit_feedback_with_user_score(client, db_session):
+    """Feedback with explicit user_score is stored correctly."""
+    sj = _make_scored_job(db_session, fit_score=9.0)
+
+    resp = client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "too_high", "user_score": 6.5, "reason": "Skills mismatch"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["user_score"] == 6.5
+    assert data["original_fit_score"] == 9.0
+
+
+def test_submit_feedback_invalid_direction(client, db_session):
+    """Invalid direction returns 400."""
+    sj = _make_scored_job(db_session)
+
+    resp = client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "completely_wrong"},
+    )
+    assert resp.status_code == 422  # Pydantic rejects the enum value
+
+
+def test_submit_feedback_user_score_out_of_range(client, db_session):
+    """user_score outside 0–10 returns validation error."""
+    sj = _make_scored_job(db_session)
+
+    resp = client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "too_low", "user_score": 15.0},
+    )
+    assert resp.status_code == 422
+
+
+def test_submit_feedback_scored_job_not_found(client, db_session):
+    """404 when scored_job_id does not exist."""
+    resp = client.post(
+        "/api/score/9999/feedback",
+        params={"profile_id": 1},
+        json={"direction": "correct"},
+    )
+    assert resp.status_code == 404
+
+
+def test_submit_feedback_wrong_profile(client, db_session):
+    """404 when scored_job belongs to a different profile."""
+    # Create second profile
+    p2 = Profile(id=2, name="Other User", email="other@example.com",
+                 location="Munich", job_family="TPM")
+    db_session.add(p2)
+    db_session.commit()
+
+    sj = _make_scored_job(db_session, profile_id=2, fit_score=7.0)
+
+    resp = client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},  # wrong profile
+        json={"direction": "too_low"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/score/feedback
+# ---------------------------------------------------------------------------
+
+
+def test_list_feedback_for_profile(client, db_session):
+    """GET feedback returns all entries for the profile, newest first."""
+    sj = _make_scored_job(db_session)
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1, direction="too_high")
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1, direction="correct")
+
+    resp = client.get("/api/score/feedback", params={"profile_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    # Most recent first
+    assert data[0]["direction"] == "correct"
+    assert data[1]["direction"] == "too_high"
+
+
+def test_list_feedback_empty(client, db_session):
+    """GET feedback returns empty list when no feedback submitted."""
+    resp = client.get("/api/score/feedback", params={"profile_id": 1})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/score/feedback/stats
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_stats(client, db_session):
+    """Stats endpoint returns count, avg deviation, most common direction."""
+    sj = _make_scored_job(db_session, fit_score=8.0)
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
+                    direction="too_high", user_score=6.0)
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
+                    direction="too_low", user_score=9.0)
+    submit_feedback(db_session, scored_job_id=sj.id, profile_id=1,
+                    direction="correct")
+
+    resp = client.get("/api/score/feedback/stats", params={"profile_id": 1})
+    assert resp.status_code == 200
+    stats = resp.json()
+    assert stats["total_count"] == 3
+    assert stats["explicit_count"] == 3
+    assert stats["implicit_count"] == 0
+    # avg deviation: |6.0-8.0|=2.0, |9.0-8.0|=1.0 → avg=1.5
+    assert stats["avg_deviation"] == pytest.approx(1.5)
+    assert stats["direction_counts"]["too_high"] == 1
+    assert stats["direction_counts"]["too_low"] == 1
+    assert stats["direction_counts"]["correct"] == 1
+
+
+def test_feedback_stats_empty(client, db_session):
+    """Stats with no feedback records returns zeros."""
+    resp = client.get("/api/score/feedback/stats", params={"profile_id": 1})
+    assert resp.status_code == 200
+    stats = resp.json()
+    assert stats["total_count"] == 0
+    assert stats["avg_deviation"] is None
+
+
+# ---------------------------------------------------------------------------
+# Implicit feedback — service layer
+# ---------------------------------------------------------------------------
+
+
+def test_implicit_positive_on_application_create(db_session):
+    """Creating an application linked to a ScoredJob records implicit_positive feedback."""
+    app_obj = _make_application(db_session)
+    sj = ScoredJob(
+        profile_id=1,
+        application_id=app_obj.id,
+        fit_score=7.0,
+        readiness_score=55.0,
+        career_alignment=6.5,
+        reasoning="Test reasoning " * 10,
+        estimated_salary="$100k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Notes here.",
+    )
+    db_session.add(sj)
+    db_session.commit()
+
+    # Simulate what ApplicationService.create does post-commit
+    result = record_implicit_feedback(
+        db_session,
+        profile_id=1,
+        direction="implicit_positive",
+        application_id=app_obj.id,
+    )
+
+    assert result is not None
+    assert result.direction == "implicit_positive"
+    assert result.original_fit_score == 7.0
+    assert result.user_score is None
+
+
+def test_implicit_strong_positive_on_interview(db_session):
+    """Application reaching 'interview' status triggers implicit_strong_positive."""
+    app_obj = _make_application(db_session)
+    sj = ScoredJob(
+        profile_id=1,
+        application_id=app_obj.id,
+        fit_score=8.5,
+        readiness_score=70.0,
+        career_alignment=8.0,
+        reasoning="Test reasoning " * 10,
+        estimated_salary="$130k",
+        effort_flag="high",
+        prep_level="intensive",
+        prep_notes="Prepare STAR stories.",
+    )
+    db_session.add(sj)
+    db_session.commit()
+
+    result = record_implicit_feedback(
+        db_session,
+        profile_id=1,
+        direction="implicit_strong_positive",
+        application_id=app_obj.id,
+    )
+
+    assert result is not None
+    assert result.direction == "implicit_strong_positive"
+    assert result.original_fit_score == 8.5
+
+
+def test_implicit_feedback_no_scored_job_returns_none(db_session):
+    """record_implicit_feedback returns None when no ScoredJob exists."""
+    result = record_implicit_feedback(
+        db_session,
+        profile_id=1,
+        direction="implicit_positive",
+        application_id=9999,  # doesn't exist
+    )
+    assert result is None
+
+
+def test_implicit_feedback_invalid_direction_returns_none(db_session):
+    """record_implicit_feedback with an explicit direction returns None (logged, not raised)."""
+    sj = _make_scored_job(db_session)
+    result = record_implicit_feedback(
+        db_session,
+        profile_id=1,
+        direction="too_high",  # explicit direction not allowed for implicit hook
+        scored_job_id=sj.id,
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Calibration summary
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_summary_minimum_threshold(db_session):
+    """With fewer than CALIBRATION_MIN_FEEDBACK records, returns empty list."""
+    sj = _make_scored_job(db_session, fit_score=8.0)
+    # Submit 9 feedback records (below threshold of 10)
+    for i in range(CALIBRATION_MIN_FEEDBACK - 1):
+        submit_feedback(
+            db_session,
+            scored_job_id=sj.id,
+            profile_id=1,
+            direction="too_high",
+            user_score=float(i),
+        )
+
+    result = get_feedback_calibration(db_session, profile_id=1)
+    assert result == []
+
+
+def test_calibration_summary_top_deviations(db_session):
+    """Summary returns the highest-deviation examples when ≥ threshold exist."""
+    sj = _make_scored_job(db_session, fit_score=8.0)
+
+    # Submit enough records to exceed threshold, with varying deviations
+    # Record with biggest deviation: user says 1.0 → deviation = 7.0
+    for _ in range(CALIBRATION_MIN_FEEDBACK):
+        submit_feedback(
+            db_session,
+            scored_job_id=sj.id,
+            profile_id=1,
+            direction="too_high",
+            user_score=1.0,
+        )
+
+    result = get_feedback_calibration(db_session, profile_id=1)
+    # Should return up to 5 examples
+    assert 1 <= len(result) <= 5
+    # All returned examples should have the correct ai_score snapshot
+    for example in result:
+        assert example["ai_score"] == 8.0
+        assert example["user_score"] == 1.0
+        assert example["deviation"] == pytest.approx(7.0)
+
+
+def test_calibration_summary_sorted_by_deviation(db_session):
+    """Calibration examples are sorted highest deviation first."""
+    sj_high = _make_scored_job(db_session, fit_score=9.0)
+    sj_low = _make_scored_job(db_session, fit_score=5.0)
+
+    # For sj_high: user says 2.0 → deviation 7.0
+    # For sj_low: user says 4.0 → deviation 1.0
+    # Submit enough records to exceed the threshold
+    for _ in range(CALIBRATION_MIN_FEEDBACK):
+        submit_feedback(
+            db_session,
+            scored_job_id=sj_high.id,
+            profile_id=1,
+            direction="too_high",
+            user_score=2.0,
+        )
+    submit_feedback(
+        db_session,
+        scored_job_id=sj_low.id,
+        profile_id=1,
+        direction="too_low",
+        user_score=4.0,
+    )
+
+    result = get_feedback_calibration(db_session, profile_id=1)
+    assert len(result) >= 1
+    # First example should have the highest deviation
+    assert result[0]["deviation"] >= result[-1]["deviation"]
+
+
+# ---------------------------------------------------------------------------
+# Feedback references correct original score
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_references_correct_score(db_session):
+    """original_fit_score matches the scored_job's actual fit_score at submission time."""
+    sj = _make_scored_job(db_session, fit_score=6.3)
+
+    fb = submit_feedback(
+        db_session,
+        scored_job_id=sj.id,
+        profile_id=1,
+        direction="too_low",
+        user_score=8.0,
+    )
+
+    assert fb.original_fit_score == pytest.approx(6.3)
+    assert fb.user_score == 8.0
+
+
+def test_submit_feedback_correct_direction_no_user_score(db_session):
+    """'correct' direction can be submitted without a user_score."""
+    sj = _make_scored_job(db_session, fit_score=7.0)
+
+    fb = submit_feedback(
+        db_session,
+        scored_job_id=sj.id,
+        profile_id=1,
+        direction="correct",
+    )
+
+    assert fb.direction == "correct"
+    assert fb.user_score is None
+    assert fb.original_fit_score == 7.0
+
+
+# ---------------------------------------------------------------------------
+# Service-layer validation
+# ---------------------------------------------------------------------------
+
+
+def test_submit_feedback_invalid_direction_raises(db_session):
+    """submit_feedback raises InvalidFeedbackError for unknown direction."""
+    sj = _make_scored_job(db_session)
+
+    with pytest.raises(InvalidFeedbackError, match="Invalid direction"):
+        submit_feedback(
+            db_session,
+            scored_job_id=sj.id,
+            profile_id=1,
+            direction="nonsense",
+        )
+
+
+def test_submit_feedback_bad_user_score_raises(db_session):
+    """submit_feedback raises InvalidFeedbackError when user_score is out of range."""
+    sj = _make_scored_job(db_session)
+
+    with pytest.raises(InvalidFeedbackError, match="user_score"):
+        submit_feedback(
+            db_session,
+            scored_job_id=sj.id,
+            profile_id=1,
+            direction="too_high",
+            user_score=11.0,
+        )
+
+
+def test_submit_feedback_not_found_raises(db_session):
+    """submit_feedback raises FeedbackNotFoundError for unknown scored_job_id."""
+    with pytest.raises(FeedbackNotFoundError):
+        submit_feedback(
+            db_session,
+            scored_job_id=9999,
+            profile_id=1,
+            direction="correct",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: submit → retrieve → verify stats
+# ---------------------------------------------------------------------------
+
+
+def test_integration_submit_retrieve_stats(client, db_session):
+    """Full flow: submit feedback → retrieve list → verify stats match."""
+    sj = _make_scored_job(db_session, fit_score=7.0)
+
+    # Submit three explicit feedbacks
+    client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "too_high", "user_score": 5.0, "reason": "Overvalued"},
+    )
+    client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "too_low", "user_score": 9.0},
+    )
+    client.post(
+        f"/api/score/{sj.id}/feedback",
+        params={"profile_id": 1},
+        json={"direction": "correct"},
+    )
+
+    # Retrieve list
+    list_resp = client.get("/api/score/feedback", params={"profile_id": 1})
+    assert list_resp.status_code == 200
+    records = list_resp.json()
+    assert len(records) == 3
+
+    # Verify stats
+    stats_resp = client.get("/api/score/feedback/stats", params={"profile_id": 1})
+    assert stats_resp.status_code == 200
+    stats = stats_resp.json()
+    assert stats["total_count"] == 3
+    assert stats["explicit_count"] == 3
+    assert stats["implicit_count"] == 0
+    # Deviations: |5.0-7.0|=2.0, |9.0-7.0|=2.0 → avg=2.0
+    assert stats["avg_deviation"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- `ScoringFeedback` model: explicit corrections (too_high/too_low/correct) + implicit signals (applied, interview)
- API: POST /api/score/{id}/feedback, GET /api/score/feedback, GET /api/score/feedback/stats
- Implicit hooks in ApplicationService (create → positive, interview → strong positive)
- `get_feedback_calibration()` returns top-deviation examples for prompt injection
- Calibration wired into `_build_scoring_prompt()` gated by `FEEDBACK_CALIBRATION_ENABLED` flag
- Frontend TypeScript types for all feedback schemas

## Test plan
- [ ] Tests in `tests/test_scoring_feedback.py`
- [ ] CRUD, implicit signals, calibration threshold (≥10 records)
- [ ] Feature flag gating, prompt injection format

🤖 Generated with [Claude Code](https://claude.com/claude-code)