### PR TITLE
feat(G-295): expand golden set — fix miscategorizations, add finance & design sets

### DIFF
--- a/scripts/benchmark_scoring.py
+++ b/scripts/benchmark_scoring.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""G-286: Scoring evolution benchmark — before/after validation.
+
+Scores the golden set (20 jobs × 3 runs) without and with the rubric,
+then compares variance, accuracy, red flags, dual-score, and full pipeline.
+
+Requires:
+    AI_PROVIDER=openrouter  OPENROUTER_API_KEY=...
+    (or set in .env / environment before running)
+
+Usage:
+    .venv/bin/python scripts/benchmark_scoring.py
+    .venv/bin/python scripts/benchmark_scoring.py \\
+        --golden-set tests/fixtures/scoring_golden_set_finance.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Env vars must be set BEFORE importing career_os (Settings validates on load)
+# ---------------------------------------------------------------------------
+os.environ.setdefault("AI_PROVIDER", "openrouter")
+# Accept key from env or fall back to rbw lookup later
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+GOLDEN_SET_PATH = PROJECT_ROOT / "tests" / "fixtures" / "scoring_golden_set.json"
+PRIVATE_DIR = PROJECT_ROOT / "private"
+PRIVATE_DIR.mkdir(exist_ok=True)
+BASELINE_PATH = PRIVATE_DIR / "benchmark-baseline-no-rubric.json"
+RUBRIC_PATH = PRIVATE_DIR / "benchmark-with-rubric.json"
+
+RUNS_PER_JOB = 3
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-5s | %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("benchmark")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_golden_set(path: Path = GOLDEN_SET_PATH) -> tuple[dict, list[dict]]:
+    with open(path) as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        # Legacy format (bare array)
+        return {}, data
+    return data.get("profile", {}), data["jobs"]
+
+
+def create_benchmark_profile(db, profile_data: dict | None = None):
+    """Create a benchmark profile with skills & goals for scoring context.
+
+    When *profile_data* is provided (from the golden set's ``profile`` section),
+    its ``job_family``, ``location``, and ``key_skills`` override the defaults.
+    """
+    from career_os.models.models import Profile
+    from career_os.models.skills import Goal, Skill
+
+    job_family = (profile_data or {}).get("job_family", "TPM")
+    location = (profile_data or {}).get("location", "Frankfurt, Germany")
+    key_skills = (profile_data or {}).get("key_skills")
+
+    profile = Profile(
+        name=f"Benchmark {job_family}",
+        email="benchmark@test.local",
+        location=location,
+        job_family=job_family,
+    )
+    db.add(profile)
+    db.flush()
+
+    def _skill(name, cat, prof):
+        return Skill(
+            profile_id=profile.id,
+            name=name,
+            category=cat,
+            proficiency=prof,
+            evidence_source="benchmark",
+        )
+
+    if key_skills:
+        skills = [_skill(s, "technical", "expert") for s in key_skills]
+    else:
+        skills = [
+            _skill("Python", "technical", "expert"),
+            _skill("Program Management", "management", "expert"),
+            _skill("AI/ML", "technical", "advanced"),
+            _skill("Cross-functional Leadership", "management", "expert"),
+            _skill("Cloud Infrastructure", "technical", "intermediate"),
+            _skill("Stakeholder Management", "management", "expert"),
+            _skill("Agile/Scrum", "process", "expert"),
+            _skill("Technical Architecture", "technical", "advanced"),
+            _skill("Data Analysis", "technical", "advanced"),
+            _skill("Risk Management", "process", "advanced"),
+        ]
+    db.add_all(skills)
+
+    goals = [
+        Goal(
+            profile_id=profile.id,
+            title="Lead AI program at a top-tier tech company",
+            goal_type="career",
+            description="TPM/Program Lead role at an AI-native company (Anthropic, DeepMind, Mistral, etc.)",
+            status="active",
+        ),
+        Goal(
+            profile_id=profile.id,
+            title="Remote-first or hybrid in Frankfurt area",
+            goal_type="location",
+            description="Prefer remote EU roles; on-site only acceptable for dream companies",
+            status="active",
+        ),
+    ]
+    db.add_all(goals)
+    db.commit()
+    db.refresh(profile)
+
+    log.info("Created benchmark profile id=%d (%s, %s)", profile.id, job_family, location)
+    return profile
+
+
+async def score_one(db, profile_id: int, job: dict) -> dict:
+    """Score a single golden-set job and return raw result dict."""
+    from career_os.services.scoring import score_job
+
+    t0 = time.monotonic()
+    scored = await score_job(
+        db,
+        profile_id,
+        job["description"],
+        job_title=job["title"],
+        job_company=job["company"],
+    )
+    elapsed = round(time.monotonic() - t0, 2)
+
+    dim_scores = {}
+    for dim in [
+        "dim_technical_fit",
+        "dim_seniority_alignment",
+        "dim_compensation_fit",
+        "dim_location_fit",
+        "dim_career_trajectory",
+        "dim_company_fit",
+    ]:
+        dim_scores[dim] = getattr(scored, dim, None)
+
+    return {
+        "golden_id": job["id"],
+        "category": job["category"],
+        "expected_band": job["expected_band"],
+        "title": job["title"],
+        "company": job["company"],
+        "fit_score": scored.fit_score,
+        "readiness_score": scored.readiness_score,
+        "career_alignment": scored.career_alignment,
+        "reasoning": scored.reasoning,
+        "dimensional_scores": dim_scores,
+        "desire_score": scored.desire_score,
+        "desire_score_method": scored.desire_score_method,
+        "desire_reasoning": scored.desire_reasoning,
+        "red_flags": json.loads(scored.red_flags) if scored.red_flags else [],
+        "ats_keywords": json.loads(scored.ats_keywords) if scored.ats_keywords else [],
+        "score_breakdown": json.loads(scored.score_breakdown) if scored.score_breakdown else [],
+        "effort_flag": scored.effort_flag,
+        "elapsed_seconds": elapsed,
+    }
+
+
+async def run_scoring_pass(db, profile_id: int, golden_set: list[dict], label: str) -> list[dict]:
+    """Score all golden-set jobs RUNS_PER_JOB times. Returns flat list of results."""
+    results = []
+    total = len(golden_set) * RUNS_PER_JOB
+    done = 0
+
+    for job in golden_set:
+        for run in range(1, RUNS_PER_JOB + 1):
+            done += 1
+            log.info(
+                "[%s] %d/%d — %s @ %s (run %d)",
+                label,
+                done,
+                total,
+                job["title"],
+                job["company"],
+                run,
+            )
+            try:
+                result = await score_one(db, profile_id, job)
+                result["run"] = run
+                results.append(result)
+                log.info(
+                    "  → fit=%.1f desire=%s elapsed=%.1fs",
+                    result["fit_score"],
+                    result.get("desire_score"),
+                    result["elapsed_seconds"],
+                )
+            except Exception as e:
+                log.error("  ✗ FAILED: %s", e)
+                results.append(
+                    {
+                        "golden_id": job["id"],
+                        "category": job["category"],
+                        "expected_band": job["expected_band"],
+                        "title": job["title"],
+                        "company": job["company"],
+                        "run": run,
+                        "error": str(e),
+                    }
+                )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def analyze_pass(results: list[dict], label: str) -> dict:
+    """Compute per-job and overall statistics for a scoring pass."""
+    # Group by golden_id
+    by_job: dict[str, list[dict]] = {}
+    for r in results:
+        if "error" in r:
+            continue
+        by_job.setdefault(r["golden_id"], []).append(r)
+
+    job_stats = []
+    for gid, runs in sorted(by_job.items()):
+        scores = [r["fit_score"] for r in runs]
+        mean = statistics.mean(scores)
+        std = statistics.stdev(scores) if len(scores) > 1 else 0.0
+        in_band = sum(
+            1 for r in runs if r["expected_band"][0] <= r["fit_score"] <= r["expected_band"][1]
+        )
+        job_stats.append(
+            {
+                "golden_id": gid,
+                "category": runs[0]["category"],
+                "expected_band": runs[0]["expected_band"],
+                "title": runs[0]["title"],
+                "company": runs[0]["company"],
+                "scores": scores,
+                "mean": round(mean, 2),
+                "std": round(std, 3),
+                "in_band_count": in_band,
+                "in_band_pct": round(in_band / len(runs) * 100, 1),
+            }
+        )
+
+    # Overall stats
+    all_stds = [j["std"] for j in job_stats if j["std"] > 0]
+    mean_std = round(statistics.mean(all_stds), 3) if all_stds else 0.0
+
+    # Category stats
+    cat_stats = {}
+    for cat in ["reject", "mediocre", "strong", "dream"]:
+        cat_jobs = [j for j in job_stats if j["category"] == cat]
+        if cat_jobs:
+            cat_scores = [s for j in cat_jobs for s in j["scores"]]
+            in_band = sum(j["in_band_count"] for j in cat_jobs)
+            total_runs = sum(len(j["scores"]) for j in cat_jobs)
+            cat_stats[cat] = {
+                "mean": round(statistics.mean(cat_scores), 2),
+                "std": round(statistics.stdev(cat_scores), 3) if len(cat_scores) > 1 else 0.0,
+                "min": min(cat_scores),
+                "max": max(cat_scores),
+                "in_band_pct": round(in_band / total_runs * 100, 1) if total_runs else 0,
+                "n_jobs": len(cat_jobs),
+                "n_runs": total_runs,
+            }
+
+    # Dimensional consistency
+    dim_names = [
+        "dim_technical_fit",
+        "dim_seniority_alignment",
+        "dim_compensation_fit",
+        "dim_location_fit",
+        "dim_career_trajectory",
+        "dim_company_fit",
+    ]
+    dim_consistency = {}
+    for dim in dim_names:
+        dim_stds = []
+        for gid, runs in by_job.items():
+            vals = [
+                r["dimensional_scores"].get(dim)
+                for r in runs
+                if r["dimensional_scores"].get(dim) is not None
+            ]
+            if len(vals) > 1:
+                dim_stds.append(statistics.stdev(vals))
+        dim_consistency[dim] = round(statistics.mean(dim_stds), 3) if dim_stds else None
+
+    return {
+        "label": label,
+        "total_runs": len([r for r in results if "error" not in r]),
+        "errors": len([r for r in results if "error" in r]),
+        "mean_std_across_jobs": mean_std,
+        "category_stats": cat_stats,
+        "dimensional_consistency": dim_consistency,
+        "per_job": job_stats,
+    }
+
+
+def compare_passes(baseline: dict, rubric: dict) -> dict:
+    """Compare baseline vs rubric results."""
+    b_std = baseline["mean_std_across_jobs"]
+    r_std = rubric["mean_std_across_jobs"]
+    variance_reduction = round((1 - r_std / b_std) * 100, 1) if b_std > 0 else None
+
+    # Per-category accuracy comparison
+    accuracy_comparison = {}
+    for cat in ["reject", "mediocre", "strong", "dream"]:
+        b_cat = baseline["category_stats"].get(cat, {})
+        r_cat = rubric["category_stats"].get(cat, {})
+        accuracy_comparison[cat] = {
+            "baseline_in_band_pct": b_cat.get("in_band_pct", 0),
+            "rubric_in_band_pct": r_cat.get("in_band_pct", 0),
+            "baseline_mean": b_cat.get("mean", 0),
+            "rubric_mean": r_cat.get("mean", 0),
+        }
+
+    # Category separation: do categories have distinct, non-overlapping ranges?
+    separation = {}
+    for label, analysis in [("baseline", baseline), ("rubric", rubric)]:
+        ranges = {}
+        for cat in ["reject", "mediocre", "strong", "dream"]:
+            cs = analysis["category_stats"].get(cat, {})
+            ranges[cat] = (cs.get("min", 0), cs.get("max", 0))
+        separation[label] = ranges
+
+    return {
+        "variance_reduction_pct": variance_reduction,
+        "baseline_mean_std": b_std,
+        "rubric_mean_std": r_std,
+        "accuracy_comparison": accuracy_comparison,
+        "category_separation": separation,
+        "dimensional_consistency_comparison": {
+            "baseline": baseline["dimensional_consistency"],
+            "rubric": rubric["dimensional_consistency"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Red flags validation
+# ---------------------------------------------------------------------------
+
+
+def validate_red_flags(rubric_results: list[dict]) -> dict:
+    """Analyze red flag detection across golden set."""
+
+    flag_counts: dict[str, int] = {}
+    false_positives = []  # flags on dream/strong jobs
+    per_job = []
+
+    for r in rubric_results:
+        if "error" in r or r["run"] != 1:  # only check first run
+            continue
+        flags = r.get("red_flags", [])
+        for f in flags:
+            flag_counts[f["flag_type"]] = flag_counts.get(f["flag_type"], 0) + 1
+            if r["category"] in ("strong", "dream"):
+                false_positives.append(
+                    {
+                        "job": f"{r['title']} @ {r['company']}",
+                        "category": r["category"],
+                        "flag": f["flag_type"],
+                        "severity": f["severity"],
+                        "description": f["description"],
+                    }
+                )
+        per_job.append(
+            {
+                "golden_id": r["golden_id"],
+                "category": r["category"],
+                "title": r["title"],
+                "n_flags": len(flags),
+                "flag_types": [f["flag_type"] for f in flags],
+            }
+        )
+
+    return {
+        "total_flags_triggered": sum(flag_counts.values()),
+        "flag_type_counts": flag_counts,
+        "false_positives_on_strong_dream": false_positives,
+        "per_job": per_job,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dual-score spot check
+# ---------------------------------------------------------------------------
+
+
+def validate_dual_score(rubric_results: list[dict]) -> list[dict]:
+    """Spot-check desire_score quadrant classifications."""
+    checks = []
+    for r in rubric_results:
+        if "error" in r or r["run"] != 1:
+            continue
+
+        fit = r["fit_score"]
+        desire = r.get("desire_score")
+        if desire is None:
+            quadrant = "no_desire_score"
+        elif fit >= 7 and desire >= 7:
+            quadrant = "Dream Job"
+        elif fit >= 7 and desire < 7:
+            quadrant = "Safe Bet"
+        elif fit < 7 and desire >= 7:
+            quadrant = "Reach"
+        else:
+            quadrant = "Skip"
+
+        checks.append(
+            {
+                "golden_id": r["golden_id"],
+                "category": r["category"],
+                "title": r["title"],
+                "company": r["company"],
+                "fit_score": fit,
+                "desire_score": desire,
+                "desire_method": r.get("desire_score_method"),
+                "quadrant": quadrant,
+            }
+        )
+
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Embedding analysis (optional — requires Ollama)
+# ---------------------------------------------------------------------------
+
+
+async def embedding_analysis(golden_set: list[dict], rubric_analysis: dict) -> dict | None:
+    """Generate embeddings and compare cosine similarity vs fit_score."""
+    try:
+        import httpx
+    except ImportError:
+        log.warning("httpx not available, skipping embedding analysis")
+        return None
+
+    OLLAMA_URL = "http://localhost:11434"
+    MODEL = "nomic-embed-text"
+
+    # Check Ollama availability
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{OLLAMA_URL}/api/tags")
+            models = [m["name"] for m in resp.json().get("models", [])]
+            if MODEL not in models and f"{MODEL}:latest" not in models:
+                log.warning("Embedding model '%s' not found in Ollama (have: %s)", MODEL, models)
+                return None
+    except Exception as e:
+        log.warning("Ollama not available: %s", e)
+        return None
+
+    async def get_embedding(text: str) -> list[float]:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                f"{OLLAMA_URL}/api/embed",
+                json={"model": MODEL, "input": text},
+            )
+            resp.raise_for_status()
+            return resp.json()["embeddings"][0]
+
+    def cosine_sim(a: list[float], b: list[float]) -> float:
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = sum(x * x for x in a) ** 0.5
+        norm_b = sum(x * x for x in b) ** 0.5
+        return dot / (norm_a * norm_b) if norm_a and norm_b else 0.0
+
+    # Synthetic profile embedding
+    profile_text = (
+        "Technical Program Manager with expertise in AI/ML, Python, "
+        "cross-functional leadership, cloud infrastructure, and stakeholder management. "
+        "Based in Frankfurt, Germany. Seeking AI program lead role at a top-tier tech company."
+    )
+    log.info("Generating profile embedding...")
+    profile_emb = await get_embedding(profile_text)
+
+    # Job embeddings + similarity
+    results = []
+    for job in golden_set:
+        log.info("Embedding: %s @ %s", job["title"], job["company"])
+        job_emb = await get_embedding(f"{job['title']} at {job['company']}. {job['description']}")
+        sim = cosine_sim(profile_emb, job_emb)
+
+        # Find mean fit_score from rubric pass
+        job_stats = [j for j in rubric_analysis["per_job"] if j["golden_id"] == job["id"]]
+        mean_fit = job_stats[0]["mean"] if job_stats else None
+
+        results.append(
+            {
+                "golden_id": job["id"],
+                "category": job["category"],
+                "title": job["title"],
+                "company": job["company"],
+                "cosine_similarity": round(sim, 4),
+                "mean_fit_score": mean_fit,
+            }
+        )
+
+    # Sort by similarity
+    results.sort(key=lambda x: x["cosine_similarity"], reverse=True)
+
+    # Find threshold that filters all rejects without losing strong/dream
+    reject_sims = [r["cosine_similarity"] for r in results if r["category"] == "reject"]
+    strong_dream_sims = [
+        r["cosine_similarity"] for r in results if r["category"] in ("strong", "dream")
+    ]
+
+    max_reject_sim = max(reject_sims) if reject_sims else 0
+    min_sd_sim = min(strong_dream_sims) if strong_dream_sims else 1
+
+    threshold_analysis = {
+        "max_reject_similarity": max_reject_sim,
+        "min_strong_dream_similarity": min_sd_sim,
+        "clean_threshold_exists": max_reject_sim < min_sd_sim,
+    }
+
+    if max_reject_sim < min_sd_sim:
+        suggested_threshold = round((max_reject_sim + min_sd_sim) / 2, 4)
+        # Count what this threshold would filter
+        filtered = sum(1 for r in results if r["cosine_similarity"] < suggested_threshold)
+        false_negatives = sum(
+            1
+            for r in results
+            if r["cosine_similarity"] < suggested_threshold and r["category"] in ("strong", "dream")
+        )
+        threshold_analysis["suggested_threshold"] = suggested_threshold
+        threshold_analysis["would_filter_pct"] = round(filtered / len(results) * 100, 1)
+        threshold_analysis["false_negative_rate"] = round(false_negatives / len(results) * 100, 1)
+
+    return {
+        "model": MODEL,
+        "per_job": results,
+        "threshold_analysis": threshold_analysis,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    import career_os.services.scoring as scoring_mod
+    from career_os.database import SessionLocal
+
+    parser = argparse.ArgumentParser(description="Scoring benchmark")
+    parser.add_argument(
+        "--golden-set", default=str(GOLDEN_SET_PATH), help="Path to golden set JSON"
+    )
+    args = parser.parse_args()
+    golden_set_path = Path(args.golden_set)
+
+    profile_data, golden_set = load_golden_set(golden_set_path)
+    log.info("Loaded %d golden-set jobs from %s", len(golden_set), golden_set_path)
+
+    db = SessionLocal()
+    try:
+        profile = create_benchmark_profile(db, profile_data)
+        profile_id = profile.id
+
+        # ── Phase 1: Baseline (no rubric) ──────────────────────────
+        log.info("═" * 60)
+        log.info("PHASE 1: BASELINE SCORING (no rubric)")
+        log.info("═" * 60)
+
+        # Monkey-patch: disable rubric
+        original_rubric = scoring_mod.SCORING_RUBRIC
+        scoring_mod.SCORING_RUBRIC = ""
+        log.info("Rubric disabled (monkey-patched to empty string)")
+
+        baseline_results = await run_scoring_pass(db, profile_id, golden_set, "BASELINE")
+
+        with open(BASELINE_PATH, "w") as f:
+            json.dump(baseline_results, f, indent=2, default=str)
+        log.info("Baseline results saved to %s", BASELINE_PATH)
+
+        # ── Phase 2: With rubric ──────────────────────────────────
+        log.info("═" * 60)
+        log.info("PHASE 2: RUBRIC SCORING")
+        log.info("═" * 60)
+
+        # Restore rubric
+        scoring_mod.SCORING_RUBRIC = original_rubric
+        log.info("Rubric re-enabled")
+
+        rubric_results = await run_scoring_pass(db, profile_id, golden_set, "RUBRIC")
+
+        with open(RUBRIC_PATH, "w") as f:
+            json.dump(rubric_results, f, indent=2, default=str)
+        log.info("Rubric results saved to %s", RUBRIC_PATH)
+
+        # ── Phase 3: Analysis ─────────────────────────────────────
+        log.info("═" * 60)
+        log.info("PHASE 3: ANALYSIS")
+        log.info("═" * 60)
+
+        baseline_analysis = analyze_pass(baseline_results, "baseline")
+        rubric_analysis = analyze_pass(rubric_results, "rubric")
+        comparison = compare_passes(baseline_analysis, rubric_analysis)
+
+        # Red flags
+        red_flag_report = validate_red_flags(rubric_results)
+
+        # Dual-score
+        dual_score_report = validate_dual_score(rubric_results)
+
+        # Embedding analysis
+        embedding_report = await embedding_analysis(golden_set, rubric_analysis)
+
+        # ── Save full analysis ────────────────────────────────────
+        full_report = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "config": {
+                "runs_per_job": RUNS_PER_JOB,
+                "n_jobs": len(golden_set),
+                "ai_provider": os.environ.get("AI_PROVIDER"),
+                "model": os.environ.get("OPENROUTER_MODEL", "default"),
+            },
+            "baseline_analysis": baseline_analysis,
+            "rubric_analysis": rubric_analysis,
+            "comparison": comparison,
+            "red_flags": red_flag_report,
+            "dual_score": dual_score_report,
+            "embedding_analysis": embedding_report,
+        }
+
+        analysis_path = PRIVATE_DIR / "benchmark-analysis.json"
+        with open(analysis_path, "w") as f:
+            json.dump(full_report, f, indent=2, default=str)
+        log.info("Full analysis saved to %s", analysis_path)
+
+        # ── Print summary ─────────────────────────────────────────
+        print("\n" + "═" * 60)
+        print("BENCHMARK SUMMARY")
+        print("═" * 60)
+
+        vr = comparison["variance_reduction_pct"]
+        print(f"\nVariance reduction: {vr}%" if vr is not None else "\nVariance reduction: N/A")
+        print(f"  Baseline mean σ: {comparison['baseline_mean_std']}")
+        print(f"  Rubric mean σ:   {comparison['rubric_mean_std']}")
+
+        print("\nCategory accuracy (% scores in expected band):")
+        for cat, data in comparison["accuracy_comparison"].items():
+            print(
+                f"  {cat:10s} — baseline: {data['baseline_in_band_pct']:5.1f}%  rubric: {data['rubric_in_band_pct']:5.1f}%"
+            )
+
+        print(
+            f"\nRed flags: {red_flag_report['total_flags_triggered']} total, "
+            f"{len(red_flag_report['false_positives_on_strong_dream'])} false positives on strong/dream"
+        )
+
+        print("\nDual-score quadrants:")
+        quadrant_counts: dict[str, int] = {}
+        for ds in dual_score_report:
+            q = ds["quadrant"]
+            quadrant_counts[q] = quadrant_counts.get(q, 0) + 1
+        for q, n in sorted(quadrant_counts.items()):
+            print(f"  {q}: {n}")
+
+        if embedding_report:
+            ta = embedding_report["threshold_analysis"]
+            print("\nEmbedding pre-filter:")
+            print(f"  Clean threshold exists: {ta['clean_threshold_exists']}")
+            if ta.get("suggested_threshold"):
+                print(f"  Suggested threshold: {ta['suggested_threshold']}")
+                print(f"  Would filter: {ta['would_filter_pct']}%")
+                print(f"  False negative rate: {ta['false_negative_rate']}%")
+
+        print(f"\nFull analysis: {analysis_path}")
+        print("═" * 60)
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/fixtures/scoring_golden_set.json
+++ b/tests/fixtures/scoring_golden_set.json
@@ -1,182 +1,189 @@
-[
-  {
-    "id": "gs-01",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Senior .NET Developer",
-    "company": "SAP SE",
-    "location": "Walldorf, Germany",
-    "description": "Build enterprise ERP modules in C#/.NET 8, Azure DevOps, SQL Server. 5+ years .NET required. Team of 12 backend developers. On-site only."
-  },
-  {
-    "id": "gs-02",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Compensation & Benefits Analyst",
-    "company": "Deel",
-    "location": "Remote, EMEA",
-    "description": "Manage global compensation benchmarking, benefits administration, and payroll compliance across 30+ countries. Excel/HRIS expertise required."
-  },
-  {
-    "id": "gs-03",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Senior iOS Developer (Swift)",
-    "company": "N26",
-    "location": "Berlin, Germany",
-    "description": "Build native iOS banking features in Swift/SwiftUI. 6+ years iOS development. Strong UIKit and Core Data experience required."
-  },
-  {
-    "id": "gs-04",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Clinical Data Manager",
-    "company": "BioNTech",
-    "location": "Mainz, Germany",
-    "description": "Manage clinical trial databases, ensure GCP compliance, write data management plans. Medidata Rave experience required. Pharma background essential."
-  },
-  {
-    "id": "gs-05",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Product Manager, Growth",
-    "company": "Personio",
-    "location": "Remote, EU",
-    "description": "Own activation and retention funnels for HR SaaS platform. Run A/B experiments, define growth metrics, work with data team. B2C growth experience preferred."
-  },
-  {
-    "id": "gs-06",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Project Manager, Cloud Migration",
-    "company": "T-Systems",
+{
+  "profile": {
+    "job_family": "TPM",
     "location": "Frankfurt, Germany",
-    "description": "Lead cloud migration projects for enterprise clients. PMP/PRINCE2 certification required. Manage budgets, timelines, vendor relationships. Some technical oversight."
+    "key_skills": ["Python", "AI/ML", "Program Management", "Cross-functional Leadership", "Cloud Infrastructure"]
   },
-  {
-    "id": "gs-07",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Developer Relations Engineer",
-    "company": "Stripe",
-    "location": "Remote, EU",
-    "description": "Create technical content, build sample apps, speak at conferences. Deep payments/fintech knowledge required. Ruby/Python proficiency."
-  },
-  {
-    "id": "gs-08",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Engineering Manager, Backend",
-    "company": "SoundCloud",
-    "location": "Berlin, Germany",
-    "description": "Lead a team of 8 backend engineers. Scala/JVM stack. Drive technical roadmap for audio processing pipeline. People management experience required."
-  },
-  {
-    "id": "gs-09",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Solutions Architect, AWS",
-    "company": "Amazon Web Services",
-    "location": "Munich, Germany",
-    "description": "Help enterprise customers design cloud architectures. Pre-sales technical support. AWS certifications required. Travel 30%."
-  },
-  {
-    "id": "gs-10",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Data Engineering Lead",
-    "company": "Zalando",
-    "location": "Berlin, Germany",
-    "description": "Lead data platform team. Build ETL pipelines with Spark/Airflow. Python/SQL proficiency. E-commerce domain experience preferred."
-  },
-  {
-    "id": "gs-11",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Technical Program Manager, Platform",
-    "company": "Datadog",
-    "location": "Remote, EU",
-    "description": "Drive cross-functional delivery for observability platform. Coordinate 4 engineering teams. Python scripting, CI/CD expertise. Technical background required."
-  },
-  {
-    "id": "gs-12",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Senior TPM, Developer Tools",
-    "company": "GitLab",
-    "location": "Remote",
-    "description": "Program-manage DevOps toolchain initiatives. Stakeholder management across product, engineering, and design. Strong technical acumen, Python/Go experience."
-  },
-  {
-    "id": "gs-13",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Product Engineer, AI Features",
-    "company": "Notion",
-    "location": "Remote, EU",
-    "description": "Build AI-powered features end-to-end. React/TypeScript frontend, Python/FastAPI backend. LLM integration experience valued. Small autonomous team."
-  },
-  {
-    "id": "gs-14",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Program Manager, ML Infrastructure",
-    "company": "DeepMind",
-    "location": "London, UK",
-    "description": "Coordinate ML infrastructure programs. Manage cross-team dependencies for training pipelines. Python proficiency, ML ecosystem familiarity."
-  },
-  {
-    "id": "gs-15",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Staff TPM, AI Platform",
-    "company": "Anthropic",
-    "location": "Remote",
-    "description": "Lead technical programs for AI safety infrastructure. Cross-functional coordination, Python, distributed systems experience. Strong written communication."
-  },
-  {
-    "id": "gs-16",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Technical Program Manager, Cloud AI",
-    "company": "Mistral AI",
-    "location": "Paris, France",
-    "description": "Drive delivery of cloud AI products. Coordinate ML and platform engineering. Python scripting, API design experience. Builder culture, small team."
-  },
-  {
-    "id": "gs-17",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Head of Technical Programs, AI",
-    "company": "Anthropic",
-    "location": "Remote, EU",
-    "description": "Lead the TPM function for AI safety and infrastructure. Build the program management discipline from scratch. Deep AI/ML familiarity, Python, distributed systems. Remote-first, mission-driven."
-  },
-  {
-    "id": "gs-18",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Principal TPM, AI Developer Platform",
-    "company": "Mistral AI",
-    "location": "Remote, EU",
-    "description": "Own the technical program for Mistral's developer platform. API design, LLM deployment, cross-functional leadership. Python/FastAPI. Founding-team energy, high autonomy."
-  },
-  {
-    "id": "gs-19",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "VP of Engineering, AI Products",
-    "company": "Linear",
-    "location": "Remote",
-    "description": "Lead engineering for AI-powered productivity tools. Build and scale engineering teams. Deep technical background in AI/ML, Python, modern web stack. Remote-first, builder culture."
-  },
-  {
-    "id": "gs-20",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Founding AI Program Lead",
-    "company": "Vercel",
-    "location": "Remote, EU",
-    "description": "First TPM hire. Define program management for AI features (v0, AI SDK). Python/TypeScript, LLM integration, developer tools background. High autonomy, startup pace."
-  }
-]
+  "jobs": [
+    {
+      "id": "gs-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior .NET Developer",
+      "company": "SAP SE",
+      "location": "Walldorf, Germany",
+      "description": "Build enterprise ERP modules in C#/.NET 8, Azure DevOps, SQL Server. 5+ years .NET required. Team of 12 backend developers. On-site only."
+    },
+    {
+      "id": "gs-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Compensation & Benefits Analyst",
+      "company": "Deel",
+      "location": "Remote, EMEA",
+      "description": "Manage global compensation benchmarking, benefits administration, and payroll compliance across 30+ countries. Excel/HRIS expertise required."
+    },
+    {
+      "id": "gs-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior iOS Developer (Swift)",
+      "company": "N26",
+      "location": "Berlin, Germany",
+      "description": "Build native iOS banking features in Swift/SwiftUI. 6+ years iOS development. Strong UIKit and Core Data experience required."
+    },
+    {
+      "id": "gs-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Clinical Data Manager",
+      "company": "BioNTech",
+      "location": "Mainz, Germany",
+      "description": "Manage clinical trial databases, ensure GCP compliance, write data management plans. Medidata Rave experience required. Pharma background essential."
+    },
+    {
+      "id": "gs-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Manager, Growth",
+      "company": "Personio",
+      "location": "Remote, EU",
+      "description": "Own activation and retention funnels for HR SaaS platform. Run A/B experiments, define growth metrics, work with data team. B2C growth experience preferred."
+    },
+    {
+      "id": "gs-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Project Manager, Cloud Migration",
+      "company": "T-Systems",
+      "location": "Frankfurt, Germany",
+      "description": "Lead cloud migration projects for enterprise clients. PMP/PRINCE2 certification required. Manage budgets, timelines, vendor relationships. Some technical oversight."
+    },
+    {
+      "id": "gs-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Developer Relations Engineer",
+      "company": "Stripe",
+      "location": "Remote, EU",
+      "description": "Create technical content, build sample apps, speak at conferences. Deep payments/fintech knowledge required. Ruby/Python proficiency."
+    },
+    {
+      "id": "gs-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Engineering Manager, Backend",
+      "company": "SoundCloud",
+      "location": "Berlin, Germany",
+      "description": "Lead a team of 8 backend engineers. Scala/JVM stack. Drive technical roadmap for audio processing pipeline. People management experience required."
+    },
+    {
+      "id": "gs-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Solutions Architect, AWS",
+      "company": "Amazon Web Services",
+      "location": "Munich, Germany",
+      "description": "Help enterprise customers design cloud architectures. Pre-sales technical support. AWS certifications required. Travel 30%."
+    },
+    {
+      "id": "gs-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Data Engineering Lead",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Lead data platform team. Build ETL pipelines with Spark/Airflow. Python/SQL proficiency. E-commerce domain experience preferred."
+    },
+    {
+      "id": "gs-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Technical Program Manager, Platform",
+      "company": "Datadog",
+      "location": "Remote, EU",
+      "description": "Drive cross-functional delivery for observability platform. Coordinate 4 engineering teams. Python scripting, CI/CD expertise. Technical background required."
+    },
+    {
+      "id": "gs-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Senior TPM, Developer Tools",
+      "company": "GitLab",
+      "location": "Remote",
+      "description": "Program-manage DevOps toolchain initiatives. Stakeholder management across product, engineering, and design. Strong technical acumen, Python/Go experience."
+    },
+    {
+      "id": "gs-13",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Engineer, AI Features",
+      "company": "Notion",
+      "location": "Remote, EU",
+      "description": "Build AI-powered features end-to-end. React/TypeScript frontend, Python/FastAPI backend. LLM integration experience valued. Small autonomous team."
+    },
+    {
+      "id": "gs-14",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Program Manager, ML Infrastructure",
+      "company": "DeepMind",
+      "location": "London, UK",
+      "description": "Coordinate ML infrastructure programs. Manage cross-team dependencies for training pipelines. Python proficiency, ML ecosystem familiarity."
+    },
+    {
+      "id": "gs-15",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Staff TPM, AI Platform",
+      "company": "Anthropic",
+      "location": "Remote",
+      "description": "Lead technical programs for AI safety infrastructure. Cross-functional coordination, Python, distributed systems experience. Strong written communication."
+    },
+    {
+      "id": "gs-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Technical Program Manager, Cloud AI",
+      "company": "Mistral AI",
+      "location": "Paris, France",
+      "description": "Drive delivery of cloud AI products. Coordinate ML and platform engineering. Python scripting, API design experience. Builder culture, small team."
+    },
+    {
+      "id": "gs-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of Technical Programs, AI",
+      "company": "Anthropic",
+      "location": "Remote, EU",
+      "description": "Lead the TPM function for AI safety and infrastructure. Build the program management discipline from scratch. Deep AI/ML familiarity, Python, distributed systems. Remote-first, mission-driven."
+    },
+    {
+      "id": "gs-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Principal TPM, AI Developer Platform",
+      "company": "Mistral AI",
+      "location": "Remote, EU",
+      "description": "Own the technical program for Mistral's developer platform. API design, LLM deployment, cross-functional leadership. Python/FastAPI. Founding-team energy, high autonomy."
+    },
+    {
+      "id": "gs-19",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "VP of Engineering, AI Products",
+      "company": "Linear",
+      "location": "Remote",
+      "description": "Lead engineering for AI-powered productivity tools. Build and scale engineering teams. Deep technical background in AI/ML, Python, modern web stack. Remote-first, builder culture."
+    },
+    {
+      "id": "gs-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Founding AI Program Lead",
+      "company": "Vercel",
+      "location": "Remote, EU",
+      "description": "First TPM hire. Define program management for AI features (v0, AI SDK). Python/TypeScript, LLM integration, developer tools background. High autonomy, startup pace."
+    }
+  ]
+}

--- a/tests/fixtures/scoring_golden_set_design.json
+++ b/tests/fixtures/scoring_golden_set_design.json
@@ -1,0 +1,189 @@
+{
+  "profile": {
+    "job_family": "UX Designer",
+    "location": "Berlin, Germany",
+    "key_skills": ["Figma", "User Research", "Prototyping", "Design Systems", "Interaction Design", "Usability Testing"]
+  },
+  "jobs": [
+    {
+      "id": "ds-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Backend Engineer, Rust",
+      "company": "Cloudflare",
+      "location": "Remote, EU",
+      "description": "Design and implement high-performance edge computing services in Rust, handling millions of requests per second across Cloudflare's global network. You will work on the Workers runtime, optimize memory allocation patterns, and contribute to open-source networking libraries. Requires 4+ years of systems programming experience in Rust or C++, deep understanding of TCP/IP and HTTP protocols, and experience with async runtimes like Tokio. No design or UX responsibilities."
+    },
+    {
+      "id": "ds-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Actuarial Analyst",
+      "company": "Munich Re",
+      "location": "Munich, Germany",
+      "description": "Build and validate actuarial models for property and casualty reinsurance portfolios using R and SAS. You will analyze loss development triangles, calculate IBNR reserves, and prepare reports for regulatory filings under Solvency II. Requires an actuarial science degree, progress toward FIA/DAV qualification, and 2+ years of experience in P&C reserving. Strong statistical skills and attention to detail are essential for this highly quantitative role."
+    },
+    {
+      "id": "ds-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Supply Chain Manager",
+      "company": "BMW",
+      "location": "Munich, Germany",
+      "description": "Manage tier-1 supplier relationships and logistics for BMW's electric vehicle battery supply chain across European manufacturing sites. You will negotiate contracts, monitor delivery performance KPIs, and coordinate with production planning to ensure just-in-time delivery. Requires 5+ years of automotive supply chain experience, SAP MM/PP proficiency, and fluent German. APICS/CPIM certification preferred. This is a procurement and logistics role with no design component."
+    },
+    {
+      "id": "ds-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "DevOps Engineer",
+      "company": "Datadog",
+      "location": "Paris, France",
+      "description": "Build and maintain CI/CD pipelines, Kubernetes clusters, and infrastructure-as-code for Datadog's SaaS platform. You will manage Terraform configurations, optimize Docker container deployments, and implement monitoring and alerting using Datadog's own products. Requires 4+ years of DevOps or SRE experience, strong Linux administration skills, and proficiency with AWS or GCP. Experience with Go or Python scripting is expected. No frontend or design work involved."
+    },
+    {
+      "id": "ds-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Graphic Designer",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Create visual assets for Zalando's brand campaigns including print advertisements, out-of-home billboards, social media graphics, and packaging design. You will work closely with the brand marketing team to maintain visual consistency across all touchpoints. Requires 3+ years of graphic design experience, expert-level Adobe Illustrator and Photoshop skills, and a strong portfolio of brand and print work. While you will use Figma for some deliverables, this is a visual/brand design role rather than product or UX design."
+    },
+    {
+      "id": "ds-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Frontend Developer",
+      "company": "N26",
+      "location": "Berlin, Germany",
+      "description": "Implement pixel-perfect UI components for N26's mobile banking web app using React and TypeScript. You will collaborate with the design team to translate Figma mockups into production code, build reusable component libraries, and ensure WCAG 2.1 accessibility compliance. Requires 4+ years of frontend development, strong CSS/HTML skills, and experience with design systems from the implementation side. While you will work closely with designers, the primary focus is on code rather than research or visual design."
+    },
+    {
+      "id": "ds-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Marketing Designer",
+      "company": "Personio",
+      "location": "Berlin, Germany",
+      "description": "Design landing pages, email templates, event collateral, and sales enablement materials for Personio's B2B marketing team. You will own the visual execution of campaign briefs, maintain the marketing asset library in Figma, and coordinate with external agencies on larger brand initiatives. Requires 3+ years of marketing or communications design experience, proficiency in Figma and Adobe Creative Suite, and an understanding of B2B SaaS marketing funnels. This role is marketing-focused rather than product UX."
+    },
+    {
+      "id": "ds-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Technical Writer",
+      "company": "JetBrains",
+      "location": "Berlin, Germany",
+      "description": "Write and maintain developer documentation for JetBrains IDEs including IntelliJ IDEA and PyCharm. You will create tutorials, API references, and migration guides, working closely with product teams to ensure accuracy. Requires 3+ years of technical writing experience, ability to read and understand code (Java, Kotlin, Python), and familiarity with docs-as-code workflows. Some UX writing and in-product help text authoring is part of the role, but the primary focus is long-form documentation."
+    },
+    {
+      "id": "ds-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Manager",
+      "company": "SoundCloud",
+      "location": "Berlin, Germany",
+      "description": "Define product strategy and roadmap for SoundCloud's creator tools, managing the full product lifecycle from discovery through launch. You will write PRDs, prioritize features based on user research and data analysis, and work closely with engineering and design teams. Requires 4+ years of product management experience in consumer tech, strong analytical skills, and experience with A/B testing frameworks. While you will partner with UX designers, this is a product management role focused on strategy and execution."
+    },
+    {
+      "id": "ds-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "UI Developer",
+      "company": "SAP",
+      "location": "Berlin, Germany",
+      "description": "Build and maintain UI components for SAP's Fiori design system using SAPUI5 and Web Components. You will implement accessibility features, write unit tests for visual regression, and ensure cross-browser compatibility across enterprise deployments. Requires 3+ years of frontend development experience, strong JavaScript/TypeScript skills, and familiarity with design system architecture. While you will work within design specifications, the role is implementation-focused with limited involvement in user research or interaction design."
+    },
+    {
+      "id": "ds-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Product Designer",
+      "company": "Figma",
+      "location": "Remote, EU",
+      "description": "Design end-to-end product experiences for Figma's collaboration features, from initial user research through high-fidelity prototypes and design system contributions. You will conduct user interviews, synthesize research findings, create interaction specifications, and partner closely with engineering to ship features used by millions of designers. Requires 4+ years of product design experience, expert Figma skills, strong prototyping abilities, and a portfolio demonstrating both visual craft and user-centered problem solving."
+    },
+    {
+      "id": "ds-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "UX Researcher",
+      "company": "Spotify",
+      "location": "Berlin, Germany",
+      "description": "Plan and conduct user research studies for Spotify's premium subscription experience, including moderated usability tests, diary studies, and large-scale surveys. You will synthesize qualitative and quantitative findings into actionable insights, present research readouts to product leadership, and maintain a research repository. Requires 3+ years of UX research experience, fluency in research methodologies (contextual inquiry, card sorting, A/B test interpretation), and experience with tools like UserTesting, Dovetail, and Optimal Workshop."
+    },
+    {
+      "id": "ds-13",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Interaction Designer",
+      "company": "Google",
+      "location": "Munich, Germany",
+      "description": "Design micro-interactions, motion patterns, and transition flows for Google Workspace products. You will create detailed interaction specifications in Figma, build prototypes using Principle and ProtoPie, and collaborate with Material Design teams to evolve the design system. Requires 4+ years of interaction design experience, deep understanding of animation principles and easing curves, and the ability to articulate design decisions through documentation. Experience designing for both desktop and mobile platforms is essential."
+    },
+    {
+      "id": "ds-14",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Design System Lead",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Lead the evolution of Zalando's cross-platform design system, defining component specifications, design tokens, and interaction patterns used by 50+ product designers and 200+ engineers. You will establish governance processes, create Figma component libraries with auto-layout and variants, and drive adoption metrics across teams. Requires 5+ years of product design experience with at least 2 years focused on design systems, expertise in Figma component architecture, and strong understanding of CSS custom properties and design token workflows."
+    },
+    {
+      "id": "ds-15",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "UX Designer",
+      "company": "Siemens Healthineers",
+      "location": "Berlin, Germany",
+      "description": "Design user interfaces for medical imaging software used by radiologists and clinicians in high-stakes diagnostic workflows. You will conduct contextual inquiries in hospital settings, create wireframes and prototypes for complex data visualization screens, and ensure compliance with IEC 62366 usability engineering standards. Requires 4+ years of UX design experience, Figma proficiency, and comfort with research-heavy design processes in regulated industries. Experience designing for complex, information-dense interfaces is strongly preferred."
+    },
+    {
+      "id": "ds-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Senior Product Designer",
+      "company": "Miro",
+      "location": "Berlin, Germany",
+      "description": "Own the design of Miro's real-time collaboration features, from discovery research through shipped product. You will run design sprints, create interactive prototypes in Figma, conduct usability testing sessions, and contribute to Miro's design system. Requires 5+ years of product design experience, strong skills in both visual design and user research, and experience designing complex multi-user interactions. Familiarity with collaboration tools and multiplayer interaction patterns is a significant plus."
+    },
+    {
+      "id": "ds-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of UX Design",
+      "company": "Linear",
+      "location": "Remote, EU",
+      "description": "Lead UX design for Linear's product suite, setting the design vision and quality bar for one of the most design-forward tools in the developer productivity space. You will manage a team of 4 designers, define research and design processes, own the design system, and work directly with the CEO and engineering leads on product direction. Requires 7+ years of product design experience, at least 2 years in a leadership role, expert Figma and prototyping skills, and a portfolio demonstrating craft-level attention to detail in complex SaaS products. Remote-first, high autonomy, and a culture that treats design as a competitive advantage."
+    },
+    {
+      "id": "ds-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Principal Designer, Design Systems",
+      "company": "Airbnb",
+      "location": "Remote, EU",
+      "description": "Define the strategic direction of Airbnb's design system infrastructure, used across web, iOS, and Android by hundreds of designers and engineers globally. You will lead the design token architecture, establish multi-brand theming capabilities, and create governance frameworks for component contribution and deprecation. Requires 8+ years of design experience with deep expertise in design systems at scale, mastery of Figma variables and component architecture, and a strong understanding of frontend implementation patterns. This is a staff-level IC role with significant organizational influence."
+    },
+    {
+      "id": "ds-19",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "VP of Design",
+      "company": "Pitch",
+      "location": "Berlin, Germany",
+      "description": "Lead the entire design function at Pitch, the Berlin-based presentation software company, owning product design, brand design, and design operations. You will build and mentor a team of 6 designers, define the product design strategy, and serve as the design voice in executive leadership. Requires 8+ years of design experience including 3+ in leadership, a portfolio of shipped consumer or prosumer products, and expertise in Figma, prototyping, and user research. This is a VP-level role with end-to-end ownership and direct report to the CEO in a design-centric company culture."
+    },
+    {
+      "id": "ds-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Staff UX Designer, AI Interfaces",
+      "company": "DeepMind",
+      "location": "London, UK",
+      "description": "Pioneer the design of user interfaces for DeepMind's AI research tools and external-facing AI products, defining interaction paradigms for LLM-powered experiences. You will conduct foundational research on how humans interact with AI systems, create novel prototyping methods for conversational and generative interfaces, and establish design patterns for responsible AI disclosure. Requires 6+ years of UX design experience, deep expertise in Figma and advanced prototyping tools, proven experience designing for emerging technology domains, and strong user research skills. A passion for AI safety and human-centered AI is essential."
+    }
+  ]
+}

--- a/tests/fixtures/scoring_golden_set_finance.json
+++ b/tests/fixtures/scoring_golden_set_finance.json
@@ -1,0 +1,189 @@
+{
+  "profile": {
+    "job_family": "Financial Analyst",
+    "location": "London, UK",
+    "key_skills": ["Financial Modeling", "Excel/VBA", "Bloomberg Terminal", "Risk Analysis", "SQL", "Python"]
+  },
+  "jobs": [
+    {
+      "id": "fs-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior Frontend Developer",
+      "company": "Shopify",
+      "location": "Remote, EMEA",
+      "description": "Build and maintain merchant-facing storefronts using React 19 and TypeScript. You will work on Shopify's Hydrogen framework, optimizing Remix-based server components for performance. Requires 5+ years of frontend development experience with strong knowledge of CSS-in-JS, GraphQL, and accessibility standards. No finance or analytics background needed."
+    },
+    {
+      "id": "fs-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Veterinary Technician",
+      "company": "Green Lane Animal Hospital",
+      "location": "London, UK",
+      "description": "Assist veterinarians with surgical procedures, administer medications, and monitor animal patients during recovery. You will handle lab work including blood draws, urinalysis, and radiographs. Requires RCVS-registered veterinary nursing qualification and at least 2 years of clinical experience. Must be comfortable handling large and small animals in a fast-paced emergency clinic environment."
+    },
+    {
+      "id": "fs-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Mechanical Engineer",
+      "company": "Siemens",
+      "location": "Munich, Germany",
+      "description": "Design and validate gas turbine components using SolidWorks and ANSYS FEA simulation. You will own the full product lifecycle from concept through manufacturing handoff, collaborating with materials science and quality teams. Requires a degree in mechanical engineering and 4+ years of experience in rotating equipment design. Familiarity with GD&T and ISO 2768 tolerancing standards is essential."
+    },
+    {
+      "id": "fs-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Social Media Manager",
+      "company": "HubSpot",
+      "location": "Remote, UK",
+      "description": "Develop and execute social media strategy across LinkedIn, Instagram, TikTok, and X. You will create content calendars, manage community engagement, and track campaign performance using HubSpot's own marketing analytics suite. Requires 3+ years of B2B social media experience and a portfolio of successful brand campaigns. Strong copywriting skills and experience with Canva or Adobe Creative Suite preferred."
+    },
+    {
+      "id": "fs-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Business Analyst",
+      "company": "Accenture",
+      "location": "London, UK",
+      "description": "Support client engagements by gathering requirements, mapping business processes, and delivering data-driven recommendations for operational improvement. You will build financial models and business cases for transformation initiatives across banking and insurance verticals. Requires 3+ years of consulting experience, advanced Excel skills, and familiarity with SQL or Tableau. Some exposure to financial analysis is expected but the primary focus is on process optimization and stakeholder management."
+    },
+    {
+      "id": "fs-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Data Analyst",
+      "company": "Spotify",
+      "location": "London, UK",
+      "description": "Analyze user behavior and content performance metrics to inform product decisions for Spotify's podcast platform. You will build dashboards in Looker, write complex SQL queries against BigQuery, and present findings to product and engineering leadership. Requires strong statistical skills, 2+ years with SQL and Python, and experience with A/B test analysis. This is a product analytics role with no direct finance or investment focus."
+    },
+    {
+      "id": "fs-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Accounting Manager",
+      "company": "Deloitte",
+      "location": "London, UK",
+      "description": "Oversee month-end close processes, manage a team of 4 staff accountants, and ensure compliance with IFRS standards for audit clients in the technology sector. You will review journal entries, prepare consolidated financial statements, and liaise with external auditors. Requires ACA/ACCA qualification and 5+ years of accounting experience. Strong knowledge of SAP and Excel required, but this is an accounting operations role rather than financial analysis or modeling."
+    },
+    {
+      "id": "fs-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Operations Analyst",
+      "company": "Amazon",
+      "location": "London, UK",
+      "description": "Drive operational efficiency improvements across Amazon's UK fulfillment network by analyzing throughput data, identifying bottlenecks, and recommending process changes. You will build weekly reports on labor productivity and cost-per-unit metrics, and present findings to site leadership. Requires SQL proficiency, experience with operational KPIs, and comfort working in a fast-paced warehouse environment. Some financial reporting exposure is helpful but the core focus is logistics and operations."
+    },
+    {
+      "id": "fs-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Compliance Officer",
+      "company": "HSBC",
+      "location": "London, UK",
+      "description": "Monitor and enforce regulatory compliance across HSBC's Global Banking and Markets division, focusing on MiFID II, MAR, and FCA conduct rules. You will conduct surveillance reviews, investigate potential breaches, and prepare regulatory filings. Requires 4+ years of compliance experience in financial services and strong knowledge of UK regulatory frameworks. While you will work closely with trading desks and finance teams, this is a regulatory and governance role rather than a financial analysis position."
+    },
+    {
+      "id": "fs-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Management Consultant",
+      "company": "McKinsey & Company",
+      "location": "London, UK",
+      "description": "Serve clients across industries on strategic and operational problems, from market entry to organizational transformation. You will build financial models for business cases, conduct market sizing exercises, and develop executive presentations. Requires an MBA or equivalent, 3+ years of professional experience, and strong analytical skills including Excel and PowerPoint. Financial modeling is a component of the work but the role spans strategy, operations, and organizational design."
+    },
+    {
+      "id": "fs-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Financial Analyst, Equity Research",
+      "company": "Goldman Sachs",
+      "location": "London, UK",
+      "description": "Build and maintain detailed financial models (DCF, comparables, sum-of-parts) for coverage of European technology companies. You will write earnings previews, publish research notes, and support the senior analyst in client presentations and marketing trips. Requires 2-4 years of equity research or investment banking experience, expert-level Excel and financial modeling skills, and CFA Level I or higher. Bloomberg Terminal proficiency and familiarity with FactSet are essential."
+    },
+    {
+      "id": "fs-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Credit Risk Analyst",
+      "company": "Deutsche Bank",
+      "location": "London, UK",
+      "description": "Assess creditworthiness of corporate and institutional clients by building probability-of-default and loss-given-default models. You will analyze financial statements, evaluate covenant structures, and prepare credit memos for the risk committee. Requires strong understanding of Basel III/IV capital requirements, 3+ years in credit risk or corporate lending, and proficiency in Excel/VBA and SQL. Experience with Moody's Analytics or S&P Capital IQ is a plus."
+    },
+    {
+      "id": "fs-13",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "FP&A Analyst",
+      "company": "Microsoft",
+      "location": "London, UK",
+      "description": "Own the budgeting, forecasting, and variance analysis processes for Microsoft's EMEA commercial sales organization. You will build rolling forecasts in Excel and Adaptive Planning, prepare monthly business reviews for senior leadership, and partner with sales operations to improve revenue predictability. Requires 3+ years of FP&A or corporate finance experience, advanced Excel/VBA skills, and familiarity with ERP systems (SAP, Oracle). SQL or Python scripting for data automation is highly valued."
+    },
+    {
+      "id": "fs-14",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Quantitative Analyst",
+      "company": "Citadel",
+      "location": "London, UK",
+      "description": "Develop and backtest quantitative trading strategies using Python, pandas, and statistical modeling techniques. You will analyze large datasets of market microstructure data, build factor models, and collaborate with portfolio managers to refine signal generation. Requires a quantitative degree (mathematics, physics, statistics, or computer science), 2+ years in a quantitative finance role, and strong programming skills in Python and SQL. Experience with time-series analysis and machine learning frameworks is preferred."
+    },
+    {
+      "id": "fs-15",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Treasury Analyst",
+      "company": "BP",
+      "location": "London, UK",
+      "description": "Manage daily cash positioning, monitor FX exposures across 30+ currencies, and execute hedging strategies using forwards and options. You will maintain cash flow forecasting models, optimize intercompany lending structures, and support the Treasury Manager in bank relationship management. Requires 3+ years of corporate treasury experience, strong Excel/VBA skills, and familiarity with treasury management systems (Kyriba or FIS). Understanding of IFRS 9 hedge accounting and commodity risk is a plus."
+    },
+    {
+      "id": "fs-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Investment Analyst",
+      "company": "BlackRock",
+      "location": "London, UK",
+      "description": "Conduct fundamental analysis of European equities for BlackRock's active funds, building detailed financial models and preparing investment recommendations for portfolio managers. You will use Bloomberg Terminal and Aladdin for portfolio analytics, monitor earnings releases, and attend company management meetings. Requires CFA Level II or higher, 3-5 years of buy-side or sell-side equity analysis experience, and expert-level financial modeling skills in Excel. Strong written communication for investment memos is essential."
+    },
+    {
+      "id": "fs-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Senior Financial Analyst, M&A",
+      "company": "Morgan Stanley",
+      "location": "London, UK",
+      "description": "Lead financial analysis for cross-border M&A transactions in the technology sector, building LBO models, accretion/dilution analyses, and discounted cash flow valuations. You will prepare pitch materials for C-suite clients, manage due diligence workstreams, and coordinate with legal and tax advisory teams. Requires 4-6 years of investment banking experience, expert-level Excel/VBA and financial modeling skills, and proven deal execution experience. CFA or MBA preferred. This role offers direct client exposure and fast-track to VP promotion."
+    },
+    {
+      "id": "fs-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "VP Financial Planning",
+      "company": "Stripe",
+      "location": "London, UK",
+      "description": "Lead the FP&A function for Stripe's EMEA business, owning the annual planning cycle, quarterly forecasting, and board-level financial reporting as the company prepares for IPO readiness. You will build and manage a team of 4 analysts, partner with product and engineering leadership on unit economics, and develop financial infrastructure using SQL, Python, and modern FP&A tools. Requires 8+ years of progressive finance experience including fintech or high-growth tech, strong leadership skills, and deep expertise in financial modeling and data-driven decision-making."
+    },
+    {
+      "id": "fs-19",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Portfolio Manager, Emerging Markets",
+      "company": "Fidelity International",
+      "location": "London, UK",
+      "description": "Manage a $2B emerging markets equity portfolio with full discretion over security selection and portfolio construction. You will conduct primary research across Asia, Latin America, and EMEA, build proprietary valuation frameworks, and present investment theses to the global CIO. Requires 10+ years of investment management experience, CFA charter, and deep expertise in emerging market economies and currencies. Bloomberg Terminal mastery, strong risk management instincts, and a documented track record of alpha generation are essential."
+    },
+    {
+      "id": "fs-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of Financial Analytics",
+      "company": "Revolut",
+      "location": "London, UK",
+      "description": "Build and lead the financial analytics function at Revolut, combining traditional finance expertise with data engineering to create real-time financial intelligence across lending, trading, and payments verticals. You will architect the financial data warehouse, develop automated reporting pipelines in Python and SQL, and deliver actionable insights directly to the CFO and executive team. Requires 7+ years in finance with strong programming skills (Python, SQL, dbt), experience at a fintech or digital bank, and the ability to translate complex financial data into strategic recommendations. CFA or CPA preferred."
+    }
+  ]
+}

--- a/tests/test_golden_set_integrity.py
+++ b/tests/test_golden_set_integrity.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURES = list(Path("tests/fixtures").glob("scoring_golden_set*.json"))
+
+
+@pytest.mark.parametrize("fixture_path", FIXTURES, ids=lambda p: p.name)
+def test_golden_set_structure(fixture_path):
+    with open(fixture_path) as f:
+        data = json.load(f)
+
+    assert "profile" in data, "Missing profile section"
+    assert "jobs" in data, "Missing jobs section"
+    assert "job_family" in data["profile"]
+    assert "location" in data["profile"]
+
+    jobs = data["jobs"]
+    assert len(jobs) >= 20
+
+    ids = [j["id"] for j in jobs]
+    assert len(ids) == len(set(ids)), "Duplicate IDs found"
+
+    valid_categories = {"reject", "mediocre", "strong", "dream"}
+    for job in jobs:
+        assert "id" in job
+        assert "category" in job and job["category"] in valid_categories
+        assert "expected_band" in job and len(job["expected_band"]) == 2
+        assert job["expected_band"][0] <= job["expected_band"][1]
+        assert "title" in job
+        assert "company" in job
+        assert "description" in job
+        assert len(job["description"]) >= 50, f"Description too short for {job['id']}"


### PR DESCRIPTION
## Summary
- Fixed 4 miscategorized TPM jobs (gs-13 strong→mediocre, gs-14 strong→dream, gs-15 strong→dream, gs-19 dream→mediocre)
- Wrapped golden set in profile-aware format (`profile.job_family`, `location`, `key_skills`)
- Added finance analyst golden set (20 jobs, London UK profile)
- Added UX designer golden set (20 jobs, Berlin DE profile)
- Updated benchmark script with `--golden-set` CLI arg and profile-aware creation
- Added golden set integrity test (validates all 3 fixtures)

**Context:** G-286 benchmark only tested TPM jobs against a TPM profile. Kestrel must work for any profession — banker, designer, lawyer. This is the test infrastructure for validating cross-family scoring.

## Test plan
- [x] Golden set integrity test passes for all 3 fixtures
- [x] Benchmark script handles both legacy and new format
- [x] All job descriptions are realistic (3-5 sentences)
- [x] No duplicate IDs across fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)