### PR TITLE
feat(G-350): add token usage tracking to AIResponse

### DIFF
--- a/docs/sessions/2026-04-14_scoring-evolution.md
+++ b/docs/sessions/2026-04-14_scoring-evolution.md
@@ -1,0 +1,63 @@
+---
+title: Scoring Evolution
+---
+
+# Session: Scoring Evolution — 11 Epics in 2 Days
+**Date:** 2026-04-14 to 2026-04-15
+**Branch:** main (all merged)
+**Tickets:** G-268 (master), G-269 through G-279 (11 sub-epics), G-282, G-283, G-284 (follow-ups)
+
+## What was done
+- Cleaned up 8 local + 29 remote stale branches
+- Ran 3 parallel deep research agents (competitors, academic, engineering)
+- Synthesized research into `private/research-scoring-deep-dive-2026-04-14.md`
+- Designed 11-epic roadmap across 5 phases in `docs/scoring-evolution-epics.md`
+- Created 12 Linear tickets (G-268 master + G-269 through G-279)
+- Orchestrated 11 agent executions on Mac Mini via tmux (3 sessions Day 1, 2 sessions Day 2)
+- Reviewed all 7 Day 1 branches with parallel review agents
+- Fixed G-274 calibration injection gap (agent on Mac Mini)
+- Resolved Alembic migration conflicts across 4 branches (revision chain + ID collisions)
+- Merged all 11 PRs (#177-#187) to main
+- Closed all 12 Linear tickets as Done
+- Created 3 follow-up tickets (G-282 edutainment doc, G-283 alembic consolidation, G-284 test fix)
+
+## Features shipped
+- Scoring rubric with 3 calibration examples + golden set (G-269)
+- Ghost job detection from discovery history (G-270)
+- Score percentiles and context (G-271)
+- Embedding pre-filter with Ollama shadow mode (G-272)
+- Borderline 2-pass scoring for 4.0-6.5 zone (G-273)
+- User feedback loop with calibration injection (G-274)
+- Dual-score: fit_score + desire_score with quadrant classification (G-275)
+- ESCO skill normalization with 3-pass matching (G-276)
+- WARN Act layoff red flags from public data (G-277)
+- Uncertainty ranges for sparse profiles (G-278)
+- Bayesian preference learning from feedback (G-279)
+
+## Decisions made
+- Opus for judgment-heavy epics (rubric, embeddings, dual-score, Bayesian), Sonnet for execution
+- Mac Mini + tmux + `--dangerously-skip-permissions` for agent execution
+- Option B (AI-generated) as default desire_score method, Option A (derived) as fallback
+- No sqlite-vec C extension — pure Python cosine similarity for now
+- Feedback calibration gated behind feature flag, requires ≥10 corrections
+- Shadow mode default for embedding pre-filter (log similarities, don't filter yet)
+
+## Open items
+- G-282: Edutainment doc "How Kestrel Scores"
+- G-283: Consolidate dual Alembic migration directories
+- G-284: Fix pre-existing test_md_to_pdf.py failures
+- Integration testing across all 11 features combined
+- Phase 4 session prompt for Mac Mini still in `private/agent-prompts.md`
+
+## PRs merged
+- #175: docs(G-268): scoring evolution epic specs
+- #177: feat(G-269): scoring rubric & few-shot calibration
+- #178: feat(G-270): ghost job detection
+- #179: feat(G-271): score context & percentiles
+- #180: feat(G-275): dual-score architecture
+- #181: feat(G-274): user feedback loop
+- #182: feat(G-276): ESCO skill normalization
+- #183: feat(G-277): WARN Act layoff integration
+- #184: feat(G-278): uncertainty ranges
+- #185: feat(G-279): Bayesian preference learning
+- #187: feat(G-273): borderline 2-pass scoring (includes G-272 embeddings)

--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -18,7 +18,7 @@ from career_os.ai.openrouter_provider import (
     _system_prompt_for_feature,
     _try_parse_structured,
 )
-from career_os.schemas.ai import AIFeature, AIResponse
+from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,15 @@ class AnthropicProvider(AIProvider):
             )
             model_used = data.get("model", self._model)
 
+            # Extract token usage from Anthropic response
+            usage_data = data.get("usage", {})
+            usage = TokenUsage(
+                input_tokens=usage_data.get("input_tokens", 0),
+                output_tokens=usage_data.get("output_tokens", 0),
+                cache_creation_input_tokens=usage_data.get("cache_creation_input_tokens", 0),
+                cache_read_input_tokens=usage_data.get("cache_read_input_tokens", 0),
+            )
+
             # Try to parse structured data for known features
             structured = _try_parse_structured(content, feature)
 
@@ -133,6 +142,7 @@ class AnthropicProvider(AIProvider):
                     feature=feature,
                     structured=structured,
                     model=model_used,
+                    usage=usage,
                 )
 
             # Structured parse failed — retry if we have attempts left

