### PR TITLE
fix(G-294): add JSON parse retry and robust extraction in AI providers

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -13,7 +13,11 @@ import logging
 import httpx
 
 from career_os.ai.base import AIProvider, ProviderQuotaError
-from career_os.ai.openrouter_provider import _system_prompt_for_feature, _try_parse_structured
+from career_os.ai.openrouter_provider import (
+    _SCHEMA_MAP,
+    _system_prompt_for_feature,
+    _try_parse_structured,
+)
 from career_os.schemas.ai import AIFeature, AIResponse
 
 logger = logging.getLogger(__name__)
@@ -48,74 +52,104 @@ class AnthropicProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        max_retries: int = 1,
         **kwargs: object,
     ) -> AIResponse:
         """Send a completion request to the Anthropic Messages API."""
-        messages = [{"role": "user", "content": prompt}]
+        expects_structured = feature in _SCHEMA_MAP
 
-        # Build system blocks with cache_control for prompt caching
-        system_blocks: list[dict] | None = None
-        system_msg = _system_prompt_for_feature(feature)
-        if system_msg:
-            system_blocks = [
-                {
-                    "type": "text",
-                    "text": system_msg,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ]
-
-        payload: dict = {
-            "model": self._model,
-            "max_tokens": 4096,
-            "messages": messages,
-        }
-        if system_blocks:
-            payload["system"] = system_blocks
-
-        try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
-                response = await client.post(
-                    ANTHROPIC_API_URL,
-                    headers={
-                        "x-api-key": self._api_key,
-                        "anthropic-version": ANTHROPIC_VERSION,
-                        "Content-Type": "application/json",
-                    },
-                    json=payload,
+        for attempt in range(1, max_retries + 2):
+            user_content = prompt
+            if attempt > 1:
+                user_content += (
+                    "\n\nIMPORTANT: Return ONLY valid JSON"
+                    " with no surrounding text or markdown fences."
                 )
-                if response.status_code in (402, 429):
-                    detail = _extract_error_detail(response)
-                    if response.status_code == 429:
-                        retry_after = response.headers.get("retry-after")
-                        if retry_after:
-                            retry_msg = f"retry-after: {retry_after}s"
-                            detail = f"{detail} ({retry_msg})" if detail else retry_msg
-                    raise ProviderQuotaError("anthropic", response.status_code, detail)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.ConnectError as exc:
-            raise httpx.ConnectError(
-                f"Cannot connect to Anthropic API at {ANTHROPIC_API_URL}: {exc}"
-            ) from exc
-        except httpx.TimeoutException as exc:
-            raise httpx.TimeoutException(f"Anthropic API request timed out: {exc}") from exc
 
-        # Anthropic Messages API returns content as array of blocks
-        content_blocks = data.get("content", [])
-        content = "".join(
-            block.get("text", "") for block in content_blocks if block.get("type") == "text"
-        )
-        model_used = data.get("model", self._model)
+            messages = [{"role": "user", "content": user_content}]
 
-        # Try to parse structured data for known features
-        structured = _try_parse_structured(content, feature)
+            # Build system blocks with cache_control for prompt caching
+            system_blocks: list[dict] | None = None
+            system_msg = _system_prompt_for_feature(feature)
+            if system_msg:
+                system_blocks = [
+                    {
+                        "type": "text",
+                        "text": system_msg,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
 
+            payload: dict = {
+                "model": self._model,
+                "max_tokens": 4096,
+                "messages": messages,
+            }
+            if system_blocks:
+                payload["system"] = system_blocks
+
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    response = await client.post(
+                        ANTHROPIC_API_URL,
+                        headers={
+                            "x-api-key": self._api_key,
+                            "anthropic-version": ANTHROPIC_VERSION,
+                            "Content-Type": "application/json",
+                        },
+                        json=payload,
+                    )
+                    if response.status_code in (402, 429):
+                        detail = _extract_error_detail(response)
+                        if response.status_code == 429:
+                            retry_after = response.headers.get("retry-after")
+                            if retry_after:
+                                retry_msg = f"retry-after: {retry_after}s"
+                                detail = f"{detail} ({retry_msg})" if detail else retry_msg
+                        raise ProviderQuotaError("anthropic", response.status_code, detail)
+                    response.raise_for_status()
+                    data = response.json()
+            except httpx.ConnectError as exc:
+                raise httpx.ConnectError(
+                    f"Cannot connect to Anthropic API at {ANTHROPIC_API_URL}: {exc}"
+                ) from exc
+            except httpx.TimeoutException as exc:
+                raise httpx.TimeoutException(f"Anthropic API request timed out: {exc}") from exc
+
+            # Anthropic Messages API returns content as array of blocks
+            content_blocks = data.get("content", [])
+            content = "".join(
+                block.get("text", "") for block in content_blocks if block.get("type") == "text"
+            )
+            model_used = data.get("model", self._model)
+
+            # Try to parse structured data for known features
+            structured = _try_parse_structured(content, feature)
+
+            if structured is not None or not expects_structured:
+                return AIResponse(
+                    content=content,
+                    provider="anthropic",
+                    feature=feature,
+                    structured=structured,
+                    model=model_used,
+                )
+
+            # Structured parse failed — retry if we have attempts left
+            if attempt <= max_retries:
+                logger.warning(
+                    "Structured parse failed for %s, retrying (attempt %d/%d)",
+                    feature,
+                    attempt,
+                    max_retries + 1,
+                )
+
+        # Exhausted retries — return last response without structured data
         return AIResponse(
             content=content,
             provider="anthropic",
             feature=feature,
-            structured=structured,
+            structured=None,
             model=model_used,
         )
 

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -6,6 +6,7 @@ Requires OPENROUTER_API_KEY in environment.
 
 import json
 import logging
+import re
 
 import httpx
 
@@ -78,49 +79,81 @@ class OpenRouterProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        max_retries: int = 1,
         **kwargs: object,
     ) -> AIResponse:
         """Send a completion request to OpenRouter."""
-        messages = [{"role": "user", "content": prompt}]
+        expects_structured = feature in _SCHEMA_MAP
 
-        # Add system message for structured features
-        system_msg = _system_prompt_for_feature(feature)
-        if system_msg:
-            messages.insert(0, {"role": "system", "content": system_msg})
+        for attempt in range(1, max_retries + 2):  # 1-based, up to max_retries+1
+            user_content = prompt
+            if attempt > 1:
+                user_content += (
+                    "\n\nIMPORTANT: Return ONLY valid JSON"
+                    " with no surrounding text or markdown fences."
+                )
 
-        payload = {
-            "model": self._model,
-            "messages": messages,
-        }
+            messages: list[dict[str, str]] = [
+                {"role": "user", "content": user_content},
+            ]
 
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            response = await client.post(
-                OPENROUTER_API_URL,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://career-os.local",
-                    "X-Title": "Career OS",
-                },
-                json=payload,
-            )
-            if response.status_code in (402, 429):
-                detail = _extract_error_detail(response)
-                raise CreditsExhaustedError(status_code=response.status_code, detail=detail)
-            response.raise_for_status()
-            data = response.json()
+            # Add system message for structured features
+            system_msg = _system_prompt_for_feature(feature)
+            if system_msg:
+                messages.insert(0, {"role": "system", "content": system_msg})
 
-        content = data["choices"][0]["message"]["content"]
-        model_used = data.get("model", self._model)
+            payload = {
+                "model": self._model,
+                "messages": messages,
+            }
 
-        # Try to parse structured data for known features
-        structured = _try_parse_structured(content, feature)
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    OPENROUTER_API_URL,
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                        "HTTP-Referer": "https://career-os.local",
+                        "X-Title": "Career OS",
+                    },
+                    json=payload,
+                )
+                if response.status_code in (402, 429):
+                    detail = _extract_error_detail(response)
+                    raise CreditsExhaustedError(status_code=response.status_code, detail=detail)
+                response.raise_for_status()
+                data = response.json()
 
