### PR TITLE
feat(G-277): WARN Act layoff integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Documentation = "https://github.com/pleasedodisturb/kestrel/blob/main/docs/QUICK
 "Bug Tracker" = "https://github.com/pleasedodisturb/kestrel/issues"
 
 [project.optional-dependencies]
+warn = [
+    "warn-scraper>=0.4.0",
+]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.25.0",
@@ -79,7 +82,7 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.ruff.lint.per-file-ignores]
 # B008: FastAPI's Depends() pattern is a false positive for function-call-in-default-argument
 "src/career_os/api/*.py" = ["B008", "E741"]
-"src/career_os/cli/*.py" = ["E501"]
+"src/career_os/cli/*.py" = ["E501", "B008"]
 "src/career_os/migration/*.py" = ["E402"]
 "src/career_os/models/*.py" = ["E501"]
 "src/career_os/services/*.py" = ["E501", "SIM117", "E402"]

--- a/src/career_os/_alembic/versions/m4n5o6p7q8r9_add_warn_filings_table.py
+++ b/src/career_os/_alembic/versions/m4n5o6p7q8r9_add_warn_filings_table.py
@@ -1,0 +1,69 @@
+"""Add warn_filings table for WARN Act layoff data (Epic 9 / G-277).
+
+Revision ID: m4n5o6p7q8r9
+Revises: l3g4h5i6j7k8
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "m4n5o6p7q8r9"
+down_revision: Union[str, None] = "l3g4h5i6j7k8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create warn_filings table."""
+    op.create_table(
+        "warn_filings",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("company_name", sa.String(length=500), nullable=False),
+        sa.Column("company_name_normalized", sa.String(length=500), nullable=False),
+        sa.Column("state", sa.String(length=2), nullable=False),
+        sa.Column("employees_affected", sa.Integer(), nullable=True),
+        sa.Column("effective_date", sa.Date(), nullable=True),
+        sa.Column("notice_date", sa.Date(), nullable=False),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_warn_filings_company_name"),
+        "warn_filings",
+        ["company_name"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_warn_filings_company_name_normalized"),
+        "warn_filings",
+        ["company_name_normalized"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_warn_filings_state"),
+        "warn_filings",
+        ["state"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_warn_filings_notice_date"),
+        "warn_filings",
+        ["notice_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop warn_filings table."""
+    op.drop_index(op.f("ix_warn_filings_notice_date"), table_name="warn_filings")
+    op.drop_index(op.f("ix_warn_filings_state"), table_name="warn_filings")
+    op.drop_index(op.f("ix_warn_filings_company_name_normalized"), table_name="warn_filings")
+    op.drop_index(op.f("ix_warn_filings_company_name"), table_name="warn_filings")
+    op.drop_table("warn_filings")

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -92,6 +92,11 @@ from career_os.cli.contacts import contacts_app  # noqa: E402
 
 app.add_typer(contacts_app, name="contacts")
 
+# WARN Act subcommand group (Epic 9 / G-277)
+from career_os.cli.warn import warn_app  # noqa: E402
+
+app.add_typer(warn_app, name="warn")
+
 
 # ---------------------------------------------------------------------------
 # Database helpers

--- a/src/career_os/cli/warn.py
+++ b/src/career_os/cli/warn.py
@@ -1,0 +1,93 @@
+"""CLI commands for WARN Act data management (Epic 9 / G-277).
+
+Usage:
+    kestrel warn-update              # update all default states
+    kestrel warn-update --states CA,NY,WA
+    kestrel warn-update --state CA --state NY
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from career_os.database import SessionLocal
+from career_os.services.warn_data import DEFAULT_STATES, _is_warnscraper_available, load_warn_data
+
+console = Console()
+
+_DEFAULT_STATES_HELP = (
+    "Two-letter state abbreviation to fetch (repeatable). Defaults to: " + ", ".join(DEFAULT_STATES)
+)
+
+warn_app = typer.Typer(
+    name="warn",
+    help="WARN Act layoff data — download and manage filings from state portals.",
+    no_args_is_help=True,
+)
+
+
+@warn_app.command("update")
+def update(
+    states: list[str] = typer.Option(
+        None,
+        "--state",
+        "-s",
+        help=_DEFAULT_STATES_HELP,
+    ),
+) -> None:
+    """Download WARN Act filings from state government portals.
+
+    Fetches current WARN data for the specified states (or all default states)
+    and stores results in the local database. Run weekly to keep data fresh.
+
+    Requires the warn-scraper package:
+        pip install "kestrel-app[warn]"
+    """
+    if not _is_warnscraper_available():
+        console.print(
+            "[bold red]warn-scraper is not installed.[/bold red]\n"
+            "Install it with:\n"
+            '    pip install "kestrel-app[warn]"\n'
+            "or:\n"
+            "    pip install warn-scraper"
+        )
+        raise typer.Exit(code=1)
+
+    target_states = [s.upper() for s in states] if states else DEFAULT_STATES
+
+    console.print(
+        f"[bold]Fetching WARN Act data for {len(target_states)} state(s):[/bold] "
+        + ", ".join(target_states)
+    )
+
+    with SessionLocal() as db:
+        results = load_warn_data(db, states=target_states)
+        db.commit()
+
+    # Summary table
+    table = Table(title="WARN Data Update Results", show_header=True)
+    table.add_column("State", style="bold")
+    table.add_column("Filings", justify="right")
+    table.add_column("Status")
+
+    total = 0
+    for state in target_states:
+        count = results.get(state, 0)
+        if count == -1:
+            table.add_row(state, "—", "[red]failed[/red]")
+        else:
+            table.add_row(state, str(count), "[green]ok[/green]")
+            total += count
+
+    console.print(table)
+    console.print(f"\n[bold green]Done.[/bold green] Total filings processed: {total}")
+
+
+@warn_app.command("list-states")
+def list_states() -> None:
+    """Show the default states tracked for WARN Act data."""
+    console.print("[bold]Default WARN Act states:[/bold]")
+    for state in DEFAULT_STATES:
+        console.print(f"  {state}")

--- a/src/career_os/models/warn.py
+++ b/src/career_os/models/warn.py
@@ -1,0 +1,61 @@
+"""SQLAlchemy ORM model for WARN Act filing records (Epic 9 / G-277).
+
+WARN Act (Worker Adjustment and Retraining Notification Act) requires employers to
+give 60 days notice before mass layoffs. This data is public record, filed with state
+governments. We scrape it via the warn-scraper library and use it as a red-flag signal.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from sqlalchemy import Date, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from career_os.database import Base
+
+
+def _utcnow() -> datetime:
+    """Return timezone-aware UTC now."""
+    return datetime.now(UTC)
+
+
+class WARNFiling(Base):
+    """A single WARN Act notice filed with a state government.
+
+    Data sourced from warn-scraper (biglocalnews/warn-scraper). One row per
+    unique (company_name, state, effective_date) combination; subsequent scrapes
+    for the same notice update the existing row rather than inserting duplicates.
+    """
+
+    __tablename__ = "warn_filings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Raw company name exactly as it appears in the state filing
+    company_name: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
+
+    # Lowercased, suffix-stripped version for fuzzy matching
+    company_name_normalized: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
+
+    state: Mapped[str] = mapped_column(String(2), nullable=False, index=True)
+
+    employees_affected: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Effective date of the layoff (60 days after notice, per WARN Act)
+    effective_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    # Date the notice was filed with the state
+    notice_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<WARNFiling(id={self.id}, company='{self.company_name}', "
+            f"state='{self.state}', notice_date={self.notice_date})>"
+        )

--- a/src/career_os/services/red_flags.py
+++ b/src/career_os/services/red_flags.py
@@ -17,12 +17,15 @@ See ``tests/test_ghost_jobs.py`` for ghost-job detection expectations.
 
 from __future__ import annotations
 
+import logging
 import re
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -462,6 +465,82 @@ def _detect_multi_city_blast(
 
 
 # ---------------------------------------------------------------------------
+# WARN Act layoff detection (Epic 9 / G-277)
+# ---------------------------------------------------------------------------
+
+_WARN_CAUTION_DAYS = 180  # filings within 180 days → caution
+_WARN_WARNING_DAYS = 60  # filings within 60 days → warning (imminent/in-progress)
+
+
+def _detect_recent_layoffs(
+    company_name: str | None,
+    *,
+    db: Session | None = None,
+    today: date | None = None,
+) -> dict[str, str] | None:
+    """Check WARN Act filings for recent layoffs at this company.
+
+    Queries the warn_filings table for any notice filed in the last 180 days.
+    - Filing within 60 days  → severity "warning" (layoffs imminent or in progress)
+    - Filing within 180 days → severity "caution" (recent layoffs, still a risk signal)
+    - No filing / WARN data unavailable → None (no flag emitted)
+
+    This rule is US-only — it silently returns None for non-US roles or when
+    the company name cannot be matched.
+
+    Args:
+        company_name: Company name from the job posting.
+        db: SQLAlchemy session. If None, rule is skipped (no DB access).
+        today: Override for today's date (used in tests).
+
+    Returns:
+        A flag dict or None.
+    """
+    if not company_name or db is None:
+        return None
+
+    # Lazy import to avoid circular dependency and keep warn_data truly optional
+    try:
+        from career_os.services.warn_data import get_filings_for_company
+    except ImportError:
+        logger.debug("warn_data module not available — skipping WARN check")
+        return None
+
+    reference_date = today or datetime.now(UTC).date()
+    cutoff = reference_date - timedelta(days=_WARN_CAUTION_DAYS)
+
+    try:
+        filings = get_filings_for_company(db, company_name, since=cutoff)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("WARN filing lookup failed for '%s': %s", company_name, exc)
+        return None
+
+    if not filings:
+        return None
+
+    # Most recent filing first (get_filings_for_company orders DESC)
+    most_recent = filings[0]
+    age_days = (reference_date - most_recent.notice_date).days
+
+    employee_str = (
+        f" affecting {most_recent.employees_affected:,} employees"
+        if most_recent.employees_affected
+        else ""
+    )
+    description = (
+        f"Company filed WARN Act notice on {most_recent.notice_date.isoformat()}"
+        f"{employee_str} in {most_recent.state}."
+    )
+
+    if age_days <= _WARN_WARNING_DAYS:
+        description += " Layoffs are imminent or currently in progress."
+        return _flag("recent_layoffs", "warning", description)
+
+    description += f" Filed {age_days} days ago — layoff risk signal."
+    return _flag("recent_layoffs", "caution", description)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -473,6 +552,8 @@ def detect_red_flags(
     title: str | None = None,
     salary_range: str | None = None,
     location: str | None = None,
+    company_name: str | None = None,
+    db: Session | None = None,
 ) -> list[dict[str, str]]:
     """Run all rule-based red-flag rules and return any flags found.
 
@@ -517,6 +598,12 @@ def detect_red_flags(
         excessive = _detect_excessive_requirements(job_description)
         if excessive:
             flags.append(excessive)
+
+    # WARN Act layoff check — requires DB session and company name.
+    # Silently skipped if either is absent.
+    layoffs = _detect_recent_layoffs(company_name, db=db)
+    if layoffs:
+        flags.append(layoffs)
 
     return flags
 

--- a/src/career_os/services/warn_data.py
+++ b/src/career_os/services/warn_data.py
@@ -1,0 +1,406 @@
+"""WARN Act data loading and querying service (Epic 9 / G-277).
+
+This module handles:
+- Company name normalization for fuzzy matching across data sources
+- Loading WARN data via the warn-scraper library (optional dependency)
+- Querying warn_filings for a given company name
+- Graceful degradation when warn-scraper is not installed
+
+warn-scraper (pip install warn-scraper) is an open-source CLI/library that
+scrapes WARN Act notices from state government websites. Install via:
+    pip install "kestrel-app[warn]"
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from career_os.models.warn import WARNFiling
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: States with consistently good WARN data coverage.
+DEFAULT_STATES = ["CA", "NY", "WA", "TX", "IL", "MA", "CO", "GA"]
+
+#: Common company name suffixes to strip for normalization.
+_COMPANY_SUFFIXES = re.compile(
+    r"""\s*[,.]?\s*\b(
+        llc|l\.l\.c\.|
+        inc|incorporated|
+        corp|corporation|
+        ltd|limited|
+        co\b|company|
+        lp|l\.p\.|
+        llp|l\.l\.p\.|
+        pllc|
+        plc|
+        gmbh|ag|sa|bv|
+        group|holdings|holding|
+        technologies|technology|tech|
+        solutions|services|systems|
+        international|global|
+        north\s+america|usa|us
+    )\b\s*$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9\s]")
+_EXTRA_WHITESPACE = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# Company name normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_company_name(name: str) -> str:
+    """Normalize a company name for fuzzy matching across data sources.
+
+    Steps:
+    1. Lowercase
+    2. Strip trailing legal suffixes (LLC, Inc, Corp, etc.)
+    3. Remove punctuation
+    4. Collapse whitespace
+    5. Strip
+
+    Examples:
+        "Google LLC" -> "google"
+        "Meta Platforms, Inc." -> "meta platforms"
+        "Amazon.com, Inc." -> "amazoncom"  (dot removed, not suffix)
+        "Microsoft Corporation" -> "microsoft"
+    """
+    if not name:
+        return ""
+
+    normalized = name.lower().strip()
+
+    # Iteratively strip suffixes — some companies have stacked suffixes like "Corp., Inc."
+    prev = None
+    while prev != normalized:
+        prev = normalized
+        normalized = _COMPANY_SUFFIXES.sub("", normalized).strip().rstrip(",.")
+
+    # Remove non-alphanumeric characters (punctuation, special chars)
+    normalized = _NON_ALPHANUMERIC.sub("", normalized)
+
+    # Collapse extra whitespace
+    normalized = _EXTRA_WHITESPACE.sub(" ", normalized).strip()
+
+    return normalized
+
+
+def company_names_match(filing_name: str, job_company: str, *, threshold: int = 0) -> bool:
+    """Return True if two company names match after normalization.
+
+    For an exact normalized match (threshold=0), both normalized strings must be equal.
+    This avoids false positives from substring matching (e.g. "Apple" matching "Pineapple").
+
+    Args:
+        filing_name: Company name from a WARN Act filing.
+        job_company: Company name from a job posting.
+        threshold: Reserved for future fuzzy matching (Levenshtein distance).
+                   Currently only exact match (0) is supported.
+
+    Returns:
+        True if the normalized names are considered a match.
+    """
+    norm_filing = normalize_company_name(filing_name)
+    norm_job = normalize_company_name(job_company)
+
+    if not norm_filing or not norm_job:
+        return False
+
+    if threshold == 0:
+        return norm_filing == norm_job
+
+    # Future: Levenshtein / token-set ratio
+    return norm_filing == norm_job
+
+
+# ---------------------------------------------------------------------------
+# Database queries
+# ---------------------------------------------------------------------------
+
+
+def get_filings_for_company(
+    db: Session,
+    company_name: str,
+    *,
+    since: date | None = None,
+) -> list[WARNFiling]:
+    """Return all WARN filings matching the given company name.
+
+    Uses normalized name matching. If `since` is provided, only filings with
+    notice_date >= since are returned.
+
+    Args:
+        db: SQLAlchemy synchronous session.
+        company_name: Company name to look up (will be normalized).
+        since: Optional cutoff date for notice_date.
+
+    Returns:
+        List of matching WARNFiling ORM objects, ordered by notice_date DESC.
+    """
+    normalized = normalize_company_name(company_name)
+    if not normalized:
+        return []
+
+    # Pull all filings for the normalized name from the DB.
+    # We do post-filter matching because partial-token matching may be added later.
+    query = db.query(WARNFiling).filter(WARNFiling.company_name_normalized == normalized)
+    if since is not None:
+        query = query.filter(WARNFiling.notice_date >= since)
+
+    return query.order_by(WARNFiling.notice_date.desc()).all()
+
+
+def upsert_filing(
+    db: Session,
+    *,
+    company_name: str,
+    state: str,
+    notice_date: date,
+    effective_date: date | None = None,
+    employees_affected: int | None = None,
+    source_url: str | None = None,
+) -> WARNFiling:
+    """Insert a WARN filing or return the existing one if already present.
+
+    Deduplication key: (company_name_normalized, state, notice_date).
+
+    Args:
+        db: SQLAlchemy synchronous session.
+        company_name: Raw company name from the state filing.
+        state: Two-letter state abbreviation.
+        notice_date: Date the notice was filed.
+        effective_date: Effective date of the layoff (optional).
+        employees_affected: Number of employees affected (optional).
+        source_url: URL of the source page (optional).
+
+    Returns:
+        The existing or newly created WARNFiling instance.
+    """
+    normalized = normalize_company_name(company_name)
+    state_upper = state.upper()[:2]
+
+    existing = (
+        db.query(WARNFiling)
+        .filter(
+            WARNFiling.company_name_normalized == normalized,
+            WARNFiling.state == state_upper,
+            WARNFiling.notice_date == notice_date,
+        )
+        .first()
+    )
+
+    if existing is not None:
+        # Update mutable fields if we have richer data now
+        if employees_affected is not None and existing.employees_affected is None:
+            existing.employees_affected = employees_affected
+        if effective_date is not None and existing.effective_date is None:
+            existing.effective_date = effective_date
+        return existing
+
+    filing = WARNFiling(
+        company_name=company_name,
+        company_name_normalized=normalized,
+        state=state_upper,
+        notice_date=notice_date,
+        effective_date=effective_date,
+        employees_affected=employees_affected,
+        source_url=source_url,
+        created_at=datetime.now(UTC),
+    )
+    db.add(filing)
+    return filing
+
+
+# ---------------------------------------------------------------------------
+# Data loading via warn-scraper
+# ---------------------------------------------------------------------------
+
+
+def _is_warnscraper_available() -> bool:
+    """Return True if the warn-scraper package is importable."""
+    try:
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            import warn  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def load_warn_data_for_state(
+    db: Session,
+    state: str,
+) -> int:
+    """Download and store WARN filings for a single state.
+
+    Uses the warn-scraper library to fetch current data from the state's WARN
+    portal. Each filing is upserted into the warn_filings table.
+
+    Args:
+        db: SQLAlchemy synchronous session (caller commits).
+        state: Two-letter state abbreviation (e.g. "CA").
+
+    Returns:
+        Number of filings inserted or updated.
+
+    Raises:
+        ImportError: If warn-scraper is not installed. Callers should handle
+                     this gracefully.
+        RuntimeError: If the scraper fails for this state.
+    """
+    try:
+        import warn as warnscraper
+    except ImportError as exc:
+        raise ImportError(
+            "warn-scraper is not installed. Install it with: pip install 'kestrel-app[warn]'"
+        ) from exc
+
+    logger.info("Fetching WARN data for state: %s", state)
+
+    try:
+        scraper_class = warnscraper.get_scraper(state.upper())
+        scraper = scraper_class()
+        rows = scraper.scrape()
+    except Exception as exc:
+        raise RuntimeError(f"warn-scraper failed for state {state}: {exc}") from exc
+
+    count = 0
+    for row in rows:
+        # warn-scraper uses different column names per state; try common patterns.
+        company = (
+            row.get("company")
+            or row.get("company_name")
+            or row.get("employer")
+            or row.get("Employer")
+            or ""
+        )
+        if not company:
+            continue
+
+        # Notice date parsing — warn-scraper returns strings or date objects
+        raw_notice = (
+            row.get("notice_date") or row.get("date") or row.get("received_date") or row.get("Date")
+        )
+        notice_date = _parse_date(raw_notice)
+        if notice_date is None:
+            logger.debug("Skipping row with unparseable notice date: %r", row)
+            continue
+
+        raw_effective = (
+            row.get("effective_date") or row.get("layoff_date") or row.get("Effective Date")
+        )
+        effective_date = _parse_date(raw_effective)
+
+        raw_employees = row.get("employees") or row.get("workers_affected") or row.get("Employees")
+        employees_affected = _parse_int(raw_employees)
+
+        upsert_filing(
+            db,
+            company_name=str(company).strip(),
+            state=state.upper(),
+            notice_date=notice_date,
+            effective_date=effective_date,
+            employees_affected=employees_affected,
+        )
+        count += 1
+
+    db.flush()
+    logger.info("State %s: upserted %d filings", state, count)
+    return count
+
+
+def load_warn_data(
+    db: Session,
+    states: list[str] | None = None,
+) -> dict[str, int]:
+    """Download and store WARN filings for multiple states.
+
+    Args:
+        db: SQLAlchemy synchronous session (caller commits after).
+        states: List of two-letter state abbreviations. Defaults to DEFAULT_STATES.
+
+    Returns:
+        Dict mapping state -> number of filings processed. States that
+        failed are mapped to -1.
+    """
+    if not _is_warnscraper_available():
+        logger.warning(
+            "warn-scraper not installed — WARN data loading skipped. "
+            "Install with: pip install 'kestrel-app[warn]'"
+        )
+        return {}
+
+    if states is None:
+        states = DEFAULT_STATES
+
+    results: dict[str, int] = {}
+    for state in states:
+        try:
+            results[state] = load_warn_data_for_state(db, state)
+        except (RuntimeError, ImportError) as exc:
+            logger.warning("Failed to load WARN data for %s: %s", state, exc)
+            results[state] = -1
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_date(value: object) -> date | None:
+    """Parse a date from various types returned by warn-scraper."""
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y", "%Y/%m/%d", "%d-%b-%Y", "%B %d, %Y"):
+            try:
+                return datetime.strptime(value, fmt).date()
+            except ValueError:
+                continue
+    return None
+
+
+def _parse_int(value: object) -> int | None:
+    """Parse an integer from various representations."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        cleaned = re.sub(r"[^\d]", "", value)
+        if cleaned:
+            try:
+                return int(cleaned)
+            except ValueError:
+                pass
+    return None

--- a/tests/test_warn_integration.py
+++ b/tests/test_warn_integration.py
@@ -397,8 +397,8 @@ class TestGracefulSkipNoWarnScraper:
         career_os.services.warn_data raise ImportError. The function must catch
         this and return None rather than propagating the error.
         """
-        import sys
         import importlib
+        import sys
 
         # Remove warn_data from sys.modules so the lazy import re-executes,
         # then substitute a broken module reference.

--- a/tests/test_warn_integration.py
+++ b/tests/test_warn_integration.py
@@ -1,0 +1,461 @@
+"""Tests for WARN Act layoff integration (Epic 9 / G-277).
+
+Covers:
+- Company name normalization
+- Filing lookup and severity thresholds
+- Red flag detection via detect_red_flags()
+- Graceful degradation when warn-scraper is absent
+- Flag description content
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from career_os.database import Base
+from career_os.models.warn import WARNFiling
+from career_os.services.red_flags import _detect_recent_layoffs, detect_red_flags
+from career_os.services.warn_data import (
+    _parse_date,
+    _parse_int,
+    company_names_match,
+    get_filings_for_company,
+    load_warn_data,
+    normalize_company_name,
+    upsert_filing,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """In-memory SQLite engine with warn_filings table."""
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def db(engine):
+    """Transactional test session that rolls back after each test."""
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _make_filing(
+    db: Session,
+    company_name: str,
+    state: str = "CA",
+    notice_date: date | None = None,
+    employees_affected: int | None = 100,
+    effective_date: date | None = None,
+) -> WARNFiling:
+    """Helper: insert a WARNFiling and flush."""
+    nd = notice_date or date.today()
+    filing = upsert_filing(
+        db,
+        company_name=company_name,
+        state=state,
+        notice_date=nd,
+        effective_date=effective_date,
+        employees_affected=employees_affected,
+    )
+    db.flush()
+    return filing
+
+
+# ---------------------------------------------------------------------------
+# Company name normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCompanyName:
+    def test_strips_llc(self):
+        assert normalize_company_name("Acme LLC") == "acme"
+
+    def test_strips_inc(self):
+        assert normalize_company_name("Acme Inc") == "acme"
+
+    def test_strips_incorporated(self):
+        assert normalize_company_name("Acme Incorporated") == "acme"
+
+    def test_strips_corp(self):
+        assert normalize_company_name("Acme Corp") == "acme"
+
+    def test_strips_corporation(self):
+        assert normalize_company_name("Acme Corporation") == "acme"
+
+    def test_strips_ltd(self):
+        assert normalize_company_name("Acme Ltd") == "acme"
+
+    def test_strips_limited(self):
+        assert normalize_company_name("Acme Limited") == "acme"
+
+    def test_google_llc(self):
+        assert normalize_company_name("Google LLC") == "google"
+
+    def test_meta_platforms_inc(self):
+        assert normalize_company_name("Meta Platforms, Inc.") == "meta platforms"
+
+    def test_microsoft_corporation(self):
+        assert normalize_company_name("Microsoft Corporation") == "microsoft"
+
+    def test_already_normalized(self):
+        assert normalize_company_name("acme") == "acme"
+
+    def test_empty_string(self):
+        assert normalize_company_name("") == ""
+
+    def test_removes_punctuation(self):
+        assert normalize_company_name("Acme, Inc.") == "acme"
+
+    def test_case_insensitive(self):
+        assert normalize_company_name("ACME LLC") == "acme"
+
+    def test_extra_whitespace(self):
+        assert normalize_company_name("  Acme  LLC  ") == "acme"
+
+    def test_stacked_suffixes(self):
+        # "Corp., Inc." — two suffixes
+        assert normalize_company_name("Acme Corp., Inc.") == "acme"
+
+    def test_multi_word_company(self):
+        # Suffixes are stripped iteratively until no more match.
+        # "Sunrise Foods Company Inc" → strip "inc" → strip "company" → "sunrise foods"
+        assert normalize_company_name("Sunrise Foods Company Inc") == "sunrise foods"
+
+
+class TestCompanyNamesMatch:
+    def test_match_with_llc_vs_bare(self):
+        assert company_names_match("Google LLC", "Google") is True
+
+    def test_match_inc_vs_bare(self):
+        assert company_names_match("Stripe, Inc.", "Stripe") is True
+
+    def test_no_match_different_companies(self):
+        assert company_names_match("Apple Inc", "Microsoft") is False
+
+    def test_no_match_empty_job(self):
+        assert company_names_match("Acme LLC", "") is False
+
+    def test_no_match_empty_filing(self):
+        assert company_names_match("", "Acme") is False
+
+    def test_case_insensitive_match(self):
+        assert company_names_match("ACME CORP", "acme") is True
+
+    def test_exact_match_both_bare(self):
+        assert company_names_match("stripe", "stripe") is True
+
+
+# ---------------------------------------------------------------------------
+# Database upsert / dedup
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertFiling:
+    def test_inserts_new_filing(self, db):
+        filing = _make_filing(db, "TestCo LLC", notice_date=date(2026, 1, 1))
+        assert filing.id is not None
+        assert filing.company_name_normalized == "testco"
+
+    def test_dedup_returns_existing(self, db):
+        nd = date(2026, 2, 1)
+        f1 = upsert_filing(db, company_name="Acme LLC", state="CA", notice_date=nd)
+        db.flush()
+        f2 = upsert_filing(db, company_name="Acme LLC", state="CA", notice_date=nd)
+        db.flush()
+        assert f1.id == f2.id
+
+    def test_enriches_existing_with_employee_count(self, db):
+        nd = date(2026, 3, 1)
+        f1 = upsert_filing(
+            db, company_name="Acme LLC", state="NY", notice_date=nd, employees_affected=None
+        )
+        db.flush()
+        f2 = upsert_filing(
+            db, company_name="Acme LLC", state="NY", notice_date=nd, employees_affected=250
+        )
+        db.flush()
+        assert f1.id == f2.id
+        assert f1.employees_affected == 250
+
+    def test_different_state_creates_new_row(self, db):
+        nd = date(2026, 4, 1)
+        f1 = upsert_filing(db, company_name="Acme LLC", state="CA", notice_date=nd)
+        db.flush()
+        f2 = upsert_filing(db, company_name="Acme LLC", state="TX", notice_date=nd)
+        db.flush()
+        assert f1.id != f2.id
+
+
+# ---------------------------------------------------------------------------
+# Filing lookups
+# ---------------------------------------------------------------------------
+
+
+class TestGetFilingsForCompany:
+    def test_returns_matching_filings(self, db):
+        _make_filing(db, "Stripe, Inc.", state="CA", notice_date=date(2026, 1, 15))
+        results = get_filings_for_company(db, "Stripe")
+        assert len(results) >= 1
+        assert results[0].company_name == "Stripe, Inc."
+
+    def test_no_match_returns_empty(self, db):
+        results = get_filings_for_company(db, "NonExistentCo")
+        assert results == []
+
+    def test_empty_name_returns_empty(self, db):
+        results = get_filings_for_company(db, "")
+        assert results == []
+
+    def test_since_filter_excludes_old(self, db):
+        _make_filing(db, "OldCo LLC", notice_date=date(2024, 1, 1))
+        _make_filing(db, "OldCo LLC", notice_date=date(2026, 1, 1))
+        results = get_filings_for_company(db, "OldCo", since=date(2025, 6, 1))
+        assert len(results) == 1
+        assert results[0].notice_date == date(2026, 1, 1)
+
+    def test_orders_by_notice_date_desc(self, db):
+        _make_filing(db, "BigCorp Inc", notice_date=date(2025, 6, 1))
+        _make_filing(db, "BigCorp Inc", notice_date=date(2026, 1, 1), state="NY")
+        results = get_filings_for_company(db, "BigCorp")
+        assert results[0].notice_date > results[-1].notice_date
+
+
+# ---------------------------------------------------------------------------
+# _detect_recent_layoffs severity thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRecentLayoffs:
+    def test_warn_within_60_days_severity_warning(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=30)
+        _make_filing(db, "RifCo Inc", notice_date=notice, employees_affected=200)
+
+        flag = _detect_recent_layoffs("RifCo Inc", db=db, today=today)
+        assert flag is not None
+        assert flag["severity"] == "warning"
+        assert flag["flag_type"] == "recent_layoffs"
+
+    def test_warn_61_to_180_days_severity_caution(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=90)
+        _make_filing(db, "CautionCo LLC", notice_date=notice, employees_affected=50)
+
+        flag = _detect_recent_layoffs("CautionCo LLC", db=db, today=today)
+        assert flag is not None
+        assert flag["severity"] == "caution"
+
+    def test_warn_older_than_180_days_no_flag(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=200)
+        _make_filing(db, "OldLayoffCo", notice_date=notice)
+
+        flag = _detect_recent_layoffs("OldLayoffCo", db=db, today=today)
+        assert flag is None
+
+    def test_no_warn_data_no_flag(self, db):
+        flag = _detect_recent_layoffs("CleanCompany LLC", db=db, today=date(2026, 4, 14))
+        assert flag is None
+
+    def test_no_db_returns_none(self):
+        flag = _detect_recent_layoffs("AnyCompany", db=None)
+        assert flag is None
+
+    def test_no_company_name_returns_none(self, db):
+        flag = _detect_recent_layoffs(None, db=db)
+        assert flag is None
+
+    def test_empty_company_name_returns_none(self, db):
+        flag = _detect_recent_layoffs("", db=db)
+        assert flag is None
+
+
+# ---------------------------------------------------------------------------
+# Flag description content
+# ---------------------------------------------------------------------------
+
+
+class TestWarnFlagDescription:
+    def test_description_includes_date(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=20)
+        _make_filing(db, "DescriptCo", notice_date=notice, employees_affected=300)
+
+        flag = _detect_recent_layoffs("DescriptCo", db=db, today=today)
+        assert flag is not None
+        assert notice.isoformat() in flag["description"]
+
+    def test_description_includes_employee_count(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=15)
+        _make_filing(db, "HeadcountCo", notice_date=notice, employees_affected=500)
+
+        flag = _detect_recent_layoffs("HeadcountCo", db=db, today=today)
+        assert flag is not None
+        assert "500" in flag["description"]
+
+    def test_description_includes_state(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=10)
+        _make_filing(db, "StateCo Inc", state="WA", notice_date=notice)
+
+        flag = _detect_recent_layoffs("StateCo Inc", db=db, today=today)
+        assert flag is not None
+        assert "WA" in flag["description"]
+
+    def test_description_without_employee_count(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=10)
+        _make_filing(db, "NullEmployeesCo", notice_date=notice, employees_affected=None)
+
+        flag = _detect_recent_layoffs("NullEmployeesCo", db=db, today=today)
+        assert flag is not None
+        # Should not crash and should not include 'None'
+        assert "None" not in flag["description"]
+
+
+# ---------------------------------------------------------------------------
+# detect_red_flags() integration
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRedFlagsWarnIntegration:
+    def test_warn_flag_appears_in_detect_red_flags(self, db):
+        today = date(2026, 4, 14)
+        notice = today - timedelta(days=30)
+        _make_filing(db, "RiskyBiz Inc", notice_date=notice, employees_affected=150)
+
+        with patch("career_os.services.red_flags._detect_recent_layoffs") as mock_detect:
+            mock_detect.return_value = {
+                "flag_type": "recent_layoffs",
+                "severity": "warning",
+                "description": "WARN filing 30 days ago.",
+            }
+            flags = detect_red_flags(
+                "Great job opportunity.",
+                company_name="RiskyBiz Inc",
+                db=db,
+            )
+
+        warn_flags = [f for f in flags if f["flag_type"] == "recent_layoffs"]
+        assert len(warn_flags) == 1
+
+    def test_no_warn_flag_when_no_company(self, db):
+        flags = detect_red_flags("Great job opportunity.", db=db)
+        warn_flags = [f for f in flags if f["flag_type"] == "recent_layoffs"]
+        assert len(warn_flags) == 0
+
+    def test_no_warn_flag_when_no_db(self):
+        flags = detect_red_flags("Great job opportunity.", company_name="SomeCo")
+        warn_flags = [f for f in flags if f["flag_type"] == "recent_layoffs"]
+        assert len(warn_flags) == 0
+
+    def test_existing_rules_unaffected(self, db):
+        """Adding WARN parameters must not break existing red flag rules."""
+        old_flags = detect_red_flags("Great job opportunity.")
+        new_flags = detect_red_flags(
+            "Great job opportunity.",
+            company_name="CleanCo",
+            db=db,
+        )
+        # Both should produce same base flags (no WARN filing in DB for CleanCo)
+        assert old_flags == new_flags
+
+
+# ---------------------------------------------------------------------------
+# Graceful skip when warn-scraper not installed
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulSkipNoWarnScraper:
+    def test_load_warn_data_skips_gracefully_when_not_installed(self, db):
+        """load_warn_data returns {} without raising when warn-scraper absent."""
+        with patch("career_os.services.warn_data._is_warnscraper_available", return_value=False):
+            result = load_warn_data(db, states=["CA", "NY"])
+        assert result == {}
+
+    def test_detect_recent_layoffs_skips_on_import_error(self, db):
+        """_detect_recent_layoffs returns None when warn_data module import fails.
+
+        Simulates warn-scraper not being installed by making the lazy import of
+        career_os.services.warn_data raise ImportError. The function must catch
+        this and return None rather than propagating the error.
+        """
+        import sys
+        import importlib
+
+        # Remove warn_data from sys.modules so the lazy import re-executes,
+        # then substitute a broken module reference.
+        saved = sys.modules.pop("career_os.services.warn_data", None)
+        sys.modules["career_os.services.warn_data"] = None  # type: ignore[assignment]
+        try:
+            flag = _detect_recent_layoffs("SomeCo", db=db)
+            assert flag is None
+        finally:
+            if saved is not None:
+                sys.modules["career_os.services.warn_data"] = saved
+            else:
+                sys.modules.pop("career_os.services.warn_data", None)
+                importlib.import_module("career_os.services.warn_data")
+
+
+# ---------------------------------------------------------------------------
+# Internal helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDateHelper:
+    def test_parses_iso_string(self):
+        assert _parse_date("2026-01-15") == date(2026, 1, 15)
+
+    def test_parses_us_format(self):
+        assert _parse_date("01/15/2026") == date(2026, 1, 15)
+
+    def test_parses_date_object(self):
+        d = date(2026, 3, 10)
+        assert _parse_date(d) == d
+
+    def test_returns_none_for_none(self):
+        assert _parse_date(None) is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _parse_date("") is None
+
+    def test_returns_none_for_unparseable(self):
+        assert _parse_date("not-a-date") is None
+
+
+class TestParseIntHelper:
+    def test_parses_int(self):
+        assert _parse_int(42) == 42
+
+    def test_parses_float(self):
+        assert _parse_int(42.0) == 42
+
+    def test_parses_string_with_commas(self):
+        assert _parse_int("1,500") == 1500
+
+    def test_returns_none_for_none(self):
+        assert _parse_int(None) is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _parse_int("") is None
+
+    def test_returns_none_for_non_numeric(self):
+        assert _parse_int("n/a") is None


### PR DESCRIPTION
## Summary
- `WARNFiling` model with company name normalization
- Data loading via warn-scraper for 8+ US states (CA, NY, WA, TX, IL, MA, CO, GA)
- `_detect_recent_layoffs()` red flag rule: ≤60 days → warning, 61-180 days → caution
- CLI command: `kestrel warn-update [--state CA] [--state NY]`
- warn-scraper as optional dependency (`pip install "kestrel-app[warn]"`)
- Graceful skip if warn-scraper not installed

## Test plan
- [ ] 50+ tests in `tests/test_warn_integration.py` (461 lines)
- [ ] Normalization, deduplication, severity thresholds
- [ ] Graceful degradation, date/int parsing
- [ ] Integration with detect_red_flags()

🤖 Generated with [Claude Code](https://claude.com/claude-code)