--- a/src/career_os/ai/cache.py
+++ b/src/career_os/ai/cache.py
@@ -136,6 +136,7 @@ class CachedProvider(AIProvider):
         cached = await asyncio.to_thread(self._get, key)
         if cached is not None:
             self._hits += 1
+            cached.usage = None  # No tokens consumed on cache hit
             return cached
 
         self._misses += 1
@@ -154,6 +155,7 @@ class CachedProvider(AIProvider):
         cached = await asyncio.to_thread(self._get, key)
         if cached is not None:
             self._hits += 1
+            cached.usage = None  # No tokens consumed on cache hit
             return cached
 
         self._misses += 1

--- a/src/career_os/ai/ollama_provider.py
+++ b/src/career_os/ai/ollama_provider.py
@@ -12,7 +12,7 @@ import httpx
 
 from career_os.ai.base import AIProvider
 from career_os.ai.openrouter_provider import _system_prompt_for_feature, _try_parse_structured
-from career_os.schemas.ai import AIFeature, AIResponse
+from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +112,15 @@ class OllamaProvider(AIProvider):
         content = data["choices"][0]["message"]["content"]
         model_used = data.get("model", self._model)
 
+        # Extract token usage from Ollama response
+        usage_data = data.get("usage", {})
+        usage = TokenUsage(
+            input_tokens=usage_data.get("prompt_tokens", 0)
+            or usage_data.get("prompt_eval_count", 0),
+            output_tokens=usage_data.get("completion_tokens", 0)
+            or usage_data.get("eval_count", 0),
+        )
+
         # Try to parse structured data for known features
         structured = _try_parse_structured(content, feature)
 
@@ -125,6 +134,7 @@ class OllamaProvider(AIProvider):
             feature=feature,
             structured=structured,
             model=model_used,
