### PR TITLE
feat(G-279): Bayesian preference learning from feedback

### DIFF
--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -21,6 +21,12 @@ from career_os.schemas.scoring import (
     ScoreResponse,
     ScoringWeightsResponse,
     ScoringWeightsUpdate,
+    SuggestionsResponse,
+    WeightSuggestionResponse,
+)
+from career_os.services.preference_learning import (
+    SUGGESTION_MIN_FEEDBACK,
+    generate_suggestions,
 )
 from career_os.services.pushover import send_credits_exhausted_alert
 from career_os.services.scoring import (
@@ -344,3 +350,44 @@ async def feedback_stats_endpoint(
     """
     stats = get_feedback_stats(db, profile_id)
     return FeedbackStats(**stats)
+
+
+# ---------------------------------------------------------------------------
+# Bayesian Preference Learning (Epic 11 / G-279)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/score/suggestions")
+async def suggestions_endpoint(
+    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    db: Annotated[Session, Depends(get_db)],
+) -> SuggestionsResponse:
+    """Get weight adjustment suggestions based on accumulated feedback.
+
+    Analyzes patterns in user feedback (explicit corrections and implicit
+    signals) using a Bayesian preference model to suggest scoring weight
+    changes. Returns suggestions only when ≥15 feedback records exist and
+    the model has sufficient confidence.
+
+    Suggestions are presented for review — they are never auto-applied.
+    """
+    from career_os.models.scoring import ScoringFeedback as SFModel
+
+    feedback_count = db.query(SFModel).filter(SFModel.profile_id == profile_id).count()
+    ready = feedback_count >= SUGGESTION_MIN_FEEDBACK
+
+    if not ready:
+        return SuggestionsResponse(
+            suggestions=[],
+            feedback_count=feedback_count,
+            min_feedback_required=SUGGESTION_MIN_FEEDBACK,
+            ready=False,
+        )
+
+    suggestions = generate_suggestions(db, profile_id)
+    return SuggestionsResponse(
+        suggestions=[WeightSuggestionResponse(**s.to_dict()) for s in suggestions],
+        feedback_count=feedback_count,
+        min_feedback_required=SUGGESTION_MIN_FEEDBACK,
+        ready=True,
+    )

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -40,6 +40,12 @@ class Settings(BaseSettings):
     # until the user has provided enough feedback. Can be disabled via env var.
     feedback_calibration_enabled: bool = True
 
+    # Active query selection (Epic 11 / G-279) — when enabled, borderline
+    # scores may include a prompt asking the user for feedback to reduce
+    # preference model uncertainty.  Disabled by default to avoid annoying
+    # users with too many prompts.
+    active_query_enabled: bool = False
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     # Per-provider API key requirements: provider → (settings_attr, expected_prefix).

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -477,3 +477,48 @@ class CalibrationExample(BaseModel):
     user_score: float
     reason: str | None = None
     deviation: float
+
+
+# ---------------------------------------------------------------------------
+# Bayesian Preference Learning (Epic 11 / G-279)
+# ---------------------------------------------------------------------------
+
+
+class WeightSuggestionResponse(BaseModel):
+    """A single weight adjustment suggestion from the preference model."""
+
+    dimension: str = Field(..., description="Weight dimension name (e.g. 'skills_match')")
+    current_weight: float = Field(..., ge=0, le=1, description="Current configured weight")
+    suggested_weight: float = Field(..., ge=0, le=1, description="Suggested new weight")
+    confidence: float = Field(..., ge=0, le=1, description="Confidence in the suggestion (0-1)")
+    reason: str = Field(..., description="Human-readable explanation of the suggestion")
+
+
+class SuggestionsResponse(BaseModel):
+    """Response for GET /api/score/suggestions — weight adjustment suggestions."""
+
+    suggestions: list[WeightSuggestionResponse] = Field(
+        default_factory=list,
+        description="Weight adjustment suggestions based on feedback patterns",
+    )
+    feedback_count: int = Field(
+        ..., description="Total feedback records used to generate suggestions"
+    )
+    min_feedback_required: int = Field(
+        ..., description="Minimum feedback records needed before suggestions appear"
+    )
+    ready: bool = Field(..., description="True when enough feedback exists to generate suggestions")
+
+
+class ActiveQueryResponse(BaseModel):
+    """Optional active query suggestion returned with a score."""
+
+    should_query: bool = Field(..., description="Whether to prompt the user for feedback")
+    uncertain_dimensions: list[str] = Field(
+        default_factory=list,
+        description="Dimensions with highest uncertainty that would benefit from feedback",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Suggested prompt message for the user (e.g. 'Would you apply to this?')",
+    )

--- a/src/career_os/services/preference_learning.py
+++ b/src/career_os/services/preference_learning.py
@@ -1,0 +1,363 @@
+"""Bayesian Preference Learning — Epic 11 (G-279).
+
+Maintains per-dimension Beta distributions updated from user feedback,
+generates weight adjustment suggestions, and selects active queries
+for borderline scores.
+
+The preference model is computed on-the-fly from existing ScoringFeedback
+and ScoredJob records — no new tables required.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from career_os.models.scoring import ScoredJob, ScoringFeedback, ScoringWeights
+from career_os.services.scoring import get_or_create_weights
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Minimum feedback records before suggestions are generated.
+SUGGESTION_MIN_FEEDBACK = 15
+
+#: Minimum confidence to include a suggestion in results.
+SUGGESTION_MIN_CONFIDENCE = 0.6
+
+#: Minimum absolute weight delta to consider a suggestion meaningful.
+SUGGESTION_MIN_DELTA = 0.03
+
+#: Learning rate for Bayesian updates (controls how much each feedback record
+#: shifts the posterior).  Smaller = slower adaptation, more stability.
+LEARNING_RATE = 0.5
+
+#: Fit-score band considered "borderline" for active query selection.
+BORDERLINE_LOW = 4.5
+BORDERLINE_HIGH = 5.5
+
+#: Uncertainty threshold (variance of Beta distribution) above which a
+#: dimension is considered "uncertain enough" to benefit from a query.
+UNCERTAINTY_THRESHOLD = 0.02
+
+# ---------------------------------------------------------------------------
+# Dimension ↔ Weight mapping
+# ---------------------------------------------------------------------------
+
+#: Maps ScoringWeights attribute names to ScoredJob dimensional column names.
+WEIGHT_TO_DIMENSION: dict[str, str | None] = {
+    "skills_match": "dim_technical_fit",
+    "career_alignment": "dim_career_trajectory",
+    "culture_fit": "dim_company_fit",
+    "salary_match": "dim_compensation_fit",
+    "location_match": "dim_location_fit",
+    "growth_potential": "dim_seniority_alignment",
+    "remote_preference": None,  # no direct dimensional score
+}
+
+#: Reverse mapping for convenience.
+DIMENSION_TO_WEIGHT: dict[str, str] = {
+    v: k for k, v in WEIGHT_TO_DIMENSION.items() if v is not None
+}
+
+
+# ---------------------------------------------------------------------------
+# Beta distribution helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BetaDistribution:
+    """Parameterisation of a Beta(α, β) distribution."""
+
+    alpha: float
+    beta: float
+
+    @property
+    def mean(self) -> float:
+        """Expected value of the distribution."""
+        total = self.alpha + self.beta
+        if total == 0:
+            return 0.5
+        return self.alpha / total
+
+    @property
+    def variance(self) -> float:
+        """Variance of the distribution."""
+        a, b = self.alpha, self.beta
+        total = a + b
+        if total == 0 or total + 1 == 0:
+            return 0.0
+        return (a * b) / (total * total * (total + 1))
+
+    def update_too_high(self, dim_score_normalised: float) -> None:
+        """User says overall score was too high — dimension may be overvalued.
+
+        If the dimension scored high for this job, increase β (evidence that
+        the dimension contributed to an inflated score).
+        """
+        self.beta += LEARNING_RATE * dim_score_normalised
+
+    def update_too_low(self, dim_score_normalised: float) -> None:
+        """User says overall score was too low — dimension may be undervalued.
+
+        If the dimension scored high for this job but the user thought the
+        overall score should be higher, increase α (evidence that the
+        dimension is more important than the weight suggests).
+        """
+        self.alpha += LEARNING_RATE * dim_score_normalised
+
+    def update_correct(self) -> None:
+        """User confirms the score was correct — reinforce both α and β slightly."""
+        self.alpha += LEARNING_RATE * 0.1
+        self.beta += LEARNING_RATE * 0.1
+
+
+@dataclass
+class PreferenceModel:
+    """Per-profile Bayesian preference model.
+
+    Each dimension has its own Beta distribution whose prior is derived
+    from the user's configured weight.
+    """
+
+    distributions: dict[str, BetaDistribution] = field(default_factory=dict)
+
+    @classmethod
+    def from_weights(cls, weights: ScoringWeights) -> PreferenceModel:
+        """Initialise priors from the user's configured scoring weights.
+
+        Higher configured weight → stronger prior (α₀ = β₀ = weight × 10).
+        """
+        model = cls()
+        for weight_name, dim_col in WEIGHT_TO_DIMENSION.items():
+            if dim_col is None:
+                continue  # skip remote_preference — no dimensional score
+            weight_val = getattr(weights, weight_name)
+            # Prior strength proportional to weight (minimum 1.0 to avoid
+            # degenerate distributions).
+            prior = max(weight_val * 10, 1.0)
+            model.distributions[weight_name] = BetaDistribution(alpha=prior, beta=prior)
+        return model
+
+    def update_from_feedback(
+        self,
+        direction: str,
+        scored_job: ScoredJob,
+    ) -> None:
+        """Update posteriors based on a single feedback record."""
+        for weight_name, dist in self.distributions.items():
+            dim_col = WEIGHT_TO_DIMENSION.get(weight_name)
+            if dim_col is None:
+                continue
+            raw_dim = getattr(scored_job, dim_col, None)
+            if raw_dim is None:
+                continue
+            # Normalise 0-10 to 0-1
+            dim_normalised = raw_dim / 10.0
+
+            if direction == "too_high":
+                dist.update_too_high(dim_normalised)
+            elif direction == "too_low":
+                dist.update_too_low(dim_normalised)
+            elif direction == "correct" or direction in (
+                "implicit_positive",
+                "implicit_strong_positive",
+            ):
+                dist.update_correct()
+            elif direction == "implicit_negative":
+                dist.update_too_high(dim_normalised)
+
+
+# ---------------------------------------------------------------------------
+# Suggestion data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WeightSuggestion:
+    """A single weight adjustment suggestion."""
+
+    dimension: str
+    current_weight: float
+    suggested_weight: float
+    confidence: float
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "dimension": self.dimension,
+            "current_weight": round(self.current_weight, 4),
+            "suggested_weight": round(self.suggested_weight, 4),
+            "confidence": round(self.confidence, 4),
+            "reason": self.reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core service functions
+# ---------------------------------------------------------------------------
+
+
+def build_preference_model(db: Session, profile_id: int) -> PreferenceModel:
+    """Build the full posterior preference model for a profile.
+
+    Starts from the user's configured weights as prior, then replays
+    all feedback records in chronological order to produce the posterior.
+    """
+    weights = get_or_create_weights(db, profile_id)
+    model = PreferenceModel.from_weights(weights)
+
+    # Load feedback with their scored jobs (need dimensional scores)
+    feedback_records = (
+        db.query(ScoringFeedback)
+        .filter(ScoringFeedback.profile_id == profile_id)
+        .order_by(ScoringFeedback.created_at.asc())
+        .all()
+    )
+
+    # Pre-load scored jobs to avoid N+1
+    scored_job_ids = {fb.scored_job_id for fb in feedback_records}
+    if scored_job_ids:
+        scored_jobs = db.query(ScoredJob).filter(ScoredJob.id.in_(scored_job_ids)).all()
+        scored_job_map = {sj.id: sj for sj in scored_jobs}
+    else:
+        scored_job_map = {}
+
+    for fb in feedback_records:
+        sj = scored_job_map.get(fb.scored_job_id)
+        if sj is None:
+            continue
+        model.update_from_feedback(fb.direction, sj)
+
+    return model
+
+
+def generate_suggestions(
+    db: Session,
+    profile_id: int,
+) -> list[WeightSuggestion]:
+    """Generate weight adjustment suggestions based on accumulated feedback.
+
+    Returns an empty list if fewer than SUGGESTION_MIN_FEEDBACK records exist.
+    """
+    feedback_count = (
+        db.query(ScoringFeedback).filter(ScoringFeedback.profile_id == profile_id).count()
+    )
+    if feedback_count < SUGGESTION_MIN_FEEDBACK:
+        return []
+
+    weights = get_or_create_weights(db, profile_id)
+    model = build_preference_model(db, profile_id)
+
+    suggestions: list[WeightSuggestion] = []
+
+    for weight_name, dist in model.distributions.items():
+        current_weight = getattr(weights, weight_name)
+        # The Beta mean represents the learned preference for this dimension.
+        # Map it back to a weight suggestion by scaling relative to the prior mean (0.5).
+        posterior_mean = dist.mean
+
+        # Confidence is inversely related to variance — lower variance = higher confidence.
+        # Use 1 - normalised_variance, where we cap variance contribution.
+        confidence = 1.0 - min(dist.variance / 0.05, 1.0)
+
+        # If posterior mean > 0.5, the user values this dimension more than the prior;
+        # if < 0.5, they value it less.
+        # Scale the delta proportionally to the current weight.
+        shift = (posterior_mean - 0.5) * 2.0  # range: -1 to +1
+        suggested_weight = current_weight + shift * current_weight * 0.5
+        # Clamp to valid range
+        suggested_weight = max(0.01, min(1.0, suggested_weight))
+
+        delta = abs(suggested_weight - current_weight)
+
+        if confidence < SUGGESTION_MIN_CONFIDENCE:
+            continue
+        if delta < SUGGESTION_MIN_DELTA:
+            continue
+
+        # Build human-readable reason
+        if suggested_weight > current_weight:
+            reason = (
+                f"You consistently rate jobs higher than the AI when "
+                f"{_human_name(weight_name)} is strong — consider increasing this weight"
+            )
+        else:
+            reason = (
+                f"You tend to dismiss jobs the AI scored highly on "
+                f"{_human_name(weight_name)} — consider decreasing this weight"
+            )
+
+        suggestions.append(
+            WeightSuggestion(
+                dimension=weight_name,
+                current_weight=current_weight,
+                suggested_weight=round(suggested_weight, 4),
+                confidence=round(confidence, 4),
+                reason=reason,
+            )
+        )
+
+    # Sort by confidence descending
+    suggestions.sort(key=lambda s: s.confidence, reverse=True)
+    return suggestions
+
+
+def should_active_query(
+    fit_score: float,
+    model: PreferenceModel,
+) -> bool:
+    """Determine whether an active query should be presented to the user.
+
+    Conditions (all must be true):
+    1. fit_score is in the borderline band (4.5–5.5)
+    2. At least one dimension has high uncertainty (variance > threshold)
+
+    This function does NOT check the feature flag — the caller is responsible
+    for gating on ACTIVE_QUERY_ENABLED.
+    """
+    if not (BORDERLINE_LOW <= fit_score <= BORDERLINE_HIGH):
+        return False
+
+    return any(dist.variance > UNCERTAINTY_THRESHOLD for dist in model.distributions.values())
+
+
+def get_active_query_dimensions(model: PreferenceModel) -> list[str]:
+    """Return the dimension names with the highest uncertainty.
+
+    Useful for telling the user which aspects of the job to focus feedback on.
+    """
+    uncertain = [
+        (name, dist.variance)
+        for name, dist in model.distributions.items()
+        if dist.variance > UNCERTAINTY_THRESHOLD
+    ]
+    uncertain.sort(key=lambda x: x[1], reverse=True)
+    return [name for name, _ in uncertain]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_HUMAN_NAMES: dict[str, str] = {
+    "skills_match": "technical fit",
+    "career_alignment": "career trajectory",
+    "culture_fit": "company/culture fit",
+    "salary_match": "compensation fit",
+    "location_match": "location fit",
+    "growth_potential": "seniority/growth alignment",
+    "remote_preference": "remote preference",
+}
+
+
+def _human_name(weight_name: str) -> str:
+    """Return a human-readable label for a weight dimension."""
+    return _HUMAN_NAMES.get(weight_name, weight_name.replace("_", " "))

--- a/tests/test_preference_learning.py
+++ b/tests/test_preference_learning.py
@@ -1,0 +1,621 @@
+"""Tests for Epic 11 — Bayesian Preference Learning (G-279).
+
+Covers:
+- Beta distribution prior initialisation from weights
+- Posterior updates for too_high, too_low, correct feedback
+- No suggestions below SUGGESTION_MIN_FEEDBACK records
+- Suggestions generated with sufficient feedback
+- Suggestion confidence & delta thresholds
+- Active query detection (borderline + high uncertainty)
+- Active query disabled by default (feature flag)
+- Weight ↔ dimension mapping correctness
+- Integration test: profile + weights + 20 feedback records → suggestions API
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.database import Base, get_db
+from career_os.main import app
+from career_os.models.models import Profile
+from career_os.models.scoring import ScoredJob, ScoringFeedback, ScoringWeights
+from career_os.services.preference_learning import (
+    BORDERLINE_HIGH,
+    BORDERLINE_LOW,
+    SUGGESTION_MIN_FEEDBACK,
+    UNCERTAINTY_THRESHOLD,
+    WEIGHT_TO_DIMENSION,
+    BetaDistribution,
+    PreferenceModel,
+    build_preference_model,
+    generate_suggestions,
+    get_active_query_dimensions,
+    should_active_query,
+)
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session():
+    """Fresh in-memory database for each test."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):
+        dbapi_conn.cursor().execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    Session_ = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = Session_()
+
+    profile = Profile(
+        id=1, name="Test User", email="test@example.com", location="Berlin", job_family="SWE"
+    )
+    session.add(profile)
+    session.commit()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client(db_session):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_weights(db: Session, *, profile_id: int = 1, **overrides) -> ScoringWeights:
+    """Insert ScoringWeights and return it."""
+    defaults = {
+        "skills_match": 0.25,
+        "career_alignment": 0.20,
+        "culture_fit": 0.15,
+        "salary_match": 0.15,
+        "location_match": 0.10,
+        "growth_potential": 0.10,
+        "remote_preference": 0.05,
+    }
+    defaults.update(overrides)
+    w = ScoringWeights(profile_id=profile_id, **defaults)
+    db.add(w)
+    db.commit()
+    db.refresh(w)
+    return w
+
+
+def _make_scored_job(
+    db: Session,
+    *,
+    profile_id: int = 1,
+    fit_score: float = 7.5,
+    dim_technical_fit: float | None = 8.0,
+    dim_seniority_alignment: float | None = 6.0,
+    dim_compensation_fit: float | None = 7.0,
+    dim_location_fit: float | None = 5.0,
+    dim_career_trajectory: float | None = 7.5,
+    dim_company_fit: float | None = 6.5,
+) -> ScoredJob:
+    """Insert a ScoredJob with dimensional scores."""
+    sj = ScoredJob(
+        profile_id=profile_id,
+        fit_score=fit_score,
+        readiness_score=60.0,
+        career_alignment=7.0,
+        reasoning="Test reasoning " * 10,
+        estimated_salary="$120k–$150k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Prep notes here.",
+        dim_technical_fit=dim_technical_fit,
+        dim_seniority_alignment=dim_seniority_alignment,
+        dim_compensation_fit=dim_compensation_fit,
+        dim_location_fit=dim_location_fit,
+        dim_career_trajectory=dim_career_trajectory,
+        dim_company_fit=dim_company_fit,
+    )
+    db.add(sj)
+    db.commit()
+    db.refresh(sj)
+    return sj
+
+
+def _make_feedback(
+    db: Session,
+    scored_job_id: int,
+    *,
+    profile_id: int = 1,
+    direction: str = "too_high",
+    user_score: float | None = None,
+) -> ScoringFeedback:
+    """Insert a ScoringFeedback record."""
+    sj = db.query(ScoredJob).filter(ScoredJob.id == scored_job_id).one()
+    fb = ScoringFeedback(
+        scored_job_id=scored_job_id,
+        profile_id=profile_id,
+        direction=direction,
+        user_score=user_score,
+        original_fit_score=sj.fit_score,
+    )
+    db.add(fb)
+    db.commit()
+    db.refresh(fb)
+    return fb
+
+
+# ---------------------------------------------------------------------------
+# 1. Beta distribution prior initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestBetaDistributionPrior:
+    """Verify prior initialisation from configured weights."""
+
+    def test_prior_from_default_weights(self, db_session):
+        """Default weights produce symmetric priors (α = β) scaled by weight × 10."""
+        weights = _make_weights(db_session)
+        model = PreferenceModel.from_weights(weights)
+
+        # skills_match = 0.25 → prior = 2.5
+        dist = model.distributions["skills_match"]
+        assert dist.alpha == pytest.approx(2.5)
+        assert dist.beta == pytest.approx(2.5)
+
+        # growth_potential = 0.10 → prior = max(1.0, 1.0) = 1.0
+        dist_gp = model.distributions["growth_potential"]
+        assert dist_gp.alpha == pytest.approx(1.0)
+        assert dist_gp.beta == pytest.approx(1.0)
+
+    def test_prior_mean_is_half(self, db_session):
+        """All priors should have mean ≈ 0.5 (symmetric)."""
+        weights = _make_weights(db_session)
+        model = PreferenceModel.from_weights(weights)
+
+        for name, dist in model.distributions.items():
+            assert dist.mean == pytest.approx(0.5), f"{name} mean is not 0.5"
+
+    def test_remote_preference_excluded(self, db_session):
+        """remote_preference has no dimensional score — should not be in model."""
+        weights = _make_weights(db_session)
+        model = PreferenceModel.from_weights(weights)
+        assert "remote_preference" not in model.distributions
+
+    def test_minimum_prior_strength(self, db_session):
+        """Even a very small weight (0.01) gets prior ≥ 1.0."""
+        weights = _make_weights(db_session, skills_match=0.01)
+        model = PreferenceModel.from_weights(weights)
+        dist = model.distributions["skills_match"]
+        assert dist.alpha >= 1.0
+        assert dist.beta >= 1.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Posterior update — too_high
+# ---------------------------------------------------------------------------
+
+
+class TestPosteriorTooHigh:
+    """Feedback direction 'too_high' should increase β for high-scoring dims."""
+
+    def test_beta_increases_on_too_high(self):
+        """When a dimension scored high and user says too_high, β increases."""
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        original_beta = dist.beta
+        # Simulate high dim score (8.0 / 10 = 0.8)
+        dist.update_too_high(0.8)
+        assert dist.beta > original_beta
+        assert dist.alpha == pytest.approx(2.5)  # α unchanged
+
+    def test_mean_decreases_on_too_high(self):
+        """Repeated too_high feedback should push the mean below 0.5."""
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        for _ in range(10):
+            dist.update_too_high(0.8)
+        assert dist.mean < 0.5
+
+
+# ---------------------------------------------------------------------------
+# 3. Posterior update — too_low
+# ---------------------------------------------------------------------------
+
+
+class TestPosteriorTooLow:
+    """Feedback direction 'too_low' should increase α for high-scoring dims."""
+
+    def test_alpha_increases_on_too_low(self):
+        """When user says too_low, α increases."""
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        original_alpha = dist.alpha
+        dist.update_too_low(0.8)
+        assert dist.alpha > original_alpha
+        assert dist.beta == pytest.approx(2.5)  # β unchanged
+
+    def test_mean_increases_on_too_low(self):
+        """Repeated too_low feedback should push the mean above 0.5."""
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        for _ in range(10):
+            dist.update_too_low(0.8)
+        assert dist.mean > 0.5
+
+
+# ---------------------------------------------------------------------------
+# 4. Posterior update — correct
+# ---------------------------------------------------------------------------
+
+
+class TestPosteriorCorrect:
+    """Feedback direction 'correct' reinforces both α and β slightly."""
+
+    def test_both_increase_on_correct(self):
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        orig_a, orig_b = dist.alpha, dist.beta
+        dist.update_correct()
+        assert dist.alpha > orig_a
+        assert dist.beta > orig_b
+
+    def test_mean_stays_near_half_on_correct(self):
+        """Correct feedback shouldn't shift the mean significantly."""
+        dist = BetaDistribution(alpha=2.5, beta=2.5)
+        for _ in range(20):
+            dist.update_correct()
+        assert dist.mean == pytest.approx(0.5, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# 5. No suggestions below threshold
+# ---------------------------------------------------------------------------
+
+
+def test_no_suggestions_below_threshold(db_session):
+    """Returns empty list when fewer than SUGGESTION_MIN_FEEDBACK records exist."""
+    _make_weights(db_session)
+    sj = _make_scored_job(db_session)
+
+    # Create feedback records below threshold
+    for _ in range(SUGGESTION_MIN_FEEDBACK - 1):
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    suggestions = generate_suggestions(db_session, profile_id=1)
+    assert suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Suggestions generated with sufficient feedback
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_generated_with_enough_feedback(db_session):
+    """With ≥15 consistent feedback records, suggestions are generated."""
+    _make_weights(db_session)
+
+    # Create jobs with high technical_fit but overall too_high feedback
+    # This should suggest decreasing skills_match weight
+    for _ in range(20):
+        sj = _make_scored_job(
+            db_session,
+            fit_score=8.0,
+            dim_technical_fit=9.0,  # high
+            dim_seniority_alignment=3.0,  # low
+            dim_compensation_fit=4.0,
+            dim_location_fit=5.0,
+            dim_career_trajectory=4.0,
+            dim_company_fit=4.0,
+        )
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    suggestions = generate_suggestions(db_session, profile_id=1)
+    # Should have at least one suggestion
+    assert len(suggestions) >= 1
+    # All suggestions should have valid fields
+    for s in suggestions:
+        assert 0 <= s.current_weight <= 1
+        assert 0 <= s.suggested_weight <= 1
+        assert 0 <= s.confidence <= 1
+        assert len(s.reason) > 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Suggestion confidence threshold
+# ---------------------------------------------------------------------------
+
+
+def test_suggestion_confidence_threshold(db_session):
+    """Low-confidence suggestions are filtered out."""
+    _make_weights(db_session)
+
+    # Mixed feedback — some too_high, some too_low — should produce lower
+    # confidence and potentially no suggestions
+    for i in range(SUGGESTION_MIN_FEEDBACK + 5):
+        sj = _make_scored_job(db_session, fit_score=7.0)
+        direction = "too_high" if i % 2 == 0 else "too_low"
+        _make_feedback(db_session, sj.id, direction=direction)
+
+    suggestions = generate_suggestions(db_session, profile_id=1)
+    # All returned suggestions must meet the confidence threshold
+    for s in suggestions:
+        assert s.confidence >= 0.6, (
+            f"Suggestion for {s.dimension} has low confidence {s.confidence}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Active query detection
+# ---------------------------------------------------------------------------
+
+
+class TestActiveQuery:
+    """Active query should trigger only for borderline scores with uncertain dims."""
+
+    def test_borderline_with_high_uncertainty(self):
+        """Borderline score + uncertain dimension → should query."""
+        model = PreferenceModel()
+        # Create a distribution with high uncertainty
+        model.distributions["skills_match"] = BetaDistribution(alpha=1.0, beta=1.0)
+        assert model.distributions["skills_match"].variance > UNCERTAINTY_THRESHOLD
+
+        assert should_active_query(5.0, model) is True
+
+    def test_non_borderline_no_query(self):
+        """Non-borderline score → no query even with uncertainty."""
+        model = PreferenceModel()
+        model.distributions["skills_match"] = BetaDistribution(alpha=1.0, beta=1.0)
+
+        assert should_active_query(8.0, model) is False
+        assert should_active_query(2.0, model) is False
+
+    def test_borderline_low_uncertainty_no_query(self):
+        """Borderline score but low uncertainty → no query."""
+        model = PreferenceModel()
+        # High α and β → low variance
+        model.distributions["skills_match"] = BetaDistribution(alpha=100.0, beta=100.0)
+        assert model.distributions["skills_match"].variance < UNCERTAINTY_THRESHOLD
+
+        assert should_active_query(5.0, model) is False
+
+    def test_borderline_edges(self):
+        """Exact boundary values (4.5 and 5.5) are within the borderline band."""
+        model = PreferenceModel()
+        model.distributions["skills_match"] = BetaDistribution(alpha=1.0, beta=1.0)
+
+        assert should_active_query(BORDERLINE_LOW, model) is True
+        assert should_active_query(BORDERLINE_HIGH, model) is True
+
+    def test_get_uncertain_dimensions(self):
+        """get_active_query_dimensions returns only uncertain dimensions, sorted."""
+        model = PreferenceModel()
+        model.distributions["skills_match"] = BetaDistribution(alpha=1.0, beta=1.0)  # uncertain
+        model.distributions["salary_match"] = BetaDistribution(alpha=100.0, beta=100.0)  # certain
+
+        dims = get_active_query_dimensions(model)
+        assert "skills_match" in dims
+        assert "salary_match" not in dims
+
+
+# ---------------------------------------------------------------------------
+# 9. Active query disabled by default (feature flag)
+# ---------------------------------------------------------------------------
+
+
+def test_active_query_feature_flag_default():
+    """ACTIVE_QUERY_ENABLED defaults to False."""
+    from career_os.config import settings
+
+    assert settings.active_query_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# 10. Weight ↔ dimension mapping correctness
+# ---------------------------------------------------------------------------
+
+
+class TestWeightDimensionMapping:
+    """Verify the mapping between weight names and dimensional score columns."""
+
+    def test_all_weights_mapped(self):
+        """All 7 weight dimensions are present in the mapping."""
+        expected_weights = {
+            "skills_match",
+            "career_alignment",
+            "culture_fit",
+            "salary_match",
+            "location_match",
+            "growth_potential",
+            "remote_preference",
+        }
+        assert set(WEIGHT_TO_DIMENSION.keys()) == expected_weights
+
+    def test_six_dimensions_mapped(self):
+        """6 of 7 weights map to dimensional score columns (remote_preference → None)."""
+        mapped = {k: v for k, v in WEIGHT_TO_DIMENSION.items() if v is not None}
+        assert len(mapped) == 6
+        assert WEIGHT_TO_DIMENSION["remote_preference"] is None
+
+    def test_dimension_columns_exist_on_scored_job(self):
+        """All mapped dimension column names exist as attributes on ScoredJob."""
+        for dim_col in WEIGHT_TO_DIMENSION.values():
+            if dim_col is None:
+                continue
+            assert hasattr(ScoredJob, dim_col), f"ScoredJob missing column {dim_col}"
+
+    def test_specific_mappings(self):
+        """Verify the exact weight → dimension mappings."""
+        assert WEIGHT_TO_DIMENSION["skills_match"] == "dim_technical_fit"
+        assert WEIGHT_TO_DIMENSION["career_alignment"] == "dim_career_trajectory"
+        assert WEIGHT_TO_DIMENSION["culture_fit"] == "dim_company_fit"
+        assert WEIGHT_TO_DIMENSION["salary_match"] == "dim_compensation_fit"
+        assert WEIGHT_TO_DIMENSION["location_match"] == "dim_location_fit"
+        assert WEIGHT_TO_DIMENSION["growth_potential"] == "dim_seniority_alignment"
+
+
+# ---------------------------------------------------------------------------
+# 11. Build preference model end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_build_preference_model_no_feedback(db_session):
+    """With no feedback, model stays at prior."""
+    _make_weights(db_session)
+    model = build_preference_model(db_session, profile_id=1)
+
+    for name, dist in model.distributions.items():
+        assert dist.mean == pytest.approx(0.5), f"{name} drifted from prior without feedback"
+
+
+def test_build_preference_model_with_feedback(db_session):
+    """Feedback shifts the model away from prior."""
+    _make_weights(db_session)
+
+    # Create 10 too_high feedback records with high technical fit
+    for _ in range(10):
+        sj = _make_scored_job(db_session, dim_technical_fit=9.0)
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    model = build_preference_model(db_session, profile_id=1)
+    # skills_match (mapped to dim_technical_fit) should have mean < 0.5
+    assert model.distributions["skills_match"].mean < 0.5
+
+
+# ---------------------------------------------------------------------------
+# 12. Integration test: full flow via API
+# ---------------------------------------------------------------------------
+
+
+def test_integration_suggestions_api(client, db_session):
+    """Full flow: create profile + weights + 20 feedback records → GET suggestions."""
+    _make_weights(db_session)
+
+    # Create 20 consistent too_high feedback records
+    for _ in range(20):
+        sj = _make_scored_job(
+            db_session,
+            fit_score=8.0,
+            dim_technical_fit=9.0,
+            dim_seniority_alignment=3.0,
+            dim_compensation_fit=4.0,
+            dim_location_fit=5.0,
+            dim_career_trajectory=4.0,
+            dim_company_fit=4.0,
+        )
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    resp = client.get("/api/score/suggestions", params={"profile_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["ready"] is True
+    assert data["feedback_count"] == 20
+    assert data["min_feedback_required"] == SUGGESTION_MIN_FEEDBACK
+    assert len(data["suggestions"]) >= 1
+
+    # Verify suggestion structure
+    for s in data["suggestions"]:
+        assert "dimension" in s
+        assert "current_weight" in s
+        assert "suggested_weight" in s
+        assert "confidence" in s
+        assert "reason" in s
+        assert 0 <= s["confidence"] <= 1
+        assert 0 <= s["suggested_weight"] <= 1
+
+
+def test_integration_suggestions_not_ready(client, db_session):
+    """Suggestions API returns ready=False when below threshold."""
+    _make_weights(db_session)
+
+    # Only 5 feedback records
+    for _ in range(5):
+        sj = _make_scored_job(db_session)
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    resp = client.get("/api/score/suggestions", params={"profile_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["ready"] is False
+    assert data["feedback_count"] == 5
+    assert data["suggestions"] == []
+
+
+def test_integration_suggestions_correct_feedback(client, db_session):
+    """Suggestions from mostly 'correct' feedback should produce few/no suggestions."""
+    _make_weights(db_session)
+
+    # 20 "correct" feedback records — should not shift preferences much
+    for _ in range(20):
+        sj = _make_scored_job(db_session)
+        _make_feedback(db_session, sj.id, direction="correct")
+
+    resp = client.get("/api/score/suggestions", params={"profile_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["ready"] is True
+    # Correct feedback shouldn't produce large suggestions
+    for s in data["suggestions"]:
+        delta = abs(s["suggested_weight"] - s["current_weight"])
+        assert delta < 0.1, f"Unexpected large suggestion for {s['dimension']}: delta={delta}"
+
+
+# ---------------------------------------------------------------------------
+# 13. Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_scored_job_missing_dimensions(db_session):
+    """Feedback for scored jobs with None dimensions is handled gracefully."""
+    _make_weights(db_session)
+
+    for _ in range(SUGGESTION_MIN_FEEDBACK + 5):
+        sj = _make_scored_job(
+            db_session,
+            dim_technical_fit=None,
+            dim_seniority_alignment=None,
+            dim_compensation_fit=None,
+            dim_location_fit=None,
+            dim_career_trajectory=None,
+            dim_company_fit=None,
+        )
+        _make_feedback(db_session, sj.id, direction="too_high")
+
+    # Should not raise, just no meaningful suggestions
+    suggestions = generate_suggestions(db_session, profile_id=1)
+    assert isinstance(suggestions, list)
+
+
+def test_beta_distribution_edge_zero(self=None):
+    """BetaDistribution handles zero alpha/beta gracefully."""
+    dist = BetaDistribution(alpha=0.0, beta=0.0)
+    assert dist.mean == 0.5  # safe default
+    assert dist.variance == 0.0  # no variance when no data
+
+
+def test_implicit_feedback_shifts_model(db_session):
+    """Implicit feedback (positive/negative) also shifts the model."""
+    _make_weights(db_session)
+
+    # Create implicit_negative feedback (treated like too_high)
+    for _ in range(SUGGESTION_MIN_FEEDBACK + 5):
+        sj = _make_scored_job(db_session, dim_technical_fit=9.0)
+        _make_feedback(db_session, sj.id, direction="implicit_negative")
+
+    model = build_preference_model(db_session, profile_id=1)
+    # implicit_negative is treated as too_high → skills_match mean < 0.5
+    assert model.distributions["skills_match"].mean < 0.5


### PR DESCRIPTION
## Summary
- Per-dimension Beta distributions initialized from ScoringWeights, updated from ScoringFeedback
- Weight suggestions via `GET /api/score/suggestions?profile_id=N` (≥15 feedback records required)
- Suggestions filtered by confidence ≥0.6 and delta ≥0.03 — presented to user, NOT auto-applied
- Active query selection targets borderline scores (4.5-5.5) with high variance
- `ACTIVE_QUERY_ENABLED` config flag (default: false)
- 31 tests passing

## Design notes
- Beta distributions rebuilt from feedback history on each request (not stored)
- 6 of 7 weight dimensions covered — remote_preference excluded (no corresponding AI dimensional score)
- Inspired by BAL-PM (NeurIPS 2024) for active query selection

## Test plan
- [ ] 31 tests in `tests/test_preference_learning.py`
- [ ] Bayesian updates, suggestion generation, threshold enforcement, active query

🤖 Generated with [Claude Code](https://claude.com/claude-code)