### PR TITLE
feat(G-273): borderline 2-pass scoring

### DIFF
--- a/alembic/versions/o6p7q8r9s0t1_add_embeddings.py
+++ b/alembic/versions/o6p7q8r9s0t1_add_embeddings.py
@@ -1,0 +1,52 @@
+"""Add embeddings table and embedding_similarity column (Epic 4 / G-272).
+
+Revision ID: o6p7q8r9s0t1
+Revises: l3m4n5o6p7q8
+Create Date: 2026-04-15 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "o6p7q8r9s0t1"
+down_revision: Union[str, None] = "l3m4n5o6p7q8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- embeddings table ---
+    op.create_table(
+        "embeddings",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("entity_type", sa.String(length=50), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("model_name", sa.String(length=100), nullable=False),
+        sa.Column("vector", sa.LargeBinary(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("entity_type", "entity_id", "model_name", name="uq_embedding_entity"),
+    )
+    op.create_index(
+        op.f("ix_embeddings_entity_type"), "embeddings", ["entity_type"], unique=False
+    )
+    op.create_index(
+        op.f("ix_embeddings_entity_id"), "embeddings", ["entity_id"], unique=False
+    )
+
+    # --- embedding_similarity column on discovered_jobs ---
+    op.add_column(
+        "discovered_jobs",
+        sa.Column("embedding_similarity", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("discovered_jobs", "embedding_similarity")
+    op.drop_index(op.f("ix_embeddings_entity_id"), table_name="embeddings")
+    op.drop_index(op.f("ix_embeddings_entity_type"), table_name="embeddings")
+    op.drop_table("embeddings")

--- a/alembic/versions/p7q8r9s0t1u2_add_scoring_passes.py
+++ b/alembic/versions/p7q8r9s0t1u2_add_scoring_passes.py
@@ -1,0 +1,29 @@
+"""add scoring_passes to scored_jobs
+
+Revision ID: p7q8r9s0t1u2
+Revises: o6p7q8r9s0t1
+Create Date: 2026-04-15 00:00:00.000000
+
+Adds ``scoring_passes`` column to ``scored_jobs`` to track whether a job used
+single-pass or 2-pass (borderline) scoring (Epic 5 / G-273).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "p7q8r9s0t1u2"
+down_revision = "o6p7q8r9s0t1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scored_jobs",
+        sa.Column("scoring_passes", sa.Integer(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scored_jobs", "scoring_passes")

--- a/src/career_os/ai/base.py
+++ b/src/career_os/ai/base.py
@@ -78,3 +78,19 @@ class AIProvider(ABC):
             AIResponse with ScoreResult structured data.
         """
         ...
+
+    async def embed(self, text: str, **kwargs: object) -> list[float]:
+        """Generate an embedding vector for the given text.
+
+        Default implementation raises NotImplementedError. Providers that
+        support embeddings (Ollama, future Voyage AI) override this method.
+        Callers should catch NotImplementedError for graceful degradation.
+
+        Args:
+            text: The input text to embed.
+            **kwargs: Provider-specific options (e.g. model override).
+
+        Returns:
+            A list of floats representing the embedding vector.
+        """
+        raise NotImplementedError(f"{self.name} provider does not support embeddings")

--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -73,6 +73,30 @@ class MockProvider(AIProvider):
         """Return deterministic scoring response."""
         return _handle_score(job_description, {"profile": profile_data})
 
+    async def embed(self, text: str, **kwargs: object) -> list[float]:
+        """Return a deterministic 768-dim embedding vector for testing.
+
+        Uses an MD5 hash of the input to seed a simple PRNG so different
+        texts produce different (but reproducible) vectors.  Vectors are
+        normalized to unit length so cosine-similarity math works correctly.
+        """
+        import math
+
+        seed = _deterministic_seed(text)
+        # Simple LCG-based PRNG seeded from the text hash
+        dim = 768
+        values: list[float] = []
+        x = seed
+        for _ in range(dim):
+            x = (x * 6364136223846793005 + 1442695040888963407) & 0xFFFFFFFFFFFFFFFF
+            # Map to [-1, 1]
+            values.append((x / 0xFFFFFFFFFFFFFFFF) * 2 - 1)
+        # L2-normalize
+        norm = math.sqrt(sum(v * v for v in values))
+        if norm > 0:
+            values = [v / norm for v in values]
+        return values
+
 
 def _deterministic_seed(text: str) -> int:
     """Produce a deterministic integer seed from input text."""

--- a/src/career_os/ai/ollama_provider.py
+++ b/src/career_os/ai/ollama_provider.py
@@ -155,6 +155,45 @@ class OllamaProvider(AIProvider):
         content = data["choices"][0]["message"]["content"]
         return _try_parse_structured(content, feature)
 
+    async def embed(self, text: str, **kwargs: object) -> list[float]:
+        """Generate an embedding vector via Ollama's /api/embeddings endpoint.
+
+        Uses the model specified by EMBEDDING_MODEL (default: nomic-embed-text),
+        NOT the chat model configured for completions/scoring.
+
+        Raises:
+            OllamaConnectionError: If the Ollama server is unreachable.
+            RuntimeError: If the response doesn't contain a valid embedding.
+        """
+        from career_os.config import settings
+
+        model = kwargs.get("model", settings.embedding_model) or "nomic-embed-text"
+        url = f"{self._base_url}/api/embeddings"
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+                response = await client.post(
+                    url,
+                    headers={"Content-Type": "application/json"},
+                    json={"model": model, "prompt": text},
+                )
+                response.raise_for_status()
+                data = response.json()
+        except httpx.ConnectError as exc:
+            raise OllamaConnectionError(self._base_url, str(exc)) from exc
+        except httpx.TimeoutException as exc:
+            raise OllamaConnectionError(
+                self._base_url, f"Embedding request timed out after {_TIMEOUT_SECONDS}s"
+            ) from exc
+
+        embedding = data.get("embedding")
+        if not embedding or not isinstance(embedding, list):
+            raise RuntimeError(
+                f"Ollama /api/embeddings did not return a valid embedding "
+                f"(model={model}, keys={list(data.keys())})"
+            )
+        return embedding
+
     async def score(
         self,
         job_description: str,

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -54,6 +54,15 @@ class Settings(BaseSettings):
     embedding_prefilter_threshold: float = 0.65
     embedding_model: str = "nomic-embed-text"
 
+    # Borderline 2-pass scoring (Epic 5 / G-273) — when a job's fit_score falls
+    # in the borderline zone [BORDERLINE_LOW, BORDERLINE_HIGH], a second scoring
+    # pass is run and the two results are averaged.  This reduces variance by ~50%
+    # in the borderline zone (LLM-as-Judge on a Budget, 2026) at ~1.3x cost.
+    # Set BORDERLINE_SCORING_ENABLED=false to disable entirely.
+    borderline_scoring_enabled: bool = True
+    borderline_low_threshold: float = 4.0
+    borderline_high_threshold: float = 6.5
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     # Per-provider API key requirements: provider → (settings_attr, expected_prefix).

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -46,6 +46,14 @@ class Settings(BaseSettings):
     # users with too many prompts.
     active_query_enabled: bool = False
 
+    # Embedding pre-filter (Epic 4 / G-272) — compute embedding cosine
+    # similarity before sending jobs through the full LLM scoring pipeline.
+    # Shadow mode (default): similarities are computed and logged but jobs are
+    # NOT filtered.  Set to True to actually skip low-similarity jobs.
+    embedding_prefilter_enabled: bool = False
+    embedding_prefilter_threshold: float = 0.65
+    embedding_model: str = "nomic-embed-text"
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     # Per-provider API key requirements: provider → (settings_attr, expected_prefix).

--- a/src/career_os/models/__init__.py
+++ b/src/career_os/models/__init__.py
@@ -8,6 +8,7 @@ from career_os.models.discovery import (
     DiscoveryRun,
     SearchProfile,
 )
+from career_os.models.embeddings import Embedding
 from career_os.models.esco import ESCOSkill, SkillMapping
 from career_os.models.integrations import IntegrationConfig
 from career_os.models.interview_prep import (
@@ -50,6 +51,7 @@ __all__ = [
     "ContactInteraction",
     "ApplicationPackage",
     "CoachingSuggestion",
+    "Embedding",
     "DiscoveredJob",
     "DiscoveryRun",
     "FollowUp",

--- a/src/career_os/models/discovery.py
+++ b/src/career_os/models/discovery.py
@@ -70,6 +70,10 @@ class DiscoveredJob(Base):
     # Scoring (populated later by M3 scoring engine)
     fit_score: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Embedding cosine similarity to profile (Epic 4 / G-272).
+    # Populated during batch scoring pre-filter; NULL until first embedding run.
+    embedding_similarity: Mapped[float | None] = mapped_column(Float, nullable=True)
+
     # Pipeline linkage — set when auto-fed into pipeline
     application_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("applications.id"), nullable=True

--- a/src/career_os/models/embeddings.py
+++ b/src/career_os/models/embeddings.py
@@ -1,0 +1,57 @@
+"""SQLAlchemy ORM model for embedding vectors (Epic 4 / G-272).
+
+Stores embedding vectors as BLOBs for profile and job text representations.
+Cosine similarity is computed in Python (numpy or manual) rather than via
+sqlite-vec, which requires a C extension not available in all environments.
+
+TODO: When deployed on a system with sqlite-vec available, add a sqlite-vec
+virtual table index for faster nearest-neighbor queries at scale.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import (
+    DateTime,
+    Integer,
+    LargeBinary,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from career_os.database import Base
+
+
+def _utcnow() -> datetime:
+    """Return timezone-aware UTC now."""
+    return datetime.now(UTC)
+
+
+class Embedding(Base):
+    """Cached embedding vector for a profile or discovered job.
+
+    entity_type: "profile" or "discovered_job"
+    entity_id:   the PK of the corresponding Profile or DiscoveredJob row
+    model_name:  embedding model used (e.g. "nomic-embed-text")
+    vector:      raw float32 bytes (768 * 4 = 3072 bytes for nomic-embed-text)
+    """
+
+    __tablename__ = "embeddings"
+    __table_args__ = (
+        UniqueConstraint("entity_type", "entity_id", "model_name", name="uq_embedding_entity"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    entity_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    entity_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    model_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    vector: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Embedding(id={self.id}, entity_type='{self.entity_type}', "
+            f"entity_id={self.entity_id}, model='{self.model_name}')>"
+        )

--- a/src/career_os/models/scoring.py
+++ b/src/career_os/models/scoring.py
@@ -127,6 +127,10 @@ class ScoredJob(Base):
     dim_career_trajectory: Mapped[float | None] = mapped_column(Float, nullable=True)
     dim_company_fit: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Borderline 2-pass scoring (Epic 5 / G-273) — number of scoring passes used.
+    # 1 = single pass (default), 2 = borderline zone triggered second pass.
+    scoring_passes: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, nullable=False
     )

--- a/src/career_os/services/embeddings.py
+++ b/src/career_os/services/embeddings.py
@@ -1,0 +1,336 @@
+"""Embedding service — manages embedding generation, caching, and similarity (G-272).
+
+Builds text representations of profiles and job descriptions, generates
+embedding vectors via the configured AI provider, and stores them in the
+``embeddings`` table.  Cosine similarity is computed in Python (no sqlite-vec
+dependency).
+
+Key design decisions:
+- Vectors are stored as raw float32 bytes in a BLOB column.
+- Cosine similarity is computed in Python using struct/math (no numpy dep).
+- Profile embeddings are invalidated when skills/goals/job_family change.
+- Graceful degradation: if the provider can't embed, callers get None.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import struct
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from career_os.config import settings
+from career_os.models.embeddings import Embedding
+from career_os.models.models import Profile
+from career_os.models.skills import Goal, Skill
+
+if TYPE_CHECKING:
+    from career_os.ai.base import AIProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Vector serialization helpers
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIM = 768  # nomic-embed-text default
+
+
+def vector_to_bytes(vec: list[float]) -> bytes:
+    """Serialize a float list to raw little-endian float32 bytes."""
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def bytes_to_vector(data: bytes) -> list[float]:
+    """Deserialize raw float32 bytes back to a float list."""
+    count = len(data) // 4
+    return list(struct.unpack(f"<{count}f", data))
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors.
+
+    Returns 0.0 if either vector has zero magnitude.
+    """
+    if len(a) != len(b):
+        raise ValueError(f"Vector length mismatch: {len(a)} vs {len(b)}")
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+# ---------------------------------------------------------------------------
+# Text builders
+# ---------------------------------------------------------------------------
+
+_MAX_JD_CHARS = 32_000  # ~8K tokens at ~4 chars/token
+
+
+def build_profile_text(db: Session, profile_id: int) -> str | None:
+    """Build a structured text representation of a profile for embedding.
+
+    Returns None if the profile doesn't exist or has no useful content.
+    """
+    profile = db.query(Profile).filter(Profile.id == profile_id).first()
+    if not profile:
+        return None
+
+    parts: list[str] = []
+
+    if profile.job_family:
+        parts.append(f"Job Family: {profile.job_family}")
+
+    # Skills with proficiency
+    skills = db.query(Skill).filter(Skill.profile_id == profile_id).all()
+    if skills:
+        skill_strs = []
+        for s in skills[:30]:  # Cap to avoid huge text
+            level = f" ({s.proficiency})" if s.proficiency else ""
+            skill_strs.append(f"{s.name}{level}")
+        parts.append(f"Skills: {', '.join(skill_strs)}")
+
+    # Goals
+    goals = db.query(Goal).filter(Goal.profile_id == profile_id).all()
+    if goals:
+        goal_strs = [g.description for g in goals[:10] if g.description]
+        if goal_strs:
+            parts.append(f"Goals: {', '.join(goal_strs)}")
+
+    if profile.location:
+        parts.append(f"Location: {profile.location}")
+
+    if not parts:
+        return None
+
+    return "\n".join(parts)
+
+
+def build_job_text(description: str | None, title: str = "", company: str = "") -> str:
+    """Build text for embedding a job posting.
+
+    Uses title + company as prefix, then the description (truncated).
+    """
+    parts: list[str] = []
+    if title:
+        parts.append(f"Title: {title}")
+    if company:
+        parts.append(f"Company: {company}")
+    if description:
+        parts.append(description[:_MAX_JD_CHARS])
+    return "\n".join(parts) if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# Embedding CRUD
+# ---------------------------------------------------------------------------
+
+
+def get_embedding(
+    db: Session,
+    entity_type: str,
+    entity_id: int,
+    model_name: str | None = None,
+) -> list[float] | None:
+    """Retrieve a cached embedding vector, or None if not found."""
+    model = model_name or settings.embedding_model
+    row = (
+        db.query(Embedding)
+        .filter(
+            Embedding.entity_type == entity_type,
+            Embedding.entity_id == entity_id,
+            Embedding.model_name == model,
+        )
+        .first()
+    )
+    if row is None:
+        return None
+    return bytes_to_vector(row.vector)
+
+
+def store_embedding(
+    db: Session,
+    entity_type: str,
+    entity_id: int,
+    vector: list[float],
+    model_name: str | None = None,
+) -> Embedding:
+    """Store (or update) an embedding vector."""
+    model = model_name or settings.embedding_model
+    blob = vector_to_bytes(vector)
+
+    existing = (
+        db.query(Embedding)
+        .filter(
+            Embedding.entity_type == entity_type,
+            Embedding.entity_id == entity_id,
+            Embedding.model_name == model,
+        )
+        .first()
+    )
+    if existing:
+        existing.vector = blob
+        db.flush()
+        return existing
+
+    emb = Embedding(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        model_name=model,
+        vector=blob,
+    )
+    db.add(emb)
+    db.flush()
+    return emb
+
+
+def delete_embedding(
+    db: Session,
+    entity_type: str,
+    entity_id: int,
+    model_name: str | None = None,
+) -> int:
+    """Delete cached embedding(s) for an entity. Returns count deleted."""
+    model = model_name or settings.embedding_model
+    count = (
+        db.query(Embedding)
+        .filter(
+            Embedding.entity_type == entity_type,
+            Embedding.entity_id == entity_id,
+            Embedding.model_name == model,
+        )
+        .delete()
+    )
+    db.flush()
+    return count
+
+
+# ---------------------------------------------------------------------------
+# High-level operations
+# ---------------------------------------------------------------------------
+
+
+async def generate_profile_embedding(
+    db: Session,
+    profile_id: int,
+    provider: AIProvider,
+) -> list[float] | None:
+    """Generate and cache a profile embedding.
+
+    Returns the embedding vector, or None if the profile has no useful text
+    or the provider doesn't support embeddings.
+    """
+    text = build_profile_text(db, profile_id)
+    if not text:
+        logger.debug("Profile %d has no useful text for embedding", profile_id)
+        return None
+
+    try:
+        vector = await provider.embed(text)
+    except NotImplementedError:
+        logger.debug("Provider %s does not support embeddings", provider.name)
+        return None
+    except Exception:
+        logger.warning("Failed to generate embedding for profile %d", profile_id, exc_info=True)
+        return None
+
+    store_embedding(db, "profile", profile_id, vector)
+    db.commit()
+    return vector
+
+
+async def generate_job_embedding(
+    db: Session,
+    job_id: int,
+    description: str | None,
+    title: str = "",
+    company: str = "",
+    provider: AIProvider | None = None,
+) -> list[float] | None:
+    """Generate and cache a job embedding.
+
+    Returns the vector, or None on failure/unsupported.
+    """
+    text = build_job_text(description, title, company)
+    if not text:
+        return None
+
+    if provider is None:
+        from career_os.ai.factory import get_ai_provider
+
+        provider = get_ai_provider()
+
+    try:
+        vector = await provider.embed(text)
+    except NotImplementedError:
+        logger.debug("Provider %s does not support embeddings", provider.name)
+        return None
+    except Exception:
+        logger.warning("Failed to generate embedding for job %d", job_id, exc_info=True)
+        return None
+
+    store_embedding(db, "discovered_job", job_id, vector)
+    db.flush()
+    return vector
+
+
+def invalidate_profile_embedding(db: Session, profile_id: int) -> int:
+    """Delete cached profile embedding so it gets regenerated on next scoring.
+
+    Call this when skills, goals, or job_family change.
+    Returns the number of embeddings deleted.
+    """
+    count = delete_embedding(db, "profile", profile_id)
+    if count:
+        logger.info("Invalidated %d profile embedding(s) for profile %d", count, profile_id)
+    return count
+
+
+async def compute_job_similarities(
+    db: Session,
+    profile_id: int,
+    jobs: list,
+    provider: AIProvider,
+) -> dict[int, float]:
+    """Compute cosine similarity between profile and each job.
+
+    Returns a dict of {job_id: similarity_score}.
+    Jobs without descriptions or that fail embedding are omitted.
+    """
+    # Ensure profile embedding exists
+    profile_vec = get_embedding(db, "profile", profile_id)
+    if profile_vec is None:
+        profile_vec = await generate_profile_embedding(db, profile_id, provider)
+    if profile_vec is None:
+        logger.info("Cannot compute similarities: no profile embedding for %d", profile_id)
+        return {}
+
+    similarities: dict[int, float] = {}
+
+    for job in jobs:
+        # Try cached embedding first
+        job_vec = get_embedding(db, "discovered_job", job.id)
+        if job_vec is None:
+            job_vec = await generate_job_embedding(
+                db,
+                job.id,
+                job.description,
+                title=job.title,
+                company=job.company,
+                provider=provider,
+            )
+        if job_vec is None:
+            continue
+
+        sim = cosine_similarity(profile_vec, job_vec)
+        similarities[job.id] = round(sim, 4)
+
+        # Store similarity on the DiscoveredJob row
+        job.embedding_similarity = sim
+
+    db.flush()
+    return similarities

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -871,6 +871,55 @@ async def batch_score_discovery(
 
     jobs = _query_jobs_to_score(db, profile_id, discovered_job_ids, rescore_stale)
 
+    # --- Embedding pre-filter (Epic 4 / G-272) ---
+    # Compute cosine similarity between profile and each job embedding.
+    # In shadow mode (default): log similarities but score all jobs.
+    # When enabled: skip jobs below threshold to save LLM costs.
+    from career_os.config import settings as _settings
+    from career_os.services.embeddings import compute_job_similarities
+
+    provider = get_ai_provider()
+    prefilter_enabled = _settings.embedding_prefilter_enabled
+    threshold = _settings.embedding_prefilter_threshold
+
+    try:
+        similarities = await compute_job_similarities(db, profile_id, jobs, provider)
+    except Exception:
+        logger.warning(
+            "Embedding pre-filter failed — skipping, all %d jobs will be fully scored",
+            len(jobs),
+            exc_info=True,
+        )
+        similarities = {}
+
+    if similarities:
+        below = sum(1 for s in similarities.values() if s < threshold)
+        above = len(similarities) - below
+        no_embed = len(jobs) - len(similarities)
+
+        if prefilter_enabled:
+            # Actually filter: keep jobs above threshold + jobs without embeddings
+            jobs = [j for j in jobs if similarities.get(j.id, threshold) >= threshold]
+            logger.info(
+                "Pre-filtered %d of %d jobs (threshold %.2f), sending %d to full scoring "
+                "(%d without embeddings passed through)",
+                below,
+                below + above + no_embed,
+                threshold,
+                len(jobs),
+                no_embed,
+            )
+        else:
+            # Shadow mode: log but don't filter
+            logger.info(
+                "Shadow pre-filter: %d/%d jobs below threshold %.2f "
+                "(would be filtered if enabled), %d without embeddings",
+                below,
+                below + above + no_embed,
+                threshold,
+                no_embed,
+            )
+
     scores: list[ScoredJob] = []
     errors: list[dict[str, str]] = []
     credits_exhausted = False

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from career_os.ai.base import ProviderQuotaError
 from career_os.ai.factory import get_ai_provider
 from career_os.ai.openrouter_provider import CreditsExhaustedError
+from career_os.config import settings
 from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
 from career_os.models.scoring import ScoredJob, ScoringFeedback, ScoringWeights
@@ -514,6 +515,96 @@ def _build_dim_columns(dim) -> dict[str, float | None]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Borderline 2-Pass Scoring (Epic 5 / G-273)
+# ---------------------------------------------------------------------------
+
+
+def _average_score_results(a: ScoreResult, b: ScoreResult) -> ScoreResult:
+    """Average two ScoreResult objects to reduce borderline scoring variance.
+
+    Numeric fields are averaged.  For qualitative fields, the result with the
+    higher fit_score contributes the reasoning/prep_notes (richer context).
+    ATS keywords come from whichever result has more keywords.
+    score_breakdown factors are deduplicated by factor name and their
+    contributions averaged.
+    """
+    # Determine which result has the richer reasoning (higher fit_score wins)
+    primary, secondary = (a, b) if a.fit_score >= b.fit_score else (b, a)
+
+    # Average numeric fields
+    avg_fit = round((a.fit_score + b.fit_score) / 2, 2)
+    avg_readiness = round((a.readiness_score + b.readiness_score) / 2, 2)
+    avg_career_alignment = round((a.career_alignment + b.career_alignment) / 2, 2)
+
+    # Average dimensional scores if both are present
+    from career_os.schemas.ai import DimensionalScores
+
+    averaged_dims: DimensionalScores | None = None
+
+    if a.dimensional_scores is not None and b.dimensional_scores is not None:
+        ad = a.dimensional_scores
+        bd = b.dimensional_scores
+        averaged_dims = DimensionalScores(
+            technical_fit=round((ad.technical_fit + bd.technical_fit) / 2, 2),
+            seniority_alignment=round((ad.seniority_alignment + bd.seniority_alignment) / 2, 2),
+            compensation_fit=round((ad.compensation_fit + bd.compensation_fit) / 2, 2),
+            location_fit=round((ad.location_fit + bd.location_fit) / 2, 2),
+            career_trajectory=round((ad.career_trajectory + bd.career_trajectory) / 2, 2),
+            company_fit=round((ad.company_fit + bd.company_fit) / 2, 2),
+        )
+    else:
+        averaged_dims = primary.dimensional_scores
+
+    # Merge score_breakdown: deduplicate by factor name, average contributions
+    breakdown_by_factor: dict[str, list] = {}
+    from career_os.schemas.ai import ScoreBreakdownFactor
+
+    for factor in list(a.score_breakdown) + list(b.score_breakdown):
+        breakdown_by_factor.setdefault(factor.factor, []).append(factor)
+
+    merged_breakdown: list[ScoreBreakdownFactor] = []
+    for factor_name, factors in breakdown_by_factor.items():
+        avg_contribution = round(sum(f.contribution for f in factors) / len(factors), 3)
+        # Use description from whichever came from the primary (higher-score) result
+        desc = next(
+            (f.description for f in factors if f in primary.score_breakdown), factors[0].description
+        )
+        merged_breakdown.append(
+            ScoreBreakdownFactor(
+                factor=factor_name,
+                contribution=avg_contribution,
+                description=desc,
+            )
+        )
+
+    # ATS keywords: keep the longer list
+    ats_keywords = a.ats_keywords if len(a.ats_keywords) >= len(b.ats_keywords) else b.ats_keywords
+
+    # Average desire score if both have it
+    desire_score: float | None = None
+    if a.desire_score is not None and b.desire_score is not None:
+        desire_score = round((a.desire_score + b.desire_score) / 2, 2)
+    else:
+        desire_score = primary.desire_score
+
+    return ScoreResult(
+        fit_score=avg_fit,
+        readiness_score=avg_readiness,
+        career_alignment=avg_career_alignment,
+        reasoning=primary.reasoning,
+        estimated_salary=primary.estimated_salary,
+        effort_flag=primary.effort_flag,
+        prep_level=primary.prep_level,
+        prep_notes=primary.prep_notes,
+        score_breakdown=merged_breakdown,
+        dimensional_scores=averaged_dims,
+        ats_keywords=ats_keywords,
+        desire_score=desire_score,
+        desire_reasoning=primary.desire_reasoning,
+    )
+
+
 def _update_linked_scores(
     db: Session,
     fit_score: float,
@@ -564,8 +655,6 @@ async def score_job(
 
     # Fetch calibration examples when feature flag is enabled
     calibration_examples: list[dict] = []
-    from career_os.config import settings
-
     if settings.feedback_calibration_enabled:
         calibration_examples = get_feedback_calibration(db, profile_id)
 
@@ -591,6 +680,50 @@ async def score_job(
         score_data = response.structured
     else:
         raise ScoringError("AI provider did not return a valid ScoreResult")
+
+    # Borderline 2-pass scoring (Epic 5 / G-273)
+    # When the first-pass score falls in the borderline zone, run a second pass
+    # and average the results to reduce variance (~50% reduction per research).
+    scoring_passes = 1
+    if (
+        settings.borderline_scoring_enabled
+        and settings.borderline_low_threshold
+        <= score_data.fit_score
+        <= settings.borderline_high_threshold
+    ):
+        logger.info(
+            "Borderline score %.2f (zone [%.1f, %.1f]), running second scoring pass",
+            score_data.fit_score,
+            settings.borderline_low_threshold,
+            settings.borderline_high_threshold,
+        )
+        try:
+            response2 = await provider.score(
+                job_description=prompt,
+                profile_data=profile_data,
+            )
+            if response2.structured and isinstance(response2.structured, ScoreResult):
+                score_data2 = response2.structured
+                score_data = _average_score_results(score_data, score_data2)
+                scoring_passes = 2
+                logger.info(
+                    "Averaged borderline scores: pass1=%.2f pass2=%.2f → avg=%.2f",
+                    score_data2.fit_score,  # original first-pass stored before averaging
+                    response2.structured.fit_score,
+                    score_data.fit_score,
+                )
+            else:
+                logger.warning(
+                    "Second scoring pass did not return a valid ScoreResult — "
+                    "using single-pass score %.2f",
+                    score_data.fit_score,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Second scoring pass failed (%s) — using single-pass score %.2f",
+                exc,
+                score_data.fit_score,
+            )
 
     # Serialize score_breakdown to JSON for storage
     breakdown_json = (
@@ -678,6 +811,7 @@ async def score_job(
         desire_score=desire_score,
         desire_score_method=desire_score_method,
         desire_reasoning=desire_reasoning,
+        scoring_passes=scoring_passes,
         **dim_columns,
     )
     db.add(scored_job)
@@ -875,12 +1009,11 @@ async def batch_score_discovery(
     # Compute cosine similarity between profile and each job embedding.
     # In shadow mode (default): log similarities but score all jobs.
     # When enabled: skip jobs below threshold to save LLM costs.
-    from career_os.config import settings as _settings
     from career_os.services.embeddings import compute_job_similarities
 
     provider = get_ai_provider()
-    prefilter_enabled = _settings.embedding_prefilter_enabled
-    threshold = _settings.embedding_prefilter_threshold
+    prefilter_enabled = settings.embedding_prefilter_enabled
+    threshold = settings.embedding_prefilter_threshold
 
     try:
         similarities = await compute_job_similarities(db, profile_id, jobs, provider)

--- a/tests/test_borderline_scoring.py
+++ b/tests/test_borderline_scoring.py
@@ -1,0 +1,503 @@
+"""Tests for Borderline 2-Pass Scoring (Epic 5 / G-273).
+
+Covers:
+- Borderline detection: scores in [4.0, 6.5] trigger a second AI call
+- Non-borderline scores use a single pass
+- _average_score_results() numeric precision and qualitative field selection
+- Graceful fallback when second pass fails
+- scoring_passes column tracking on ScoredJob
+- BORDERLINE_SCORING_ENABLED=false disables 2-pass entirely
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.database import Base
+from career_os.models.models import Profile
+from career_os.schemas.ai import ATSKeyword, DimensionalScores, ScoreBreakdownFactor, ScoreResult
+from career_os.services.scoring import _average_score_results, score_job
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_score_result(
+    fit_score: float,
+    readiness_score: float = 70.0,
+    career_alignment: float = 7.0,
+    reasoning: str = "Test reasoning",
+    ats_keywords: list[ATSKeyword] | None = None,
+    desire_score: float | None = None,
+) -> ScoreResult:
+    """Build a minimal valid ScoreResult for testing."""
+    return ScoreResult(
+        fit_score=fit_score,
+        readiness_score=readiness_score,
+        career_alignment=career_alignment,
+        reasoning=reasoning,
+        estimated_salary="$100k-$120k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Prep note",
+        score_breakdown=[
+            ScoreBreakdownFactor(factor="skills_match", contribution=2.0, description="Good match"),
+            ScoreBreakdownFactor(
+                factor="career_alignment", contribution=1.5, description="Aligned"
+            ),
+            ScoreBreakdownFactor(factor="culture_fit", contribution=1.0, description="Culture ok"),
+        ],
+        dimensional_scores=DimensionalScores(
+            technical_fit=fit_score,
+            seniority_alignment=fit_score,
+            compensation_fit=fit_score,
+            location_fit=fit_score,
+            career_trajectory=fit_score,
+            company_fit=fit_score,
+        ),
+        ats_keywords=ats_keywords
+        or [
+            ATSKeyword(keyword="Python", category="technical", matched=True),
+            ATSKeyword(keyword="FastAPI", category="tool", matched=True),
+        ],
+        desire_score=desire_score,
+        desire_reasoning="Desirable role" if desire_score is not None else None,
+    )
+
+
+def _make_ai_response(score_result: ScoreResult) -> MagicMock:
+    """Wrap a ScoreResult in a mock AIResponse."""
+    resp = MagicMock()
+    resp.structured = score_result
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Database fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_session() -> Session:
+    """Fresh in-memory SQLite session for each test."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk_pragma(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    session_cls = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = session_cls()
+
+    profile = Profile(
+        id=1,
+        name="Test User",
+        email="test@example.com",
+        location="Berlin",
+        job_family="TPM",
+    )
+    session.add(profile)
+    session.commit()
+
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _average_score_results()
+# ---------------------------------------------------------------------------
+
+
+class TestAverageScoreResults:
+    def test_numeric_averaging(self):
+        """Averaging two ScoreResults produces correct numeric means."""
+        a = _make_score_result(fit_score=4.0, readiness_score=60.0, career_alignment=6.0)
+        b = _make_score_result(fit_score=6.0, readiness_score=80.0, career_alignment=8.0)
+
+        result = _average_score_results(a, b)
+
+        assert result.fit_score == 5.0
+        assert result.readiness_score == 70.0
+        assert result.career_alignment == 7.0
+
+    def test_preserves_better_reasoning(self):
+        """The result with the higher fit_score contributes the reasoning."""
+        a = _make_score_result(fit_score=5.0, reasoning="Low reasoning")
+        b = _make_score_result(fit_score=6.5, reasoning="High reasoning")
+
+        result = _average_score_results(a, b)
+
+        assert result.reasoning == "High reasoning"
+
+    def test_preserves_better_reasoning_when_a_wins(self):
+        """When a has higher fit_score, a's reasoning is used."""
+        a = _make_score_result(fit_score=6.5, reasoning="A reasoning")
+        b = _make_score_result(fit_score=5.0, reasoning="B reasoning")
+
+        result = _average_score_results(a, b)
+
+        assert result.reasoning == "A reasoning"
+
+    def test_dimensional_scores_averaged(self):
+        """Dimensional scores are averaged element-wise."""
+        a = _make_score_result(fit_score=4.0)
+        b = _make_score_result(fit_score=6.0)
+
+        result = _average_score_results(a, b)
+
+        assert result.dimensional_scores is not None
+        assert result.dimensional_scores.technical_fit == 5.0
+        assert result.dimensional_scores.career_trajectory == 5.0
+
+    def test_dimensional_scores_fallback_when_one_missing(self):
+        """When only one result has dimensional scores, primary's dims are kept."""
+        a = _make_score_result(fit_score=6.5)
+        b = _make_score_result(fit_score=5.0)
+        b = b.model_copy(update={"dimensional_scores": None})
+
+        result = _average_score_results(a, b)
+
+        # a has higher score so it's primary — its dimensional_scores survive
+        assert result.dimensional_scores is not None
+        assert result.dimensional_scores.technical_fit == 6.5
+
+    def test_score_breakdown_factors_deduplicated_and_averaged(self):
+        """score_breakdown factors with the same name are merged with averaged contributions."""
+        a = _make_score_result(fit_score=5.0)
+        b = _make_score_result(fit_score=6.0)
+        # Both have the same 3 factors from _make_score_result
+
+        result = _average_score_results(a, b)
+
+        factor_names = [f.factor for f in result.score_breakdown]
+        # No duplicates
+        assert len(factor_names) == len(set(factor_names))
+        # skills_match contribution should be averaged: (2.0 + 2.0) / 2 = 2.0
+        skills_factor = next(f for f in result.score_breakdown if f.factor == "skills_match")
+        assert skills_factor.contribution == 2.0
+
+    def test_ats_keywords_keep_longer_list(self):
+        """ATS keywords come from whichever result has more keywords."""
+        short_kws = [ATSKeyword(keyword="Python", category="technical", matched=True)]
+        long_kws = [
+            ATSKeyword(keyword="Python", category="technical", matched=True),
+            ATSKeyword(keyword="FastAPI", category="tool", matched=True),
+            ATSKeyword(keyword="Docker", category="tool", matched=False),
+        ]
+        a = _make_score_result(fit_score=5.0, ats_keywords=short_kws)
+        b = _make_score_result(fit_score=6.0, ats_keywords=long_kws)
+
+        result = _average_score_results(a, b)
+
+        assert len(result.ats_keywords) == 3
+
+    def test_desire_score_averaged_when_both_present(self):
+        """desire_score is averaged when both results have it."""
+        a = _make_score_result(fit_score=4.5, desire_score=4.0)
+        b = _make_score_result(fit_score=6.0, desire_score=6.0)
+
+        result = _average_score_results(a, b)
+
+        assert result.desire_score == 5.0
+
+    def test_desire_score_falls_back_to_primary_when_one_missing(self):
+        """desire_score falls back to primary's value when one is None."""
+        a = _make_score_result(fit_score=6.5, desire_score=7.0)
+        b = _make_score_result(fit_score=5.0, desire_score=None)
+
+        result = _average_score_results(a, b)
+
+        assert result.desire_score == 7.0
+
+    def test_fit_score_rounded_to_two_decimals(self):
+        """fit_score is rounded to 2 decimal places after averaging."""
+        a = _make_score_result(fit_score=4.1)
+        b = _make_score_result(fit_score=6.2)
+
+        result = _average_score_results(a, b)
+
+        # 4.1 + 6.2 = 10.3 / 2 = 5.15
+        assert result.fit_score == 5.15
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for score_job() borderline detection
+# ---------------------------------------------------------------------------
+
+
+class TestBorderlineScoring:
+    @pytest.mark.asyncio
+    async def test_borderline_triggers_second_pass(self, db_session: Session):
+        """Score in [4.0, 6.5] triggers a second scoring call."""
+        borderline_result = _make_score_result(fit_score=5.0)
+        mock_response = _make_ai_response(borderline_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Senior TPM role at Datadog",
+                job_title="Senior TPM",
+                job_company="Datadog",
+            )
+
+        # Should have been called twice (first pass + second pass)
+        assert mock_provider.score.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_borderline_single_pass_high(self, db_session: Session):
+        """Score above borderline zone (>6.5) → only 1 scoring call."""
+        high_result = _make_score_result(fit_score=8.0)
+        mock_response = _make_ai_response(high_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Dream TPM role",
+                job_title="Principal TPM",
+                job_company="Anthropic",
+            )
+
+        assert mock_provider.score.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_borderline_single_pass_low(self, db_session: Session):
+        """Score below borderline zone (<4.0) → only 1 scoring call."""
+        low_result = _make_score_result(fit_score=2.0)
+        mock_response = _make_ai_response(low_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Unrelated .NET developer role",
+                job_title=".NET Developer",
+                job_company="SAP",
+            )
+
+        assert mock_provider.score.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_scoring_passes_tracked_two(self, db_session: Session):
+        """ScoredJob.scoring_passes is 2 when borderline triggers second pass."""
+        borderline_result = _make_score_result(fit_score=5.0)
+        mock_response = _make_ai_response(borderline_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored_job = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="TPM role at Datadog",
+                job_title="TPM",
+                job_company="Datadog",
+            )
+
+        assert scored_job.scoring_passes == 2
+
+    @pytest.mark.asyncio
+    async def test_scoring_passes_tracked_one(self, db_session: Session):
+        """ScoredJob.scoring_passes is 1 for non-borderline scores."""
+        high_result = _make_score_result(fit_score=9.0)
+        mock_response = _make_ai_response(high_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored_job = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Dream TPM role",
+                job_title="Head of TPM",
+                job_company="Anthropic",
+            )
+
+        assert scored_job.scoring_passes == 1
+
+    @pytest.mark.asyncio
+    async def test_second_pass_failure_fallback(self, db_session: Session):
+        """If second pass raises, original score is used and scoring_passes stays 1."""
+        borderline_result = _make_score_result(fit_score=5.5)
+        first_response = _make_ai_response(borderline_result)
+
+        mock_provider = AsyncMock()
+        # First call succeeds, second raises
+        mock_provider.score.side_effect = [first_response, RuntimeError("Provider timeout")]
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            # Should NOT raise — fallback to single score
+            scored_job = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Borderline TPM role",
+                job_title="TPM",
+                job_company="T-Systems",
+            )
+
+        assert scored_job.scoring_passes == 1
+        assert scored_job.fit_score == 5.5
+
+    @pytest.mark.asyncio
+    async def test_borderline_disabled_via_config(self, db_session: Session):
+        """When BORDERLINE_SCORING_ENABLED=false, always single pass regardless of score."""
+        borderline_result = _make_score_result(fit_score=5.0)
+        mock_response = _make_ai_response(borderline_result)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.return_value = mock_response
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = False  # disabled
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored_job = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="TPM role in borderline zone",
+                job_title="TPM",
+                job_company="Personio",
+            )
+
+        assert mock_provider.score.call_count == 1
+        assert scored_job.scoring_passes == 1
+
+    @pytest.mark.asyncio
+    async def test_boundary_values_inclusive(self, db_session: Session):
+        """Exactly 4.0 and 6.5 are in the borderline zone (inclusive bounds)."""
+        for fit_score in (4.0, 6.5):
+            borderline_result = _make_score_result(fit_score=fit_score)
+            mock_response = _make_ai_response(borderline_result)
+
+            mock_provider = AsyncMock()
+            mock_provider.score.return_value = mock_response
+
+            with (
+                patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+                patch("career_os.services.scoring.settings") as mock_settings,
+            ):
+                mock_settings.feedback_calibration_enabled = False
+                mock_settings.borderline_scoring_enabled = True
+                mock_settings.borderline_low_threshold = 4.0
+                mock_settings.borderline_high_threshold = 6.5
+
+                await score_job(
+                    db_session,
+                    profile_id=1,
+                    job_description=f"Role with score {fit_score}",
+                    job_title="TPM",
+                    job_company="Test Corp",
+                )
+
+            assert mock_provider.score.call_count == 2, (
+                f"Expected 2 calls for borderline score {fit_score}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_second_pass_invalid_response_uses_fallback(self, db_session: Session):
+        """If second pass returns non-ScoreResult, original score is used."""
+        borderline_result = _make_score_result(fit_score=5.0)
+        first_response = _make_ai_response(borderline_result)
+
+        # Second response has structured=None (malformed)
+        bad_response = MagicMock()
+        bad_response.structured = None
+
+        mock_provider = AsyncMock()
+        mock_provider.score.side_effect = [first_response, bad_response]
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored_job = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Borderline role",
+                job_title="TPM",
+                job_company="Test Corp",
+            )
+
+        assert scored_job.scoring_passes == 1
+        assert scored_job.fit_score == 5.0

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,531 @@
+"""Tests for the embedding pre-filter layer (Epic 4 / G-272).
+
+Covers:
+- Vector serialization round-trip
+- Cosine similarity calculation
+- Profile/job text builders
+- Embedding CRUD (store, retrieve, delete, invalidation)
+- Pre-filter logic (shadow mode, enabled mode, graceful degradation)
+- MockProvider.embed() determinism
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.ai.mock_provider import MockProvider
+from career_os.database import Base
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.embeddings import Embedding
+from career_os.models.models import Profile
+from career_os.models.skills import Goal, Skill
+from career_os.services.embeddings import (
+    build_job_text,
+    build_profile_text,
+    bytes_to_vector,
+    compute_job_similarities,
+    cosine_similarity,
+    delete_embedding,
+    generate_job_embedding,
+    generate_profile_embedding,
+    get_embedding,
+    invalidate_profile_embedding,
+    store_embedding,
+    vector_to_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_engine():
+    """In-memory SQLite engine with all tables."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def db(db_engine) -> Session:
+    """Yield a database session."""
+    session_cls = sessionmaker(bind=db_engine, autocommit=False, autoflush=False)
+    session = session_cls()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def profile(db: Session) -> Profile:
+    """Seed a profile with skills and goals."""
+    p = Profile(id=1, name="Test User", email="t@test.com", location="Frankfurt", job_family="TPM")
+    db.add(p)
+    db.flush()
+
+    db.add(
+        Skill(
+            profile_id=1,
+            name="Python",
+            category="technical",
+            proficiency="expert",
+            evidence_source="manual",
+        )
+    )
+    db.add(
+        Skill(
+            profile_id=1,
+            name="React",
+            category="technical",
+            proficiency="intermediate",
+            evidence_source="manual",
+        )
+    )
+    db.add(
+        Goal(
+            profile_id=1,
+            title="AI-native company",
+            goal_type="aspirational",
+            description="AI-native company, senior IC track",
+        )
+    )
+    db.commit()
+    return p
+
+
+@pytest.fixture
+def discovered_jobs(db: Session, profile: Profile) -> list[DiscoveredJob]:
+    """Seed three discovered jobs."""
+    jobs = [
+        DiscoveredJob(
+            id=10,
+            profile_id=1,
+            title="Senior AI Engineer",
+            company="Mistral AI",
+            location="Remote",
+            title_normalized="senior ai engineer",
+            company_normalized="mistral ai",
+            location_normalized="remote",
+            description="Build cutting-edge AI models. Python, PyTorch required.",
+        ),
+        DiscoveredJob(
+            id=20,
+            profile_id=1,
+            title="Office Administrator",
+            company="Big Corp",
+            location="Munich",
+            title_normalized="office administrator",
+            company_normalized="big corp",
+            location_normalized="munich",
+            description="Manage office supplies and calendar. MS Office required.",
+        ),
+        DiscoveredJob(
+            id=30,
+            profile_id=1,
+            title="No Description Job",
+            company="Mystery Inc",
+            location="Nowhere",
+            title_normalized="no description job",
+            company_normalized="mystery inc",
+            location_normalized="nowhere",
+            description=None,
+        ),
+    ]
+    db.add_all(jobs)
+    db.commit()
+    return jobs
+
+
+@pytest.fixture
+def mock_provider() -> MockProvider:
+    return MockProvider()
+
+
+# ---------------------------------------------------------------------------
+# Vector serialization
+# ---------------------------------------------------------------------------
+
+
+class TestVectorSerialization:
+    def test_round_trip(self):
+        """Vector survives serialize → deserialize."""
+        original = [0.1, -0.5, 0.0, 1.0, -1.0]
+        blob = vector_to_bytes(original)
+        restored = bytes_to_vector(blob)
+        assert len(restored) == len(original)
+        for a, b in zip(original, restored, strict=True):
+            assert abs(a - b) < 1e-6
+
+    def test_768_dim(self):
+        """768-dim vector round-trips correctly."""
+        vec = [float(i) / 768 for i in range(768)]
+        assert len(bytes_to_vector(vector_to_bytes(vec))) == 768
+
+
+# ---------------------------------------------------------------------------
+# Cosine similarity
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self):
+        """Cosine similarity of identical vectors is 1.0."""
+        v = [1.0, 2.0, 3.0]
+        assert abs(cosine_similarity(v, v) - 1.0) < 1e-6
+
+    def test_orthogonal_vectors(self):
+        """Cosine similarity of orthogonal vectors is 0.0."""
+        a = [1.0, 0.0, 0.0]
+        b = [0.0, 1.0, 0.0]
+        assert abs(cosine_similarity(a, b)) < 1e-6
+
+    def test_opposite_vectors(self):
+        """Cosine similarity of opposite vectors is -1.0."""
+        a = [1.0, 2.0, 3.0]
+        b = [-1.0, -2.0, -3.0]
+        assert abs(cosine_similarity(a, b) + 1.0) < 1e-6
+
+    def test_known_value(self):
+        """Known vectors produce expected cosine similarity."""
+        a = [1.0, 0.0]
+        b = [1.0, 1.0]
+        # cos(45°) = 1/√2 ≈ 0.7071
+        expected = 1.0 / math.sqrt(2)
+        assert abs(cosine_similarity(a, b) - expected) < 1e-6
+
+    def test_zero_vector(self):
+        """Zero vector returns 0.0 similarity."""
+        a = [0.0, 0.0, 0.0]
+        b = [1.0, 2.0, 3.0]
+        assert cosine_similarity(a, b) == 0.0
+
+    def test_length_mismatch_raises(self):
+        """Mismatched vector lengths raise ValueError."""
+        with pytest.raises(ValueError, match="length mismatch"):
+            cosine_similarity([1.0, 2.0], [1.0])
+
+
+# ---------------------------------------------------------------------------
+# Text builders
+# ---------------------------------------------------------------------------
+
+
+class TestTextBuilders:
+    def test_build_profile_text(self, db: Session, profile: Profile):
+        """Profile text includes job family, skills, goals, and location."""
+        text = build_profile_text(db, profile.id)
+        assert text is not None
+        assert "TPM" in text
+        assert "Python (expert)" in text
+        assert "React (intermediate)" in text
+        assert "AI-native company" in text
+        assert "Frankfurt" in text
+
+    def test_build_profile_text_nonexistent(self, db: Session):
+        """Non-existent profile returns None."""
+        assert build_profile_text(db, 9999) is None
+
+    def test_build_job_text(self):
+        """Job text includes title, company, and description."""
+        text = build_job_text("Full stack developer needed", title="SWE", company="Acme")
+        assert "Title: SWE" in text
+        assert "Company: Acme" in text
+        assert "Full stack developer" in text
+
+    def test_build_job_text_empty(self):
+        """Empty inputs produce empty string."""
+        assert build_job_text(None) == ""
+
+    def test_build_job_text_truncation(self):
+        """Very long descriptions are truncated."""
+        long_desc = "x" * 50_000
+        text = build_job_text(long_desc)
+        assert len(text) <= 35_000  # _MAX_JD_CHARS + small overhead
+
+
+# ---------------------------------------------------------------------------
+# Embedding CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingCRUD:
+    def test_store_and_retrieve(self, db: Session):
+        """Store an embedding and retrieve it."""
+        vec = [0.1, 0.2, 0.3]
+        store_embedding(db, "profile", 1, vec, model_name="test-model")
+        db.commit()
+
+        result = get_embedding(db, "profile", 1, model_name="test-model")
+        assert result is not None
+        assert len(result) == 3
+        for a, b in zip(vec, result, strict=True):
+            assert abs(a - b) < 1e-6
+
+    def test_store_updates_existing(self, db: Session):
+        """Storing again for the same entity updates the vector."""
+        store_embedding(db, "profile", 1, [1.0, 2.0], model_name="test-model")
+        db.commit()
+
+        store_embedding(db, "profile", 1, [3.0, 4.0], model_name="test-model")
+        db.commit()
+
+        result = get_embedding(db, "profile", 1, model_name="test-model")
+        assert result is not None
+        assert abs(result[0] - 3.0) < 1e-6
+
+        # Only one row in the table
+        count = db.query(Embedding).filter(Embedding.entity_type == "profile").count()
+        assert count == 1
+
+    def test_retrieve_nonexistent(self, db: Session):
+        """Retrieving a missing embedding returns None."""
+        assert get_embedding(db, "profile", 999, model_name="test-model") is None
+
+    def test_delete_embedding(self, db: Session):
+        """Delete removes the embedding."""
+        store_embedding(db, "profile", 1, [1.0], model_name="test-model")
+        db.commit()
+
+        count = delete_embedding(db, "profile", 1, model_name="test-model")
+        db.commit()
+        assert count == 1
+        assert get_embedding(db, "profile", 1, model_name="test-model") is None
+
+    def test_invalidate_profile_embedding(self, db: Session, profile: Profile):
+        """Invalidation deletes the profile embedding."""
+        store_embedding(db, "profile", profile.id, [1.0, 2.0], model_name="nomic-embed-text")
+        db.commit()
+
+        deleted = invalidate_profile_embedding(db, profile.id)
+        db.commit()
+        assert deleted == 1
+        assert get_embedding(db, "profile", profile.id, model_name="nomic-embed-text") is None
+
+
+# ---------------------------------------------------------------------------
+# MockProvider.embed()
+# ---------------------------------------------------------------------------
+
+
+class TestMockProviderEmbed:
+    @pytest.mark.asyncio
+    async def test_returns_768_dim(self, mock_provider: MockProvider):
+        """MockProvider.embed() returns a 768-dimensional vector."""
+        vec = await mock_provider.embed("test text")
+        assert len(vec) == 768
+
+    @pytest.mark.asyncio
+    async def test_deterministic(self, mock_provider: MockProvider):
+        """Same input produces same output."""
+        a = await mock_provider.embed("hello world")
+        b = await mock_provider.embed("hello world")
+        assert a == b
+
+    @pytest.mark.asyncio
+    async def test_different_texts_differ(self, mock_provider: MockProvider):
+        """Different inputs produce different vectors."""
+        a = await mock_provider.embed("Python developer")
+        b = await mock_provider.embed("Office administrator")
+        assert a != b
+
+    @pytest.mark.asyncio
+    async def test_unit_normalized(self, mock_provider: MockProvider):
+        """Mock embeddings are unit-normalized."""
+        vec = await mock_provider.embed("test")
+        norm = math.sqrt(sum(v * v for v in vec))
+        assert abs(norm - 1.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Profile & job embedding generation
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingGeneration:
+    @pytest.mark.asyncio
+    async def test_profile_embedding_generated(
+        self, db: Session, profile: Profile, mock_provider: MockProvider
+    ):
+        """Profile embedding is created and stored after generation."""
+        vec = await generate_profile_embedding(db, profile.id, mock_provider)
+        assert vec is not None
+        assert len(vec) == 768
+
+        # Verify it's cached
+        cached = get_embedding(db, "profile", profile.id)
+        assert cached is not None
+
+    @pytest.mark.asyncio
+    async def test_job_embedding_generated(self, db: Session, discovered_jobs, mock_provider):
+        """Job embedding is created when generated."""
+        job = discovered_jobs[0]
+        vec = await generate_job_embedding(
+            db,
+            job.id,
+            job.description,
+            title=job.title,
+            company=job.company,
+            provider=mock_provider,
+        )
+        assert vec is not None
+        assert len(vec) == 768
+
+        cached = get_embedding(db, "discovered_job", job.id)
+        assert cached is not None
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_no_embed_support(self, db: Session, profile: Profile):
+        """When provider doesn't support embeddings, returns None gracefully."""
+        from career_os.ai.base import AIProvider
+        from career_os.schemas.ai import AIFeature, AIResponse
+
+        class NoEmbedProvider(AIProvider):
+            @property
+            def name(self):
+                return "no-embed"
+
+            async def complete(self, prompt, *, feature=AIFeature.complete, context=None, **kw):
+                return AIResponse(content="", provider="no-embed", feature=feature)
+
+            async def score(self, job_description, profile_data, **kw):
+                return AIResponse(content="", provider="no-embed", feature=AIFeature.score)
+
+        provider = NoEmbedProvider()
+        vec = await generate_profile_embedding(db, profile.id, provider)
+        assert vec is None
+
+    @pytest.mark.asyncio
+    async def test_embedding_invalidation_on_profile_change(
+        self, db: Session, profile: Profile, mock_provider: MockProvider
+    ):
+        """Profile embedding is regenerated when skills/goals change."""
+        # Generate initial embedding
+        vec1 = await generate_profile_embedding(db, profile.id, mock_provider)
+        assert vec1 is not None
+
+        # Simulate profile change: invalidate
+        invalidate_profile_embedding(db, profile.id)
+        db.commit()
+
+        # Embedding is gone
+        assert get_embedding(db, "profile", profile.id) is None
+
+        # Add a new skill and regenerate
+        db.add(
+            Skill(
+                profile_id=profile.id,
+                name="Kubernetes",
+                category="technical",
+                proficiency="beginner",
+                evidence_source="manual",
+            )
+        )
+        db.commit()
+
+        vec2 = await generate_profile_embedding(db, profile.id, mock_provider)
+        assert vec2 is not None
+        # Different text should produce a different embedding
+        assert vec1 != vec2
+
+
+# ---------------------------------------------------------------------------
+# Pre-filter logic
+# ---------------------------------------------------------------------------
+
+
+class TestPreFilter:
+    @pytest.mark.asyncio
+    async def test_compute_similarities(
+        self, db: Session, profile: Profile, discovered_jobs, mock_provider
+    ):
+        """compute_job_similarities returns similarity scores for each job."""
+        sims = await compute_job_similarities(db, profile.id, discovered_jobs, mock_provider)
+
+        # Job 30 has no description but still has title/company, so it gets embedded
+        # All 3 should have similarities
+        assert len(sims) >= 2  # at least the 2 with descriptions
+        for _job_id, score in sims.items():
+            assert -1.0 <= score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_prefilter_removes_low_similarity(
+        self, db: Session, profile: Profile, discovered_jobs, mock_provider
+    ):
+        """Jobs below threshold are excluded when pre-filter is enabled."""
+        sims = await compute_job_similarities(db, profile.id, discovered_jobs, mock_provider)
+
+        # Use a threshold that filters some jobs
+        # Set threshold very high so most jobs are filtered
+        threshold = 0.99
+        filtered = [j for j in discovered_jobs if sims.get(j.id, threshold) >= threshold]
+        remaining = [j for j in discovered_jobs if sims.get(j.id, threshold) < threshold]
+
+        # At least some should be filtered at 0.99 threshold
+        # (mock embeddings are deterministic but not identical to profile)
+        assert len(remaining) > 0 or len(filtered) < len(discovered_jobs)
+
+    @pytest.mark.asyncio
+    async def test_prefilter_keeps_high_similarity(
+        self, db: Session, profile: Profile, discovered_jobs, mock_provider
+    ):
+        """Jobs above threshold proceed to full scoring."""
+        sims = await compute_job_similarities(db, profile.id, discovered_jobs, mock_provider)
+
+        # Use a very low threshold — all jobs should pass
+        threshold = -1.0
+        filtered = [j for j in discovered_jobs if sims.get(j.id, threshold) >= threshold]
+        assert len(filtered) == len(sims)
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_logs_without_filtering(
+        self, db: Session, profile: Profile, discovered_jobs, mock_provider
+    ):
+        """In shadow mode, similarities are computed and logged but all jobs remain."""
+        sims = await compute_job_similarities(db, profile.id, discovered_jobs, mock_provider)
+
+        # Shadow mode: don't filter, just log. Verify similarities were stored.
+        for job in discovered_jobs:
+            if job.id in sims:
+                assert job.embedding_similarity is not None
+
+        # All jobs still in the list (shadow mode doesn't remove any)
+        assert len(discovered_jobs) == 3
+
+    @pytest.mark.asyncio
+    async def test_similarity_stored_on_discovered_job(
+        self, db: Session, profile: Profile, discovered_jobs, mock_provider
+    ):
+        """embedding_similarity column is populated on DiscoveredJob rows."""
+        await compute_job_similarities(db, profile.id, discovered_jobs, mock_provider)
+        db.commit()
+
+        for job in discovered_jobs:
+            refreshed = db.get(DiscoveredJob, job.id)
+            if refreshed.description or refreshed.title:
+                # Jobs with any text should have similarity
+                assert refreshed.embedding_similarity is not None
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_no_profile(
+        self, db: Session, discovered_jobs, mock_provider
+    ):
+        """When profile has no embedding text, similarities dict is empty."""
+        # Create a minimal profile with no skills/goals/location/job_family
+        bare = Profile(id=99, name="Bare Profile")
+        db.add(bare)
+        db.commit()
+
+        sims = await compute_job_similarities(db, 99, discovered_jobs, mock_provider)
+        assert sims == {}


### PR DESCRIPTION
## Summary
- Scores in [4.0, 6.5] trigger a second LLM pass for variance reduction
- `_average_score_results()`: averages numerics, keeps better reasoning, deduplicates breakdowns
- `scoring_passes` column on ScoredJob (1 or 2)
- Graceful fallback if second pass fails (uses original score)
- 19 tests passing (10 unit + 9 integration)

## Config
- `BORDERLINE_SCORING_ENABLED` (default true)
- `BORDERLINE_LOW_THRESHOLD` (default 4.0)
- `BORDERLINE_HIGH_THRESHOLD` (default 6.5)

## Note
Based on G-272 branch — merge G-272 first.

## Test plan
- [ ] 19 tests in `tests/test_borderline_scoring.py`
- [ ] Triggers on borderline, skips non-borderline, averaging math, failure fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)