### PR TITLE
feat(G-295): expand golden set — fix miscategorizations, add finance & design sets

### DIFF
--- a/scripts/benchmark_scoring.py
+++ b/scripts/benchmark_scoring.py
@@ -10,10 +10,13 @@ Requires:
 
 Usage:
     .venv/bin/python scripts/benchmark_scoring.py
+    .venv/bin/python scripts/benchmark_scoring.py \\
+        --golden-set tests/fixtures/scoring_golden_set_finance.json
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import logging
@@ -52,43 +55,62 @@ log = logging.getLogger("benchmark")
 # Helpers
 # ---------------------------------------------------------------------------
 
-def load_golden_set() -> list[dict]:
-    with open(GOLDEN_SET_PATH) as f:
-        return json.load(f)
+
+def load_golden_set(path: Path = GOLDEN_SET_PATH) -> tuple[dict, list[dict]]:
+    with open(path) as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        # Legacy format (bare array)
+        return {}, data
+    return data.get("profile", {}), data["jobs"]
 
 
-def create_benchmark_profile(db):
-    """Create a TPM profile with skills & goals for scoring context."""
+def create_benchmark_profile(db, profile_data: dict | None = None):
+    """Create a benchmark profile with skills & goals for scoring context.
+
+    When *profile_data* is provided (from the golden set's ``profile`` section),
+    its ``job_family``, ``location``, and ``key_skills`` override the defaults.
+    """
     from career_os.models.models import Profile
-    from career_os.models.skills import Skill, Goal
+    from career_os.models.skills import Goal, Skill
+
+    job_family = (profile_data or {}).get("job_family", "TPM")
+    location = (profile_data or {}).get("location", "Frankfurt, Germany")
+    key_skills = (profile_data or {}).get("key_skills")
 
     profile = Profile(
-        name="Benchmark TPM",
+        name=f"Benchmark {job_family}",
         email="benchmark@test.local",
-        location="Frankfurt, Germany",
-        job_family="TPM",
+        location=location,
+        job_family=job_family,
     )
     db.add(profile)
     db.flush()
 
     def _skill(name, cat, prof):
         return Skill(
-            profile_id=profile.id, name=name, category=cat,
-            proficiency=prof, evidence_source="benchmark",
+            profile_id=profile.id,
+            name=name,
+            category=cat,
+            proficiency=prof,
+            evidence_source="benchmark",
         )
 
-    skills = [
-        _skill("Python", "technical", "expert"),
-        _skill("Program Management", "management", "expert"),
-        _skill("AI/ML", "technical", "advanced"),
-        _skill("Cross-functional Leadership", "management", "expert"),
-        _skill("Cloud Infrastructure", "technical", "intermediate"),
-        _skill("Stakeholder Management", "management", "expert"),
-        _skill("Agile/Scrum", "process", "expert"),
-        _skill("Technical Architecture", "technical", "advanced"),
-        _skill("Data Analysis", "technical", "advanced"),
-        _skill("Risk Management", "process", "advanced"),
-    ]
+    if key_skills:
+        skills = [_skill(s, "technical", "expert") for s in key_skills]
+    else:
+        skills = [
+            _skill("Python", "technical", "expert"),
+            _skill("Program Management", "management", "expert"),
+            _skill("AI/ML", "technical", "advanced"),
+            _skill("Cross-functional Leadership", "management", "expert"),
+            _skill("Cloud Infrastructure", "technical", "intermediate"),
+            _skill("Stakeholder Management", "management", "expert"),
+            _skill("Agile/Scrum", "process", "expert"),
+            _skill("Technical Architecture", "technical", "advanced"),
+            _skill("Data Analysis", "technical", "advanced"),
+            _skill("Risk Management", "process", "advanced"),
+        ]
     db.add_all(skills)
 
     goals = [
@@ -111,7 +133,7 @@ def create_benchmark_profile(db):
     db.commit()
     db.refresh(profile)
 
-    log.info("Created benchmark profile id=%d (TPM, Frankfurt)", profile.id)
+    log.info("Created benchmark profile id=%d (%s, %s)", profile.id, job_family, location)
     return profile
 
 
@@ -131,8 +153,12 @@ async def score_one(db, profile_id: int, job: dict) -> dict:
 
     dim_scores = {}
     for dim in [
-        "dim_technical_fit", "dim_seniority_alignment", "dim_compensation_fit",
-        "dim_location_fit", "dim_career_trajectory", "dim_company_fit",
+        "dim_technical_fit",
+        "dim_seniority_alignment",
+        "dim_compensation_fit",
+        "dim_location_fit",
+        "dim_career_trajectory",
+        "dim_company_fit",
     ]:
         dim_scores[dim] = getattr(scored, dim, None)
 
@@ -158,9 +184,7 @@ async def score_one(db, profile_id: int, job: dict) -> dict:
     }
 
 
-async def run_scoring_pass(
-    db, profile_id: int, golden_set: list[dict], label: str
-) -> list[dict]:
+async def run_scoring_pass(db, profile_id: int, golden_set: list[dict], label: str) -> list[dict]:
     """Score all golden-set jobs RUNS_PER_JOB times. Returns flat list of results."""
     results = []
     total = len(golden_set) * RUNS_PER_JOB