+            usage=usage,
         )
 
     async def _retry_json(

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -23,6 +23,7 @@ from career_os.schemas.ai import (
     InterviewPrepResult,
     LearningRecommendationsResult,
     ScoreResult,
+    TokenUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,13 @@ class OpenRouterProvider(AIProvider):
             content = data["choices"][0]["message"]["content"]
             model_used = data.get("model", self._model)
 
+            # Extract token usage from OpenAI-format response
+            usage_data = data.get("usage", {})
+            usage = TokenUsage(
+                input_tokens=usage_data.get("prompt_tokens", 0),
+                output_tokens=usage_data.get("completion_tokens", 0),
+            )
+
             # Try to parse structured data for known features
             structured = _try_parse_structured(content, feature)
 
@@ -137,6 +145,7 @@ class OpenRouterProvider(AIProvider):
                     feature=feature,
                     structured=structured,
                     model=model_used,
+                    usage=usage,
                 )
 
             # Structured parse failed — retry if we have attempts left

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -237,6 +237,20 @@ class InterviewPatternsResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Token usage tracking
+# ---------------------------------------------------------------------------
+
+
+class TokenUsage(BaseModel):
+    """Token usage statistics from an AI provider response."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+# ---------------------------------------------------------------------------
 # Response schemas
 # ---------------------------------------------------------------------------
 
@@ -260,3 +274,6 @@ class AIResponse(BaseModel):
         | None
     ) = Field(default=None, description="Structured response data (feature-dependent)")
     model: str | None = Field(default=None, description="Model used for generation")
+    usage: TokenUsage | None = Field(
+        default=None, description="Token usage statistics (None for cache hits)"
+    )

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,0 +1,415 @@
+"""Tests for TokenUsage tracking across all AI providers.
+
+Covers:
+- TokenUsage schema defaults and construction
+- AIResponse with usage field (optional, backwards compatible)
+- Anthropic provider extracts usage including cache tokens
+- OpenRouter provider maps prompt_tokens/completion_tokens
+- Ollama provider maps prompt_eval_count/eval_count
+- CachedProvider sets usage=None on cache hits, passes through on misses
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from career_os.ai.cache import CachedProvider
+from career_os.ai.anthropic_provider import AnthropicProvider
+from career_os.ai.ollama_provider import OllamaProvider
+from career_os.ai.openrouter_provider import OpenRouterProvider
+from career_os.ai.base import AIProvider
+from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
+
+# Fake credentials — not real.
+_TEST_KEY = "test-fake-key"  # noqa: S105
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsageSchema:
+    """Test TokenUsage Pydantic model."""
+
+    def test_defaults_are_zero(self) -> None:
+        usage = TokenUsage()
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.cache_creation_input_tokens == 0
+        assert usage.cache_read_input_tokens == 0
+
+    def test_custom_values(self) -> None:
+        usage = TokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=200,
+            cache_read_input_tokens=80,
+        )
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.cache_creation_input_tokens == 200
+        assert usage.cache_read_input_tokens == 80
+
+    def test_partial_values(self) -> None:
+        usage = TokenUsage(input_tokens=42, output_tokens=10)
+        assert usage.input_tokens == 42
+        assert usage.output_tokens == 10
+        assert usage.cache_creation_input_tokens == 0
+        assert usage.cache_read_input_tokens == 0
+
+    def test_serialization_roundtrip(self) -> None:
+        usage = TokenUsage(input_tokens=10, output_tokens=20)
+        data = usage.model_dump()
+        restored = TokenUsage.model_validate(data)
+        assert restored == usage
+
+
+# ---------------------------------------------------------------------------
+# AIResponse backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestAIResponseUsageField:
+    """Test AIResponse.usage is optional and backwards compatible."""
+
+    def test_usage_defaults_to_none(self) -> None:
+        resp = AIResponse(content="hi", provider="mock", feature=AIFeature.complete)
+        assert resp.usage is None
+
+    def test_usage_can_be_set(self) -> None:
+        usage = TokenUsage(input_tokens=10, output_tokens=5)
+        resp = AIResponse(
+            content="hi", provider="mock", feature=AIFeature.complete, usage=usage
+        )
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 10
+
+    def test_serialization_with_usage(self) -> None:
+        usage = TokenUsage(input_tokens=100, output_tokens=50)
+        resp = AIResponse(
+            content="test", provider="test", feature=AIFeature.complete, usage=usage
+        )
+        data = json.loads(resp.model_dump_json())
+        assert data["usage"]["input_tokens"] == 100
+        assert data["usage"]["output_tokens"] == 50
+
+    def test_serialization_without_usage(self) -> None:
+        resp = AIResponse(content="test", provider="test", feature=AIFeature.complete)
+        data = json.loads(resp.model_dump_json())
+        assert data["usage"] is None
+
+    def test_deserialization_without_usage_key(self) -> None:
+        """Old serialized responses without 'usage' key still deserialize."""
+        raw = {
+            "content": "hello",
+            "provider": "mock",
+            "feature": "complete",
+            "structured": None,
+            "model": None,
+        }
+        resp = AIResponse.model_validate(raw)
+        assert resp.usage is None
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider usage extraction
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicUsageExtraction:
+    """Test AnthropicProvider extracts usage from API response."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_full_usage(self) -> None:
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "content": [{"type": "text", "text": "hello"}],
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_creation_input_tokens": 200,
+                        "cache_read_input_tokens": 80,
+                    },
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 100
+        assert result.usage.output_tokens == 50
+        assert result.usage.cache_creation_input_tokens == 200
+        assert result.usage.cache_read_input_tokens == 80
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_cache_fields(self) -> None:
+        """When cache fields are absent, they default to 0."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "content": [{"type": "text", "text": "hello"}],
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 5
+        assert result.usage.cache_creation_input_tokens == 0
+        assert result.usage.cache_read_input_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_usage_block(self) -> None:
+        """When usage block is entirely absent, all fields default to 0."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "content": [{"type": "text", "text": "hello"}],
+                    "model": "claude-sonnet-4-20250514",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter provider usage extraction
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterUsageExtraction:
+    """Test OpenRouterProvider maps OpenAI-format usage fields."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_openai_format_usage(self) -> None:
+        provider = OpenRouterProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "anthropic/claude-sonnet-4",
+                    "usage": {
+                        "prompt_tokens": 75,
+                        "completion_tokens": 30,
+                        "total_tokens": 105,
+                    },
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 75
+        assert result.usage.output_tokens == 30
+        assert result.usage.cache_creation_input_tokens == 0
+        assert result.usage.cache_read_input_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_usage(self) -> None:
+        provider = OpenRouterProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "anthropic/claude-sonnet-4",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Ollama provider usage extraction
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaUsageExtraction:
+    """Test OllamaProvider maps Ollama-format usage fields."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_openai_compat_usage(self) -> None:
+        """Ollama v1 chat endpoint returns OpenAI-format usage."""
+        provider = OllamaProvider()
+        mock_resp = httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "hello"}}],
+                "model": "llama3.3",
+                "usage": {
+                    "prompt_tokens": 40,
+                    "completion_tokens": 20,
+                },
+            },
+            request=httpx.Request("POST", "http://localhost:11434/v1/chat/completions"),
+        )
+
+        with patch("career_os.ai.ollama_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 40
+        assert result.usage.output_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_extracts_native_ollama_usage(self) -> None:
+        """Ollama native format uses prompt_eval_count/eval_count."""
+        provider = OllamaProvider()
+        mock_resp = httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "hello"}}],
+                "model": "llama3.3",
+                "usage": {
+                    "prompt_eval_count": 35,
+                    "eval_count": 15,
+                },
+            },
+            request=httpx.Request("POST", "http://localhost:11434/v1/chat/completions"),
+        )
+
+        with patch("career_os.ai.ollama_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 35
+        assert result.usage.output_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_usage(self) -> None:
+        provider = OllamaProvider()
+        mock_resp = httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "hello"}}],
+                "model": "llama3.3",
+            },
+            request=httpx.Request("POST", "http://localhost:11434/v1/chat/completions"),
+        )
+
+        with patch("career_os.ai.ollama_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await provider.complete("test")
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# CachedProvider usage passthrough
+# ---------------------------------------------------------------------------
+
+
+def _make_response_with_usage(
+    content: str = "hello",
+    feature: AIFeature = AIFeature.complete,
+    usage: TokenUsage | None = None,
+) -> AIResponse:
+    return AIResponse(content=content, provider="mock", feature=feature, usage=usage)
+
+
+def _mock_provider_with_usage() -> AsyncMock:
+    provider = AsyncMock(spec=AIProvider)
+    provider.name = "mock"
+    usage = TokenUsage(input_tokens=50, output_tokens=25)
+    provider.complete.return_value = _make_response_with_usage(
+        "result", usage=usage
+    )
+    provider.score.return_value = _make_response_with_usage(
+        "score-result", AIFeature.score, usage=usage
+    )
+    return provider
+
+
+class TestCachedProviderUsage:
+    """Test CachedProvider handles usage on hits vs misses."""
+
+    @pytest.fixture()
+    def provider(self, tmp_path):
+        inner = _mock_provider_with_usage()
+        cp = CachedProvider(inner, db_path=tmp_path / "cache.db", ttl=60)
+        yield cp
+        cp.close()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_preserves_usage(self, provider):
+        """Cache miss passes through the provider's usage."""
+        resp = await provider.complete("prompt")
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 50
+        assert resp.usage.output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_clears_usage(self, provider):
+        """Cache hit sets usage to None (no tokens consumed)."""
+        await provider.complete("prompt")  # miss — populates cache
+        resp = await provider.complete("prompt")  # hit
+        assert resp.usage is None
+
+    @pytest.mark.asyncio
+    async def test_score_cache_miss_preserves_usage(self, provider):
+        resp = await provider.score("jd", {"skills": ["python"]})
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 50
+
+    @pytest.mark.asyncio
+    async def test_score_cache_hit_clears_usage(self, provider):
+        await provider.score("jd", {"skills": ["python"]})  # miss
+        resp = await provider.score("jd", {"skills": ["python"]})  # hit
+        assert resp.usage is None

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -15,11 +15,11 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from career_os.ai.cache import CachedProvider
 from career_os.ai.anthropic_provider import AnthropicProvider
+from career_os.ai.base import AIProvider
+from career_os.ai.cache import CachedProvider
 from career_os.ai.ollama_provider import OllamaProvider
 from career_os.ai.openrouter_provider import OpenRouterProvider
-from career_os.ai.base import AIProvider
 from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
 
 # Fake credentials — not real.


### PR DESCRIPTION
## Summary
- Add `TokenUsage` schema with input/output/cache_creation/cache_read token fields
- All 3 providers (Anthropic, OpenRouter, Ollama) now extract usage from API responses
- Cache hits return `usage=None` (no tokens consumed), cache misses pass through live usage
- 21 new tests covering schema, all providers, and cache behavior
- Rebased on current main, lint fix applied

## Test plan
- [x] 21 new tests pass
- [x] All existing tests still pass
- [x] Lint passes (import sort fix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)