+            content = data["choices"][0]["message"]["content"]
+            model_used = data.get("model", self._model)
+
+            # Try to parse structured data for known features
+            structured = _try_parse_structured(content, feature)
+
+            if structured is not None or not expects_structured:
+                return AIResponse(
+                    content=content,
+                    provider="openrouter",
+                    feature=feature,
+                    structured=structured,
+                    model=model_used,
+                )
+
+            # Structured parse failed — retry if we have attempts left
+            if attempt <= max_retries:
+                logger.warning(
+                    "Structured parse failed for %s, retrying (attempt %d/%d)",
+                    feature,
+                    attempt,
+                    max_retries + 1,
+                )
+
+        # Exhausted retries — return last response without structured data
         return AIResponse(
             content=content,
             provider="openrouter",
             feature=feature,
-            structured=structured,
+            structured=None,
             model=model_used,
         )
 
@@ -221,6 +254,54 @@ def _system_prompt_for_feature(feature: AIFeature) -> str | None:
     return prompts.get(feature)
 
 
+_SCHEMA_MAP: dict[AIFeature, type] = {
+    AIFeature.score: ScoreResult,
+    AIFeature.gap_analysis: GapAnalysisResult,
+    AIFeature.coaching: CoachingResult,
+    AIFeature.goal_recalibration: GoalRecalibrationResult,
+    AIFeature.interview_prep: InterviewPrepResult,
+    AIFeature.company_research: CompanyResearchResult,
+    AIFeature.learning_recommendations: LearningRecommendationsResult,
+    AIFeature.interview_format: InterviewFormatResult,
+    AIFeature.interview_patterns: InterviewPatternsResult,
+}
+
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Extract the first top-level ``{...}`` block using brace-depth counting.
+
+    Returns the substring from the first ``{`` to its matching ``}`` or
+    ``None`` if no balanced block is found.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    in_string = False
+    escape_next = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\":
+            if in_string:
+                escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
 def _try_parse_structured(
     content: str, feature: AIFeature
 ) -> (
@@ -250,24 +331,36 @@ def _try_parse_structured(
         if text.startswith("```"):
             # Strip markdown code fences
             lines = text.split("\n")
-            text = "\n".join(lines[1:-1]) if len(lines) > 2 else text
-        data = json.loads(text)
+            # Handle partial closing fence too
+            end = -1 if lines[-1].startswith("```") else len(lines)
+            text = "\n".join(lines[1:end]) if len(lines) > 2 else text
 
-        schema_map: dict[AIFeature, type] = {
-            AIFeature.score: ScoreResult,
-            AIFeature.gap_analysis: GapAnalysisResult,
-            AIFeature.coaching: CoachingResult,
-            AIFeature.goal_recalibration: GoalRecalibrationResult,
-            AIFeature.interview_prep: InterviewPrepResult,
-            AIFeature.company_research: CompanyResearchResult,
-            AIFeature.learning_recommendations: LearningRecommendationsResult,
-            AIFeature.interview_format: InterviewFormatResult,
-            AIFeature.interview_patterns: InterviewPatternsResult,
-        }
-        schema_cls = schema_map.get(feature)
+        # Strip trailing commas before } or ] (common LLM artifact)
+        text = re.sub(r",\s*([}\]])", r"\1", text)
+
+        # Try direct parse first
+        data = None
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            # Try extracting the first JSON object from surrounding text
+            extracted = _extract_first_json_object(text)
+            if extracted:
+                extracted = re.sub(r",\s*([}\]])", r"\1", extracted)
+                data = json.loads(extracted)
+
+        if data is None:
+            raise ValueError("No JSON object found in content")
+
+        schema_cls = _SCHEMA_MAP.get(feature)
         if schema_cls:
             return schema_cls.model_validate(data)
     except Exception as exc:
-        logger.debug("Could not parse structured response for %s: %s", feature, exc)
+        logger.warning(
+            "Could not parse structured response for %s: %s | raw (first 200 chars): %.200s",
+            feature,
+            exc,
+            content,
+        )
 
     return None

--- a/tests/test_json_parse_retry.py
+++ b/tests/test_json_parse_retry.py
@@ -1,0 +1,182 @@
+"""Tests for JSON parse robustness and retry logic in AI providers."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from career_os.ai.openrouter_provider import (
+    CreditsExhaustedError,
+    OpenRouterProvider,
+    _try_parse_structured,
+)
+from career_os.schemas.ai import AIFeature
+
+VALID_SCORE_JSON = {
+    "fit_score": 5.0,
+    "reasoning": (
+        "Test reasoning that is at least one hundred characters long to pass"
+        " validation requirements for the scoring system."
+    ),
+    "estimated_salary": "$100k",
+    "effort_flag": "medium",
+    "prep_level": "moderate",
+    "prep_notes": "Study up",
+    "readiness_score": 65.0,
+    "career_alignment": 6.0,
+    "score_breakdown": [
+        {"factor": "skills", "contribution": 2.0, "description": "Good match"},
+        {"factor": "experience", "contribution": 1.5, "description": "Partial"},
+        {"factor": "location", "contribution": -0.5, "description": "Remote only"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# _try_parse_structured tests
+# ---------------------------------------------------------------------------
+
+
+class TestTryParseStructured:
+    """Tests for the _try_parse_structured function."""
+
+    def test_clean_json_parses_correctly(self):
+        """Test 1: Clean JSON parses correctly."""
+        content = json.dumps(VALID_SCORE_JSON)
+        result = _try_parse_structured(content, AIFeature.score)
+        assert result is not None
+        assert result.fit_score == 5.0
+
+    def test_json_in_markdown_fence(self):
+        """Test 2: JSON wrapped in markdown code fences parses correctly."""
+        content = "```json\n" + json.dumps(VALID_SCORE_JSON) + "\n```"
+        result = _try_parse_structured(content, AIFeature.score)
+        assert result is not None
+        assert result.fit_score == 5.0
+
+    def test_json_with_trailing_comma(self):
+        """Test 3: JSON with trailing commas parses correctly."""
+        raw = json.dumps(VALID_SCORE_JSON)
+        # Insert a trailing comma before the last }
+        raw = raw[:-1] + ",}"
+        result = _try_parse_structured(raw, AIFeature.score)
+        assert result is not None
+        assert result.fit_score == 5.0
+
+    def test_json_embedded_in_text(self):
+        """Test 4: JSON embedded in explanatory text is extracted and parsed."""
+        content = (
+            "Here is the result: "
+            + json.dumps(VALID_SCORE_JSON)
+            + " Let me know if you need anything else."
+        )
+        result = _try_parse_structured(content, AIFeature.score)
+        assert result is not None
+        assert result.fit_score == 5.0
+
+    def test_completely_invalid_content_returns_none(self):
+        """Test 5: Completely invalid content returns None."""
+        result = _try_parse_structured("I cannot score this", AIFeature.score)
+        assert result is None
+
+    def test_truncated_json_returns_none(self):
+        """Test 6: Truncated JSON returns None without crashing."""
+        content = '{"fit_score": 5.0, "reasoning": "tes'
+        result = _try_parse_structured(content, AIFeature.score)
+        assert result is None
+
+    def test_complete_feature_returns_none(self):
+        """complete feature always returns None (unstructured)."""
+        content = json.dumps(VALID_SCORE_JSON)
+        result = _try_parse_structured(content, AIFeature.complete)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Retry logic tests
+# ---------------------------------------------------------------------------
+
+
+def _make_openrouter_response(content: str, status_code: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response for OpenRouter."""
+    body = {
+        "choices": [{"message": {"content": content}}],
+        "model": "test-model",
+    }
+    return httpx.Response(
+        status_code=status_code,
+        json=body,
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+
+def _make_error_response(status_code: int) -> httpx.Response:
+    """Build a fake error httpx.Response."""
+    body = {"error": {"message": "quota exceeded"}}
+    return httpx.Response(
+        status_code=status_code,
+        json=body,
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+
+class TestRetryLogic:
+    """Tests for retry logic in OpenRouterProvider.complete()."""
+
+    @pytest.mark.asyncio
+    async def test_retry_returns_valid_on_second_attempt(self):
+        """Test 7: Bad JSON first, good JSON second -> valid AIResponse."""
+        bad_response = _make_openrouter_response("Not valid JSON at all")
+        good_response = _make_openrouter_response(json.dumps(VALID_SCORE_JSON))
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[bad_response, good_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        provider = OpenRouterProvider(api_key="test-key")
+
+        with patch("career_os.ai.openrouter_provider.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete("Score this", feature=AIFeature.score)
+
+        assert result.structured is not None
+        assert result.structured.fit_score == 5.0
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_returns_none_structured(self):
+        """Test 8: Bad JSON on all attempts -> structured is None, no crash."""
+        bad_response = _make_openrouter_response("I cannot produce JSON")
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=bad_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        provider = OpenRouterProvider(api_key="test-key")
+
+        with patch("career_os.ai.openrouter_provider.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete("Score this", feature=AIFeature.score)
+
+        assert result.structured is None
+        assert result.content == "I cannot produce JSON"
+        assert mock_client.post.call_count == 2  # initial + 1 retry
+
+    @pytest.mark.asyncio
+    async def test_credits_exhausted_raises_immediately(self):
+        """Test 9: 402 raises CreditsExhaustedError immediately, no retry."""
+        error_response = _make_error_response(402)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=error_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        provider = OpenRouterProvider(api_key="test-key")
+
+        with patch("career_os.ai.openrouter_provider.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(CreditsExhaustedError):
+                await provider.complete("Score this", feature=AIFeature.score)
+
+        assert mock_client.post.call_count == 1  # no retry


### PR DESCRIPTION
## Summary
- Improved `_try_parse_structured()` to handle trailing commas, JSON embedded in text, and partial markdown fences
- Added retry logic (max 1 retry) in both OpenRouter and Anthropic `complete()` methods when structured parse fails
- 402/429 errors still raise immediately (no retry on quota exhaustion)

**Context:** G-286 benchmark showed 15.8% (19/120) scoring API calls returned unparseable JSON. This reduces that to near-zero by extracting JSON more robustly and retrying once with a "return only JSON" instruction.

## Test plan
- [x] 7 parse tests (clean, markdown fence, trailing comma, embedded text, invalid, truncated, complete feature)
- [x] 3 retry tests (successful retry, exhausted retries, 402 no-retry)
- [x] All 89 existing scoring tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)