@@ -171,7 +195,12 @@ async def run_scoring_pass(
             done += 1
             log.info(
                 "[%s] %d/%d — %s @ %s (run %d)",
-                label, done, total, job["title"], job["company"], run,
+                label,
+                done,
+                total,
+                job["title"],
+                job["company"],
+                run,
             )
             try:
                 result = await score_one(db, profile_id, job)
@@ -185,15 +214,17 @@ async def run_scoring_pass(
                 )
             except Exception as e:
                 log.error("  ✗ FAILED: %s", e)
-                results.append({
-                    "golden_id": job["id"],
-                    "category": job["category"],
-                    "expected_band": job["expected_band"],
-                    "title": job["title"],
-                    "company": job["company"],
-                    "run": run,
-                    "error": str(e),
-                })
+                results.append(
+                    {
+                        "golden_id": job["id"],
+                        "category": job["category"],
+                        "expected_band": job["expected_band"],
+                        "title": job["title"],
+                        "company": job["company"],
+                        "run": run,
+                        "error": str(e),
+                    }
+                )
 
     return results
 
@@ -201,6 +232,7 @@ async def run_scoring_pass(
 # ---------------------------------------------------------------------------
 # Analysis
 # ---------------------------------------------------------------------------
+
 
 def analyze_pass(results: list[dict], label: str) -> dict:
     """Compute per-job and overall statistics for a scoring pass."""
@@ -219,18 +251,20 @@ def analyze_pass(results: list[dict], label: str) -> dict:
         in_band = sum(
             1 for r in runs if r["expected_band"][0] <= r["fit_score"] <= r["expected_band"][1]
         )
-        job_stats.append({
-            "golden_id": gid,
-            "category": runs[0]["category"],
-            "expected_band": runs[0]["expected_band"],
-            "title": runs[0]["title"],
-            "company": runs[0]["company"],
-            "scores": scores,
-            "mean": round(mean, 2),
-            "std": round(std, 3),
-            "in_band_count": in_band,
-            "in_band_pct": round(in_band / len(runs) * 100, 1),
-        })
+        job_stats.append(
+            {
+                "golden_id": gid,
+                "category": runs[0]["category"],
+                "expected_band": runs[0]["expected_band"],
+                "title": runs[0]["title"],
+                "company": runs[0]["company"],
+                "scores": scores,
+                "mean": round(mean, 2),
+                "std": round(std, 3),
+                "in_band_count": in_band,
+                "in_band_pct": round(in_band / len(runs) * 100, 1),
+            }
+        )
 
     # Overall stats
     all_stds = [j["std"] for j in job_stats if j["std"] > 0]
@@ -256,14 +290,22 @@ def analyze_pass(results: list[dict], label: str) -> dict:
 
     # Dimensional consistency
     dim_names = [
-        "dim_technical_fit", "dim_seniority_alignment", "dim_compensation_fit",
-        "dim_location_fit", "dim_career_trajectory", "dim_company_fit",
+        "dim_technical_fit",
+        "dim_seniority_alignment",
+        "dim_compensation_fit",
+        "dim_location_fit",
+        "dim_career_trajectory",
+        "dim_company_fit",
     ]
     dim_consistency = {}
     for dim in dim_names:
         dim_stds = []
         for gid, runs in by_job.items():
-            vals = [r["dimensional_scores"].get(dim) for r in runs if r["dimensional_scores"].get(dim) is not None]
+            vals = [
+                r["dimensional_scores"].get(dim)
+                for r in runs
+                if r["dimensional_scores"].get(dim) is not None
+            ]
             if len(vals) > 1:
                 dim_stds.append(statistics.stdev(vals))
         dim_consistency[dim] = round(statistics.mean(dim_stds), 3) if dim_stds else None
@@ -323,9 +365,9 @@ def compare_passes(baseline: dict, rubric: dict) -> dict:
 # Red flags validation
 # ---------------------------------------------------------------------------
 
+
 def validate_red_flags(rubric_results: list[dict]) -> dict:
     """Analyze red flag detection across golden set."""
-    from career_os.services.red_flags import detect_red_flags
 
     flag_counts: dict[str, int] = {}
     false_positives = []  # flags on dream/strong jobs
@@ -338,20 +380,24 @@ def validate_red_flags(rubric_results: list[dict]) -> dict:
         for f in flags:
             flag_counts[f["flag_type"]] = flag_counts.get(f["flag_type"], 0) + 1
             if r["category"] in ("strong", "dream"):
-                false_positives.append({
-                    "job": f"{r['title']} @ {r['company']}",
-                    "category": r["category"],
-                    "flag": f["flag_type"],
-                    "severity": f["severity"],
-                    "description": f["description"],
-                })
-        per_job.append({
-            "golden_id": r["golden_id"],
-            "category": r["category"],
-            "title": r["title"],
-            "n_flags": len(flags),
-            "flag_types": [f["flag_type"] for f in flags],
-        })
+                false_positives.append(
+                    {
+                        "job": f"{r['title']} @ {r['company']}",
+                        "category": r["category"],
+                        "flag": f["flag_type"],
+                        "severity": f["severity"],
+                        "description": f["description"],
+                    }
+                )
+        per_job.append(
+            {
+                "golden_id": r["golden_id"],
+                "category": r["category"],
+                "title": r["title"],
+                "n_flags": len(flags),
+                "flag_types": [f["flag_type"] for f in flags],
+            }
+        )
 
     return {
         "total_flags_triggered": sum(flag_counts.values()),
@@ -364,6 +410,7 @@ def validate_red_flags(rubric_results: list[dict]) -> dict:
 # ---------------------------------------------------------------------------
 # Dual-score spot check
 # ---------------------------------------------------------------------------
+
 
 def validate_dual_score(rubric_results: list[dict]) -> list[dict]:
     """Spot-check desire_score quadrant classifications."""
@@ -385,16 +432,18 @@ def validate_dual_score(rubric_results: list[dict]) -> list[dict]:
         else:
             quadrant = "Skip"
 
-        checks.append({
-            "golden_id": r["golden_id"],
-            "category": r["category"],
-            "title": r["title"],
-            "company": r["company"],
-            "fit_score": fit,
-            "desire_score": desire,
-            "desire_method": r.get("desire_score_method"),
-            "quadrant": quadrant,
-        })
+        checks.append(
+            {
+                "golden_id": r["golden_id"],
+                "category": r["category"],
+                "title": r["title"],
+                "company": r["company"],
+                "fit_score": fit,
+                "desire_score": desire,
+                "desire_method": r.get("desire_score_method"),
+                "quadrant": quadrant,
+            }
+        )
 
     return checks
 
@@ -402,6 +451,7 @@ def validate_dual_score(rubric_results: list[dict]) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Embedding analysis (optional — requires Ollama)
 # ---------------------------------------------------------------------------
+
 
 async def embedding_analysis(golden_set: list[dict], rubric_analysis: dict) -> dict | None:
     """Generate embeddings and compare cosine similarity vs fit_score."""
@@ -461,21 +511,25 @@ async def embedding_analysis(golden_set: list[dict], rubric_analysis: dict) -> d
         job_stats = [j for j in rubric_analysis["per_job"] if j["golden_id"] == job["id"]]
         mean_fit = job_stats[0]["mean"] if job_stats else None
 
-        results.append({
-            "golden_id": job["id"],
-            "category": job["category"],
-            "title": job["title"],
-            "company": job["company"],
-            "cosine_similarity": round(sim, 4),
-            "mean_fit_score": mean_fit,
-        })
+        results.append(
+            {
+                "golden_id": job["id"],
+                "category": job["category"],
+                "title": job["title"],
+                "company": job["company"],
+                "cosine_similarity": round(sim, 4),
+                "mean_fit_score": mean_fit,
+            }
+        )
 
     # Sort by similarity
     results.sort(key=lambda x: x["cosine_similarity"], reverse=True)
 
     # Find threshold that filters all rejects without losing strong/dream
     reject_sims = [r["cosine_similarity"] for r in results if r["category"] == "reject"]
-    strong_dream_sims = [r["cosine_similarity"] for r in results if r["category"] in ("strong", "dream")]
+    strong_dream_sims = [
+        r["cosine_similarity"] for r in results if r["category"] in ("strong", "dream")
+    ]
 
     max_reject_sim = max(reject_sims) if reject_sims else 0
     min_sd_sim = min(strong_dream_sims) if strong_dream_sims else 1
@@ -491,7 +545,8 @@ async def embedding_analysis(golden_set: list[dict], rubric_analysis: dict) -> d
         # Count what this threshold would filter
         filtered = sum(1 for r in results if r["cosine_similarity"] < suggested_threshold)
         false_negatives = sum(
-            1 for r in results
+            1
+            for r in results
             if r["cosine_similarity"] < suggested_threshold and r["category"] in ("strong", "dream")
         )
         threshold_analysis["suggested_threshold"] = suggested_threshold
@@ -509,16 +564,24 @@ async def embedding_analysis(golden_set: list[dict], rubric_analysis: dict) -> d
 # Main
 # ---------------------------------------------------------------------------
 
-async def main():
-    from career_os.database import SessionLocal
-    import career_os.services.scoring as scoring_mod
 
-    golden_set = load_golden_set()
-    log.info("Loaded %d golden-set jobs", len(golden_set))
+async def main():
+    import career_os.services.scoring as scoring_mod
+    from career_os.database import SessionLocal
+
+    parser = argparse.ArgumentParser(description="Scoring benchmark")
+    parser.add_argument(
+        "--golden-set", default=str(GOLDEN_SET_PATH), help="Path to golden set JSON"
+    )
+    args = parser.parse_args()
+    golden_set_path = Path(args.golden_set)
+
+    profile_data, golden_set = load_golden_set(golden_set_path)
+    log.info("Loaded %d golden-set jobs from %s", len(golden_set), golden_set_path)
 
     db = SessionLocal()
     try:
-        profile = create_benchmark_profile(db)
+        profile = create_benchmark_profile(db, profile_data)
         profile_id = profile.id
 
         # ── Phase 1: Baseline (no rubric) ──────────────────────────
@@ -604,10 +667,14 @@ async def main():
 
         print("\nCategory accuracy (% scores in expected band):")
         for cat, data in comparison["accuracy_comparison"].items():
-            print(f"  {cat:10s} — baseline: {data['baseline_in_band_pct']:5.1f}%  rubric: {data['rubric_in_band_pct']:5.1f}%")
+            print(
+                f"  {cat:10s} — baseline: {data['baseline_in_band_pct']:5.1f}%  rubric: {data['rubric_in_band_pct']:5.1f}%"
+            )
 
-        print(f"\nRed flags: {red_flag_report['total_flags_triggered']} total, "
-              f"{len(red_flag_report['false_positives_on_strong_dream'])} false positives on strong/dream")
+        print(
+            f"\nRed flags: {red_flag_report['total_flags_triggered']} total, "
+            f"{len(red_flag_report['false_positives_on_strong_dream'])} false positives on strong/dream"
+        )
 
         print("\nDual-score quadrants:")
         quadrant_counts: dict[str, int] = {}
@@ -619,7 +686,7 @@ async def main():
 
         if embedding_report:
             ta = embedding_report["threshold_analysis"]
-            print(f"\nEmbedding pre-filter:")
+            print("\nEmbedding pre-filter:")
             print(f"  Clean threshold exists: {ta['clean_threshold_exists']}")
             if ta.get("suggested_threshold"):
                 print(f"  Suggested threshold: {ta['suggested_threshold']}")

--- a/tests/fixtures/scoring_golden_set.json
+++ b/tests/fixtures/scoring_golden_set.json
@@ -1,182 +1,189 @@
-[
-  {
-    "id": "gs-01",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Senior .NET Developer",
-    "company": "SAP SE",
-    "location": "Walldorf, Germany",
-    "description": "Build enterprise ERP modules in C#/.NET 8, Azure DevOps, SQL Server. 5+ years .NET required. Team of 12 backend developers. On-site only."
-  },
-  {
-    "id": "gs-02",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Compensation & Benefits Analyst",
-    "company": "Deel",
-    "location": "Remote, EMEA",
-    "description": "Manage global compensation benchmarking, benefits administration, and payroll compliance across 30+ countries. Excel/HRIS expertise required."
-  },
-  {
-    "id": "gs-03",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Senior iOS Developer (Swift)",
-    "company": "N26",
-    "location": "Berlin, Germany",
-    "description": "Build native iOS banking features in Swift/SwiftUI. 6+ years iOS development. Strong UIKit and Core Data experience required."
-  },
-  {
-    "id": "gs-04",
-    "category": "reject",
-    "expected_band": [1, 3],
-    "title": "Clinical Data Manager",
-    "company": "BioNTech",
-    "location": "Mainz, Germany",
-    "description": "Manage clinical trial databases, ensure GCP compliance, write data management plans. Medidata Rave experience required. Pharma background essential."
-  },
-  {
-    "id": "gs-05",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Product Manager, Growth",
-    "company": "Personio",
-    "location": "Remote, EU",
-    "description": "Own activation and retention funnels for HR SaaS platform. Run A/B experiments, define growth metrics, work with data team. B2C growth experience preferred."
-  },
-  {
-    "id": "gs-06",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Project Manager, Cloud Migration",
-    "company": "T-Systems",
+{
+  "profile": {
+    "job_family": "TPM",
     "location": "Frankfurt, Germany",
-    "description": "Lead cloud migration projects for enterprise clients. PMP/PRINCE2 certification required. Manage budgets, timelines, vendor relationships. Some technical oversight."
+    "key_skills": ["Python", "AI/ML", "Program Management", "Cross-functional Leadership", "Cloud Infrastructure"]
   },
-  {
-    "id": "gs-07",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Developer Relations Engineer",
-    "company": "Stripe",
-    "location": "Remote, EU",
-    "description": "Create technical content, build sample apps, speak at conferences. Deep payments/fintech knowledge required. Ruby/Python proficiency."
-  },
-  {
-    "id": "gs-08",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Engineering Manager, Backend",
-    "company": "SoundCloud",
-    "location": "Berlin, Germany",
-    "description": "Lead a team of 8 backend engineers. Scala/JVM stack. Drive technical roadmap for audio processing pipeline. People management experience required."
-  },
-  {
-    "id": "gs-09",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Solutions Architect, AWS",
-    "company": "Amazon Web Services",
-    "location": "Munich, Germany",
-    "description": "Help enterprise customers design cloud architectures. Pre-sales technical support. AWS certifications required. Travel 30%."
-  },
-  {
-    "id": "gs-10",
-    "category": "mediocre",
-    "expected_band": [4, 6],
-    "title": "Data Engineering Lead",
-    "company": "Zalando",
-    "location": "Berlin, Germany",
-    "description": "Lead data platform team. Build ETL pipelines with Spark/Airflow. Python/SQL proficiency. E-commerce domain experience preferred."
-  },
-  {
-    "id": "gs-11",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Technical Program Manager, Platform",
-    "company": "Datadog",
-    "location": "Remote, EU",
-    "description": "Drive cross-functional delivery for observability platform. Coordinate 4 engineering teams. Python scripting, CI/CD expertise. Technical background required."
-  },
-  {
-    "id": "gs-12",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Senior TPM, Developer Tools",
-    "company": "GitLab",
-    "location": "Remote",
-    "description": "Program-manage DevOps toolchain initiatives. Stakeholder management across product, engineering, and design. Strong technical acumen, Python/Go experience."
-  },
-  {
-    "id": "gs-13",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Product Engineer, AI Features",
-    "company": "Notion",
-    "location": "Remote, EU",
-    "description": "Build AI-powered features end-to-end. React/TypeScript frontend, Python/FastAPI backend. LLM integration experience valued. Small autonomous team."
-  },
-  {
-    "id": "gs-14",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Program Manager, ML Infrastructure",
-    "company": "DeepMind",
-    "location": "London, UK",
-    "description": "Coordinate ML infrastructure programs. Manage cross-team dependencies for training pipelines. Python proficiency, ML ecosystem familiarity."
-  },
-  {
-    "id": "gs-15",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Staff TPM, AI Platform",
-    "company": "Anthropic",
-    "location": "Remote",
-    "description": "Lead technical programs for AI safety infrastructure. Cross-functional coordination, Python, distributed systems experience. Strong written communication."
-  },
-  {
-    "id": "gs-16",
-    "category": "strong",
-    "expected_band": [7, 8],
-    "title": "Technical Program Manager, Cloud AI",
-    "company": "Mistral AI",
-    "location": "Paris, France",
-    "description": "Drive delivery of cloud AI products. Coordinate ML and platform engineering. Python scripting, API design experience. Builder culture, small team."
-  },
-  {
-    "id": "gs-17",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Head of Technical Programs, AI",
-    "company": "Anthropic",
-    "location": "Remote, EU",
-    "description": "Lead the TPM function for AI safety and infrastructure. Build the program management discipline from scratch. Deep AI/ML familiarity, Python, distributed systems. Remote-first, mission-driven."
-  },
-  {
-    "id": "gs-18",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Principal TPM, AI Developer Platform",
-    "company": "Mistral AI",
-    "location": "Remote, EU",
-    "description": "Own the technical program for Mistral's developer platform. API design, LLM deployment, cross-functional leadership. Python/FastAPI. Founding-team energy, high autonomy."
-  },
-  {
-    "id": "gs-19",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "VP of Engineering, AI Products",
-    "company": "Linear",
-    "location": "Remote",
-    "description": "Lead engineering for AI-powered productivity tools. Build and scale engineering teams. Deep technical background in AI/ML, Python, modern web stack. Remote-first, builder culture."
-  },
-  {
-    "id": "gs-20",
-    "category": "dream",
-    "expected_band": [9, 10],
-    "title": "Founding AI Program Lead",
-    "company": "Vercel",
-    "location": "Remote, EU",
-    "description": "First TPM hire. Define program management for AI features (v0, AI SDK). Python/TypeScript, LLM integration, developer tools background. High autonomy, startup pace."
-  }
-]
+  "jobs": [
+    {
+      "id": "gs-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior .NET Developer",
+      "company": "SAP SE",
+      "location": "Walldorf, Germany",
+      "description": "Build enterprise ERP modules in C#/.NET 8, Azure DevOps, SQL Server. 5+ years .NET required. Team of 12 backend developers. On-site only."
+    },
+    {
+      "id": "gs-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Compensation & Benefits Analyst",
+      "company": "Deel",
+      "location": "Remote, EMEA",
+      "description": "Manage global compensation benchmarking, benefits administration, and payroll compliance across 30+ countries. Excel/HRIS expertise required."
+    },
+    {
+      "id": "gs-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior iOS Developer (Swift)",
+      "company": "N26",
+      "location": "Berlin, Germany",
+      "description": "Build native iOS banking features in Swift/SwiftUI. 6+ years iOS development. Strong UIKit and Core Data experience required."
+    },
+    {
+      "id": "gs-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Clinical Data Manager",
+      "company": "BioNTech",
+      "location": "Mainz, Germany",
+      "description": "Manage clinical trial databases, ensure GCP compliance, write data management plans. Medidata Rave experience required. Pharma background essential."
+    },
+    {
+      "id": "gs-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Manager, Growth",
+      "company": "Personio",
+      "location": "Remote, EU",
+      "description": "Own activation and retention funnels for HR SaaS platform. Run A/B experiments, define growth metrics, work with data team. B2C growth experience preferred."
+    },
+    {
+      "id": "gs-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Project Manager, Cloud Migration",
+      "company": "T-Systems",
+      "location": "Frankfurt, Germany",
+      "description": "Lead cloud migration projects for enterprise clients. PMP/PRINCE2 certification required. Manage budgets, timelines, vendor relationships. Some technical oversight."
+    },
+    {
+      "id": "gs-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Developer Relations Engineer",
+      "company": "Stripe",
+      "location": "Remote, EU",
+      "description": "Create technical content, build sample apps, speak at conferences. Deep payments/fintech knowledge required. Ruby/Python proficiency."
+    },
+    {
+      "id": "gs-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Engineering Manager, Backend",
+      "company": "SoundCloud",
+      "location": "Berlin, Germany",
+      "description": "Lead a team of 8 backend engineers. Scala/JVM stack. Drive technical roadmap for audio processing pipeline. People management experience required."
+    },
+    {
+      "id": "gs-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Solutions Architect, AWS",
+      "company": "Amazon Web Services",
+      "location": "Munich, Germany",
+      "description": "Help enterprise customers design cloud architectures. Pre-sales technical support. AWS certifications required. Travel 30%."
+    },
+    {
+      "id": "gs-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Data Engineering Lead",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Lead data platform team. Build ETL pipelines with Spark/Airflow. Python/SQL proficiency. E-commerce domain experience preferred."
+    },
+    {
+      "id": "gs-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Technical Program Manager, Platform",
+      "company": "Datadog",
+      "location": "Remote, EU",
+      "description": "Drive cross-functional delivery for observability platform. Coordinate 4 engineering teams. Python scripting, CI/CD expertise. Technical background required."
+    },
+    {
+      "id": "gs-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Senior TPM, Developer Tools",
+      "company": "GitLab",
+      "location": "Remote",
+      "description": "Program-manage DevOps toolchain initiatives. Stakeholder management across product, engineering, and design. Strong technical acumen, Python/Go experience."
+    },
+    {
+      "id": "gs-13",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Engineer, AI Features",
+      "company": "Notion",
+      "location": "Remote, EU",
+      "description": "Build AI-powered features end-to-end. React/TypeScript frontend, Python/FastAPI backend. LLM integration experience valued. Small autonomous team."
+    },
+    {
+      "id": "gs-14",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Program Manager, ML Infrastructure",
+      "company": "DeepMind",
+      "location": "London, UK",
+      "description": "Coordinate ML infrastructure programs. Manage cross-team dependencies for training pipelines. Python proficiency, ML ecosystem familiarity."
+    },
+    {
+      "id": "gs-15",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Staff TPM, AI Platform",
+      "company": "Anthropic",
+      "location": "Remote",
+      "description": "Lead technical programs for AI safety infrastructure. Cross-functional coordination, Python, distributed systems experience. Strong written communication."
+    },
+    {
+      "id": "gs-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Technical Program Manager, Cloud AI",
+      "company": "Mistral AI",
+      "location": "Paris, France",
+      "description": "Drive delivery of cloud AI products. Coordinate ML and platform engineering. Python scripting, API design experience. Builder culture, small team."
+    },
+    {
+      "id": "gs-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of Technical Programs, AI",
+      "company": "Anthropic",
+      "location": "Remote, EU",
+      "description": "Lead the TPM function for AI safety and infrastructure. Build the program management discipline from scratch. Deep AI/ML familiarity, Python, distributed systems. Remote-first, mission-driven."
+    },
+    {
+      "id": "gs-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Principal TPM, AI Developer Platform",
+      "company": "Mistral AI",
+      "location": "Remote, EU",
+      "description": "Own the technical program for Mistral's developer platform. API design, LLM deployment, cross-functional leadership. Python/FastAPI. Founding-team energy, high autonomy."
+    },
+    {
+      "id": "gs-19",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "VP of Engineering, AI Products",
+      "company": "Linear",
+      "location": "Remote",
+      "description": "Lead engineering for AI-powered productivity tools. Build and scale engineering teams. Deep technical background in AI/ML, Python, modern web stack. Remote-first, builder culture."
+    },
+    {
+      "id": "gs-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Founding AI Program Lead",
+      "company": "Vercel",
+      "location": "Remote, EU",
+      "description": "First TPM hire. Define program management for AI features (v0, AI SDK). Python/TypeScript, LLM integration, developer tools background. High autonomy, startup pace."
+    }
+  ]
+}

--- a/tests/fixtures/scoring_golden_set_design.json
+++ b/tests/fixtures/scoring_golden_set_design.json
@@ -1,0 +1,189 @@
+{
+  "profile": {
+    "job_family": "UX Designer",
+    "location": "Berlin, Germany",
+    "key_skills": ["Figma", "User Research", "Prototyping", "Design Systems", "Interaction Design", "Usability Testing"]
+  },
+  "jobs": [
+    {
+      "id": "ds-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Backend Engineer, Rust",
+      "company": "Cloudflare",
+      "location": "Remote, EU",
+      "description": "Design and implement high-performance edge computing services in Rust, handling millions of requests per second across Cloudflare's global network. You will work on the Workers runtime, optimize memory allocation patterns, and contribute to open-source networking libraries. Requires 4+ years of systems programming experience in Rust or C++, deep understanding of TCP/IP and HTTP protocols, and experience with async runtimes like Tokio. No design or UX responsibilities."
+    },
+    {
+      "id": "ds-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Actuarial Analyst",
+      "company": "Munich Re",
+      "location": "Munich, Germany",
+      "description": "Build and validate actuarial models for property and casualty reinsurance portfolios using R and SAS. You will analyze loss development triangles, calculate IBNR reserves, and prepare reports for regulatory filings under Solvency II. Requires an actuarial science degree, progress toward FIA/DAV qualification, and 2+ years of experience in P&C reserving. Strong statistical skills and attention to detail are essential for this highly quantitative role."
+    },
+    {
+      "id": "ds-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Supply Chain Manager",
+      "company": "BMW",
+      "location": "Munich, Germany",
+      "description": "Manage tier-1 supplier relationships and logistics for BMW's electric vehicle battery supply chain across European manufacturing sites. You will negotiate contracts, monitor delivery performance KPIs, and coordinate with production planning to ensure just-in-time delivery. Requires 5+ years of automotive supply chain experience, SAP MM/PP proficiency, and fluent German. APICS/CPIM certification preferred. This is a procurement and logistics role with no design component."
+    },
+    {
+      "id": "ds-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "DevOps Engineer",
+      "company": "Datadog",
+      "location": "Paris, France",
+      "description": "Build and maintain CI/CD pipelines, Kubernetes clusters, and infrastructure-as-code for Datadog's SaaS platform. You will manage Terraform configurations, optimize Docker container deployments, and implement monitoring and alerting using Datadog's own products. Requires 4+ years of DevOps or SRE experience, strong Linux administration skills, and proficiency with AWS or GCP. Experience with Go or Python scripting is expected. No frontend or design work involved."
+    },
+    {
+      "id": "ds-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Graphic Designer",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Create visual assets for Zalando's brand campaigns including print advertisements, out-of-home billboards, social media graphics, and packaging design. You will work closely with the brand marketing team to maintain visual consistency across all touchpoints. Requires 3+ years of graphic design experience, expert-level Adobe Illustrator and Photoshop skills, and a strong portfolio of brand and print work. While you will use Figma for some deliverables, this is a visual/brand design role rather than product or UX design."
+    },
+    {
+      "id": "ds-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Frontend Developer",
+      "company": "N26",
+      "location": "Berlin, Germany",
+      "description": "Implement pixel-perfect UI components for N26's mobile banking web app using React and TypeScript. You will collaborate with the design team to translate Figma mockups into production code, build reusable component libraries, and ensure WCAG 2.1 accessibility compliance. Requires 4+ years of frontend development, strong CSS/HTML skills, and experience with design systems from the implementation side. While you will work closely with designers, the primary focus is on code rather than research or visual design."
+    },
+    {
+      "id": "ds-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Marketing Designer",
+      "company": "Personio",
+      "location": "Berlin, Germany",
+      "description": "Design landing pages, email templates, event collateral, and sales enablement materials for Personio's B2B marketing team. You will own the visual execution of campaign briefs, maintain the marketing asset library in Figma, and coordinate with external agencies on larger brand initiatives. Requires 3+ years of marketing or communications design experience, proficiency in Figma and Adobe Creative Suite, and an understanding of B2B SaaS marketing funnels. This role is marketing-focused rather than product UX."
+    },
+    {
+      "id": "ds-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Technical Writer",
+      "company": "JetBrains",
+      "location": "Berlin, Germany",
+      "description": "Write and maintain developer documentation for JetBrains IDEs including IntelliJ IDEA and PyCharm. You will create tutorials, API references, and migration guides, working closely with product teams to ensure accuracy. Requires 3+ years of technical writing experience, ability to read and understand code (Java, Kotlin, Python), and familiarity with docs-as-code workflows. Some UX writing and in-product help text authoring is part of the role, but the primary focus is long-form documentation."
+    },
+    {
+      "id": "ds-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Product Manager",
+      "company": "SoundCloud",
+      "location": "Berlin, Germany",
+      "description": "Define product strategy and roadmap for SoundCloud's creator tools, managing the full product lifecycle from discovery through launch. You will write PRDs, prioritize features based on user research and data analysis, and work closely with engineering and design teams. Requires 4+ years of product management experience in consumer tech, strong analytical skills, and experience with A/B testing frameworks. While you will partner with UX designers, this is a product management role focused on strategy and execution."
+    },
+    {
+      "id": "ds-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "UI Developer",
+      "company": "SAP",
+      "location": "Berlin, Germany",
+      "description": "Build and maintain UI components for SAP's Fiori design system using SAPUI5 and Web Components. You will implement accessibility features, write unit tests for visual regression, and ensure cross-browser compatibility across enterprise deployments. Requires 3+ years of frontend development experience, strong JavaScript/TypeScript skills, and familiarity with design system architecture. While you will work within design specifications, the role is implementation-focused with limited involvement in user research or interaction design."
+    },
+    {
+      "id": "ds-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Product Designer",
+      "company": "Figma",
+      "location": "Remote, EU",
+      "description": "Design end-to-end product experiences for Figma's collaboration features, from initial user research through high-fidelity prototypes and design system contributions. You will conduct user interviews, synthesize research findings, create interaction specifications, and partner closely with engineering to ship features used by millions of designers. Requires 4+ years of product design experience, expert Figma skills, strong prototyping abilities, and a portfolio demonstrating both visual craft and user-centered problem solving."
+    },
+    {
+      "id": "ds-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "UX Researcher",
+      "company": "Spotify",
+      "location": "Berlin, Germany",
+      "description": "Plan and conduct user research studies for Spotify's premium subscription experience, including moderated usability tests, diary studies, and large-scale surveys. You will synthesize qualitative and quantitative findings into actionable insights, present research readouts to product leadership, and maintain a research repository. Requires 3+ years of UX research experience, fluency in research methodologies (contextual inquiry, card sorting, A/B test interpretation), and experience with tools like UserTesting, Dovetail, and Optimal Workshop."
+    },
+    {
+      "id": "ds-13",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Interaction Designer",
+      "company": "Google",
+      "location": "Munich, Germany",
+      "description": "Design micro-interactions, motion patterns, and transition flows for Google Workspace products. You will create detailed interaction specifications in Figma, build prototypes using Principle and ProtoPie, and collaborate with Material Design teams to evolve the design system. Requires 4+ years of interaction design experience, deep understanding of animation principles and easing curves, and the ability to articulate design decisions through documentation. Experience designing for both desktop and mobile platforms is essential."
+    },
+    {
+      "id": "ds-14",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Design System Lead",
+      "company": "Zalando",
+      "location": "Berlin, Germany",
+      "description": "Lead the evolution of Zalando's cross-platform design system, defining component specifications, design tokens, and interaction patterns used by 50+ product designers and 200+ engineers. You will establish governance processes, create Figma component libraries with auto-layout and variants, and drive adoption metrics across teams. Requires 5+ years of product design experience with at least 2 years focused on design systems, expertise in Figma component architecture, and strong understanding of CSS custom properties and design token workflows."
+    },
+    {
+      "id": "ds-15",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "UX Designer",
+      "company": "Siemens Healthineers",
+      "location": "Berlin, Germany",
+      "description": "Design user interfaces for medical imaging software used by radiologists and clinicians in high-stakes diagnostic workflows. You will conduct contextual inquiries in hospital settings, create wireframes and prototypes for complex data visualization screens, and ensure compliance with IEC 62366 usability engineering standards. Requires 4+ years of UX design experience, Figma proficiency, and comfort with research-heavy design processes in regulated industries. Experience designing for complex, information-dense interfaces is strongly preferred."
+    },
+    {
+      "id": "ds-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Senior Product Designer",
+      "company": "Miro",
+      "location": "Berlin, Germany",
+      "description": "Own the design of Miro's real-time collaboration features, from discovery research through shipped product. You will run design sprints, create interactive prototypes in Figma, conduct usability testing sessions, and contribute to Miro's design system. Requires 5+ years of product design experience, strong skills in both visual design and user research, and experience designing complex multi-user interactions. Familiarity with collaboration tools and multiplayer interaction patterns is a significant plus."
+    },
+    {
+      "id": "ds-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of UX Design",
+      "company": "Linear",
+      "location": "Remote, EU",
+      "description": "Lead UX design for Linear's product suite, setting the design vision and quality bar for one of the most design-forward tools in the developer productivity space. You will manage a team of 4 designers, define research and design processes, own the design system, and work directly with the CEO and engineering leads on product direction. Requires 7+ years of product design experience, at least 2 years in a leadership role, expert Figma and prototyping skills, and a portfolio demonstrating craft-level attention to detail in complex SaaS products. Remote-first, high autonomy, and a culture that treats design as a competitive advantage."
+    },
+    {
+      "id": "ds-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Principal Designer, Design Systems",
+      "company": "Airbnb",
+      "location": "Remote, EU",
+      "description": "Define the strategic direction of Airbnb's design system infrastructure, used across web, iOS, and Android by hundreds of designers and engineers globally. You will lead the design token architecture, establish multi-brand theming capabilities, and create governance frameworks for component contribution and deprecation. Requires 8+ years of design experience with deep expertise in design systems at scale, mastery of Figma variables and component architecture, and a strong understanding of frontend implementation patterns. This is a staff-level IC role with significant organizational influence."
+    },
+    {
+      "id": "ds-19",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "VP of Design",
+      "company": "Pitch",
+      "location": "Berlin, Germany",
+      "description": "Lead the entire design function at Pitch, the Berlin-based presentation software company, owning product design, brand design, and design operations. You will build and mentor a team of 6 designers, define the product design strategy, and serve as the design voice in executive leadership. Requires 8+ years of design experience including 3+ in leadership, a portfolio of shipped consumer or prosumer products, and expertise in Figma, prototyping, and user research. This is a VP-level role with end-to-end ownership and direct report to the CEO in a design-centric company culture."
+    },
+    {
+      "id": "ds-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Staff UX Designer, AI Interfaces",
+      "company": "DeepMind",
+      "location": "London, UK",
+      "description": "Pioneer the design of user interfaces for DeepMind's AI research tools and external-facing AI products, defining interaction paradigms for LLM-powered experiences. You will conduct foundational research on how humans interact with AI systems, create novel prototyping methods for conversational and generative interfaces, and establish design patterns for responsible AI disclosure. Requires 6+ years of UX design experience, deep expertise in Figma and advanced prototyping tools, proven experience designing for emerging technology domains, and strong user research skills. A passion for AI safety and human-centered AI is essential."
+    }
+  ]
+}

--- a/tests/fixtures/scoring_golden_set_finance.json
+++ b/tests/fixtures/scoring_golden_set_finance.json
@@ -1,0 +1,189 @@
+{
+  "profile": {
+    "job_family": "Financial Analyst",
+    "location": "London, UK",
+    "key_skills": ["Financial Modeling", "Excel/VBA", "Bloomberg Terminal", "Risk Analysis", "SQL", "Python"]
+  },
+  "jobs": [
+    {
+      "id": "fs-01",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Senior Frontend Developer",
+      "company": "Shopify",
+      "location": "Remote, EMEA",
+      "description": "Build and maintain merchant-facing storefronts using React 19 and TypeScript. You will work on Shopify's Hydrogen framework, optimizing Remix-based server components for performance. Requires 5+ years of frontend development experience with strong knowledge of CSS-in-JS, GraphQL, and accessibility standards. No finance or analytics background needed."
+    },
+    {
+      "id": "fs-02",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Veterinary Technician",
+      "company": "Green Lane Animal Hospital",
+      "location": "London, UK",
+      "description": "Assist veterinarians with surgical procedures, administer medications, and monitor animal patients during recovery. You will handle lab work including blood draws, urinalysis, and radiographs. Requires RCVS-registered veterinary nursing qualification and at least 2 years of clinical experience. Must be comfortable handling large and small animals in a fast-paced emergency clinic environment."
+    },
+    {
+      "id": "fs-03",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Mechanical Engineer",
+      "company": "Siemens",
+      "location": "Munich, Germany",
+      "description": "Design and validate gas turbine components using SolidWorks and ANSYS FEA simulation. You will own the full product lifecycle from concept through manufacturing handoff, collaborating with materials science and quality teams. Requires a degree in mechanical engineering and 4+ years of experience in rotating equipment design. Familiarity with GD&T and ISO 2768 tolerancing standards is essential."
+    },
+    {
+      "id": "fs-04",
+      "category": "reject",
+      "expected_band": [1, 3],
+      "title": "Social Media Manager",
+      "company": "HubSpot",
+      "location": "Remote, UK",
+      "description": "Develop and execute social media strategy across LinkedIn, Instagram, TikTok, and X. You will create content calendars, manage community engagement, and track campaign performance using HubSpot's own marketing analytics suite. Requires 3+ years of B2B social media experience and a portfolio of successful brand campaigns. Strong copywriting skills and experience with Canva or Adobe Creative Suite preferred."
+    },
+    {
+      "id": "fs-05",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Business Analyst",
+      "company": "Accenture",
+      "location": "London, UK",
+      "description": "Support client engagements by gathering requirements, mapping business processes, and delivering data-driven recommendations for operational improvement. You will build financial models and business cases for transformation initiatives across banking and insurance verticals. Requires 3+ years of consulting experience, advanced Excel skills, and familiarity with SQL or Tableau. Some exposure to financial analysis is expected but the primary focus is on process optimization and stakeholder management."
+    },
+    {
+      "id": "fs-06",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Data Analyst",
+      "company": "Spotify",
+      "location": "London, UK",
+      "description": "Analyze user behavior and content performance metrics to inform product decisions for Spotify's podcast platform. You will build dashboards in Looker, write complex SQL queries against BigQuery, and present findings to product and engineering leadership. Requires strong statistical skills, 2+ years with SQL and Python, and experience with A/B test analysis. This is a product analytics role with no direct finance or investment focus."
+    },
+    {
+      "id": "fs-07",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Accounting Manager",
+      "company": "Deloitte",
+      "location": "London, UK",
+      "description": "Oversee month-end close processes, manage a team of 4 staff accountants, and ensure compliance with IFRS standards for audit clients in the technology sector. You will review journal entries, prepare consolidated financial statements, and liaise with external auditors. Requires ACA/ACCA qualification and 5+ years of accounting experience. Strong knowledge of SAP and Excel required, but this is an accounting operations role rather than financial analysis or modeling."
+    },
+    {
+      "id": "fs-08",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Operations Analyst",
+      "company": "Amazon",
+      "location": "London, UK",
+      "description": "Drive operational efficiency improvements across Amazon's UK fulfillment network by analyzing throughput data, identifying bottlenecks, and recommending process changes. You will build weekly reports on labor productivity and cost-per-unit metrics, and present findings to site leadership. Requires SQL proficiency, experience with operational KPIs, and comfort working in a fast-paced warehouse environment. Some financial reporting exposure is helpful but the core focus is logistics and operations."
+    },
+    {
+      "id": "fs-09",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Compliance Officer",
+      "company": "HSBC",
+      "location": "London, UK",
+      "description": "Monitor and enforce regulatory compliance across HSBC's Global Banking and Markets division, focusing on MiFID II, MAR, and FCA conduct rules. You will conduct surveillance reviews, investigate potential breaches, and prepare regulatory filings. Requires 4+ years of compliance experience in financial services and strong knowledge of UK regulatory frameworks. While you will work closely with trading desks and finance teams, this is a regulatory and governance role rather than a financial analysis position."
+    },
+    {
+      "id": "fs-10",
+      "category": "mediocre",
+      "expected_band": [4, 6],
+      "title": "Management Consultant",
+      "company": "McKinsey & Company",
+      "location": "London, UK",
+      "description": "Serve clients across industries on strategic and operational problems, from market entry to organizational transformation. You will build financial models for business cases, conduct market sizing exercises, and develop executive presentations. Requires an MBA or equivalent, 3+ years of professional experience, and strong analytical skills including Excel and PowerPoint. Financial modeling is a component of the work but the role spans strategy, operations, and organizational design."
+    },
+    {
+      "id": "fs-11",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Financial Analyst, Equity Research",
+      "company": "Goldman Sachs",
+      "location": "London, UK",
+      "description": "Build and maintain detailed financial models (DCF, comparables, sum-of-parts) for coverage of European technology companies. You will write earnings previews, publish research notes, and support the senior analyst in client presentations and marketing trips. Requires 2-4 years of equity research or investment banking experience, expert-level Excel and financial modeling skills, and CFA Level I or higher. Bloomberg Terminal proficiency and familiarity with FactSet are essential."
+    },
+    {
+      "id": "fs-12",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Credit Risk Analyst",
+      "company": "Deutsche Bank",
+      "location": "London, UK",
+      "description": "Assess creditworthiness of corporate and institutional clients by building probability-of-default and loss-given-default models. You will analyze financial statements, evaluate covenant structures, and prepare credit memos for the risk committee. Requires strong understanding of Basel III/IV capital requirements, 3+ years in credit risk or corporate lending, and proficiency in Excel/VBA and SQL. Experience with Moody's Analytics or S&P Capital IQ is a plus."
+    },
+    {
+      "id": "fs-13",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "FP&A Analyst",
+      "company": "Microsoft",
+      "location": "London, UK",
+      "description": "Own the budgeting, forecasting, and variance analysis processes for Microsoft's EMEA commercial sales organization. You will build rolling forecasts in Excel and Adaptive Planning, prepare monthly business reviews for senior leadership, and partner with sales operations to improve revenue predictability. Requires 3+ years of FP&A or corporate finance experience, advanced Excel/VBA skills, and familiarity with ERP systems (SAP, Oracle). SQL or Python scripting for data automation is highly valued."
+    },
+    {
+      "id": "fs-14",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Quantitative Analyst",
+      "company": "Citadel",
+      "location": "London, UK",
+      "description": "Develop and backtest quantitative trading strategies using Python, pandas, and statistical modeling techniques. You will analyze large datasets of market microstructure data, build factor models, and collaborate with portfolio managers to refine signal generation. Requires a quantitative degree (mathematics, physics, statistics, or computer science), 2+ years in a quantitative finance role, and strong programming skills in Python and SQL. Experience with time-series analysis and machine learning frameworks is preferred."
+    },
+    {
+      "id": "fs-15",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Treasury Analyst",
+      "company": "BP",
+      "location": "London, UK",
+      "description": "Manage daily cash positioning, monitor FX exposures across 30+ currencies, and execute hedging strategies using forwards and options. You will maintain cash flow forecasting models, optimize intercompany lending structures, and support the Treasury Manager in bank relationship management. Requires 3+ years of corporate treasury experience, strong Excel/VBA skills, and familiarity with treasury management systems (Kyriba or FIS). Understanding of IFRS 9 hedge accounting and commodity risk is a plus."
+    },
+    {
+      "id": "fs-16",
+      "category": "strong",
+      "expected_band": [7, 8],
+      "title": "Investment Analyst",
+      "company": "BlackRock",
+      "location": "London, UK",
+      "description": "Conduct fundamental analysis of European equities for BlackRock's active funds, building detailed financial models and preparing investment recommendations for portfolio managers. You will use Bloomberg Terminal and Aladdin for portfolio analytics, monitor earnings releases, and attend company management meetings. Requires CFA Level II or higher, 3-5 years of buy-side or sell-side equity analysis experience, and expert-level financial modeling skills in Excel. Strong written communication for investment memos is essential."
+    },
+    {
+      "id": "fs-17",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Senior Financial Analyst, M&A",
+      "company": "Morgan Stanley",
+      "location": "London, UK",
+      "description": "Lead financial analysis for cross-border M&A transactions in the technology sector, building LBO models, accretion/dilution analyses, and discounted cash flow valuations. You will prepare pitch materials for C-suite clients, manage due diligence workstreams, and coordinate with legal and tax advisory teams. Requires 4-6 years of investment banking experience, expert-level Excel/VBA and financial modeling skills, and proven deal execution experience. CFA or MBA preferred. This role offers direct client exposure and fast-track to VP promotion."
+    },
+    {
+      "id": "fs-18",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "VP Financial Planning",
+      "company": "Stripe",
+      "location": "London, UK",
+      "description": "Lead the FP&A function for Stripe's EMEA business, owning the annual planning cycle, quarterly forecasting, and board-level financial reporting as the company prepares for IPO readiness. You will build and manage a team of 4 analysts, partner with product and engineering leadership on unit economics, and develop financial infrastructure using SQL, Python, and modern FP&A tools. Requires 8+ years of progressive finance experience including fintech or high-growth tech, strong leadership skills, and deep expertise in financial modeling and data-driven decision-making."
+    },
+    {
+      "id": "fs-19",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Portfolio Manager, Emerging Markets",
+      "company": "Fidelity International",
+      "location": "London, UK",
+      "description": "Manage a $2B emerging markets equity portfolio with full discretion over security selection and portfolio construction. You will conduct primary research across Asia, Latin America, and EMEA, build proprietary valuation frameworks, and present investment theses to the global CIO. Requires 10+ years of investment management experience, CFA charter, and deep expertise in emerging market economies and currencies. Bloomberg Terminal mastery, strong risk management instincts, and a documented track record of alpha generation are essential."
+    },
+    {
+      "id": "fs-20",
+      "category": "dream",
+      "expected_band": [9, 10],
+      "title": "Head of Financial Analytics",
+      "company": "Revolut",
+      "location": "London, UK",
+      "description": "Build and lead the financial analytics function at Revolut, combining traditional finance expertise with data engineering to create real-time financial intelligence across lending, trading, and payments verticals. You will architect the financial data warehouse, develop automated reporting pipelines in Python and SQL, and deliver actionable insights directly to the CFO and executive team. Requires 7+ years in finance with strong programming skills (Python, SQL, dbt), experience at a fintech or digital bank, and the ability to translate complex financial data into strategic recommendations. CFA or CPA preferred."
+    }
+  ]
+}

--- a/tests/test_golden_set_integrity.py
+++ b/tests/test_golden_set_integrity.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURES = list(Path("tests/fixtures").glob("scoring_golden_set*.json"))
+
+
+@pytest.mark.parametrize("fixture_path", FIXTURES, ids=lambda p: p.name)
+def test_golden_set_structure(fixture_path):
+    with open(fixture_path) as f:
+        data = json.load(f)
+
+    assert "profile" in data, "Missing profile section"
+    assert "jobs" in data, "Missing jobs section"
+    assert "job_family" in data["profile"]
+    assert "location" in data["profile"]
+
+    jobs = data["jobs"]
+    assert len(jobs) >= 20
+
+    ids = [j["id"] for j in jobs]
+    assert len(ids) == len(set(ids)), "Duplicate IDs found"
+
+    valid_categories = {"reject", "mediocre", "strong", "dream"}
+    for job in jobs:
+        assert "id" in job
+        assert "category" in job and job["category"] in valid_categories
+        assert "expected_band" in job and len(job["expected_band"]) == 2
+        assert job["expected_band"][0] <= job["expected_band"][1]
+        assert "title" in job
+        assert "company" in job
+        assert "description" in job
+        assert len(job["description"]) >= 50, f"Description too short for {job['id']}"

--- a/tests/test_scoring_rubric.py
+++ b/tests/test_scoring_rubric.py
@@ -415,7 +415,11 @@ class TestGoldenSetFixture:
         path = FIXTURES_DIR / "scoring_golden_set.json"
         assert path.exists(), f"Golden set fixture not found at {path}"
         with open(path) as f:
-            return json.load(f)
+            data = json.load(f)
+        # Support both legacy (bare array) and profile-aware (wrapper) formats
+        if isinstance(data, list):
+            return data
+        return data["jobs"]
 
     def test_golden_set_has_20_jobs(self, golden_set):
         """Golden set should have exactly 20 jobs."""
@@ -427,14 +431,14 @@ class TestGoldenSetFixture:
         assert categories == {"reject", "mediocre", "strong", "dream"}
 
     def test_golden_set_category_distribution(self, golden_set):
-        """Distribution: 4 reject, 6 mediocre, 6 strong, 4 dream."""
+        """Distribution: 4 reject, 8 mediocre, 3 strong, 5 dream (after G-295 recategorization)."""
         from collections import Counter
 
         counts = Counter(job["category"] for job in golden_set)
         assert counts["reject"] == 4
-        assert counts["mediocre"] == 6
-        assert counts["strong"] == 6
-        assert counts["dream"] == 4
+        assert counts["mediocre"] == 8
+        assert counts["strong"] == 3
+        assert counts["dream"] == 5
 
     def test_golden_set_has_required_fields(self, golden_set):
         """Every job must have id, category, expected_band, title, company, description."""


### PR DESCRIPTION
## Summary
- Fixed 4 miscategorized TPM jobs (gs-13 strong→mediocre, gs-14 strong→dream, gs-15 strong→dream, gs-19 dream→mediocre)
- Wrapped golden set in profile-aware format (`profile.job_family`, `location`, `key_skills`)
- Added finance analyst golden set (20 jobs, London UK profile)
- Added UX designer golden set (20 jobs, Berlin DE profile)
- Updated benchmark script with `--golden-set` CLI arg
- Updated TestGoldenSetFixture for new wrapper format
- Added golden set integrity test (validates all 3 fixtures)

## Test plan
- [x] Golden set integrity test passes for all 3 fixtures
- [x] TestGoldenSetFixture passes with new format and category distribution
- [x] Benchmark script handles both legacy and new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)