### PR TITLE
feat(G-352): add task-based model routing with complexity tiers

### DIFF
--- a/src/career_os/ai/__init__.py
+++ b/src/career_os/ai/__init__.py
@@ -1,7 +1,7 @@
 """AI provider abstraction package."""
 
 from career_os.ai.anthropic_provider import AnthropicProvider
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
 from career_os.ai.cache import CachedProvider
 from career_os.ai.factory import UnsupportedProviderError, get_ai_provider
 from career_os.ai.mock_provider import MockProvider
@@ -13,6 +13,7 @@ __all__ = [
     "AIProvider",
     "AnthropicProvider",
     "CachedProvider",
+    "ComplexityTier",
     "CreditsExhaustedError",
     "MaskedProvider",
     "MaskMapping",

--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -12,7 +12,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -25,6 +25,13 @@ logger = logging.getLogger(__name__)
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 DEFAULT_MODEL = "claude-sonnet-4-20250514"
 ANTHROPIC_VERSION = "2023-06-01"
+
+
+_TIER_MODELS: dict[ComplexityTier, str] = {
+    ComplexityTier.SIMPLE: "claude-haiku-4-5-20251001",
+    ComplexityTier.STANDARD: "claude-sonnet-4-20250514",
+    ComplexityTier.COMPLEX: "claude-opus-4-20250514",
+}
 
 
 class AnthropicProvider(AIProvider):
@@ -46,16 +53,30 @@ class AnthropicProvider(AIProvider):
     def name(self) -> str:
         return "anthropic"
 
+    def _resolve_model(self, tier: ComplexityTier | None) -> str:
+        """Return the model to use for a request.
+
+        If the provider was constructed with an explicit model override (via env
+        var), that always wins.  Otherwise, the tier selects the model from
+        ``_TIER_MODELS``.  If tier is None, STANDARD is used.
+        """
+        if self._model != DEFAULT_MODEL:
+            return self._model
+        effective_tier = tier or ComplexityTier.STANDARD
+        return _TIER_MODELS[effective_tier]
+
     async def complete(
         self,
         prompt: str,
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         max_retries: int = 1,
         **kwargs: object,
     ) -> AIResponse:
         """Send a completion request to the Anthropic Messages API."""
+        model = self._resolve_model(tier)
         expects_structured = feature in _SCHEMA_MAP
 
         for attempt in range(1, max_retries + 2):
@@ -81,7 +102,7 @@ class AnthropicProvider(AIProvider):
                 ]
 
             payload: dict = {
-                "model": self._model,
+                "model": model,
                 "max_tokens": 4096,
                 "messages": messages,
             }
@@ -157,6 +178,8 @@ class AnthropicProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via the Anthropic API."""
@@ -181,7 +204,7 @@ class AnthropicProvider(AIProvider):
             f"Job Description:\n{job_description}\n\n"
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )
-        return await self.complete(prompt, feature=AIFeature.score)
+        return await self.complete(prompt, feature=AIFeature.score, tier=tier)
 
 
 def _extract_error_detail(response: httpx.Response) -> str:

--- a/src/career_os/ai/base.py
+++ b/src/career_os/ai/base.py
@@ -1,8 +1,25 @@
 """Abstract base class for AI providers."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from enum import StrEnum
 
 from career_os.schemas.ai import AIFeature, AIResponse
+
+
+class ComplexityTier(StrEnum):
+    """Task complexity tier for model routing.
+
+    Routes AI calls to different models based on task complexity:
+    - SIMPLE: Classification, extraction, keyword matching -> cheaper models (Haiku)
+    - STANDARD: Generation, analysis -> default models (Sonnet)
+    - COMPLEX: Deep reasoning, strategy -> most capable models (Opus)
+    """
+
+    SIMPLE = "simple"
+    STANDARD = "standard"
+    COMPLEX = "complex"
 
 
 class ProviderQuotaError(Exception):
@@ -45,6 +62,7 @@ class AIProvider(ABC):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Generate a completion for the given prompt.
@@ -53,6 +71,7 @@ class AIProvider(ABC):
             prompt: The input prompt text.
             feature: AI feature type controlling response schema.
             context: Optional context data.
+            tier: Complexity tier for model routing. None defaults to STANDARD.
             **kwargs: Provider-specific options.
 
         Returns:
@@ -65,6 +84,8 @@ class AIProvider(ABC):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile.
@@ -72,6 +93,7 @@ class AIProvider(ABC):
         Args:
             job_description: Job posting text or structured data.
             profile_data: User profile data dict.
+            tier: Complexity tier for model routing. None defaults to STANDARD.
             **kwargs: Provider-specific options.
 
         Returns:

--- a/src/career_os/ai/cache.py
+++ b/src/career_os/ai/cache.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from cryptography.fernet import Fernet, InvalidToken
 
-from career_os.ai.base import AIProvider
+from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.schemas.ai import AIFeature, AIResponse
 
 logger = logging.getLogger(__name__)
@@ -130,6 +130,7 @@ class CachedProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         key = _cache_key(feature.value, prompt, context)
@@ -139,7 +140,9 @@ class CachedProvider(AIProvider):
             return cached
 
         self._misses += 1
-        response = await self._inner.complete(prompt, feature=feature, context=context, **kwargs)
+        response = await self._inner.complete(
+            prompt, feature=feature, context=context, tier=tier, **kwargs
+        )
         await asyncio.to_thread(self._put, key, response, feature.value)
         return response
 
@@ -147,6 +150,8 @@ class CachedProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         feature = AIFeature.score
@@ -157,7 +162,7 @@ class CachedProvider(AIProvider):
             return cached
 
         self._misses += 1
-        response = await self._inner.score(job_description, profile_data, **kwargs)
+        response = await self._inner.score(job_description, profile_data, tier=tier, **kwargs)
         await asyncio.to_thread(self._put, key, response, feature.value)
         return response
 

--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -6,7 +6,7 @@ AI-dependent feature across M2-M5.
 
 import hashlib
 
-from career_os.ai.base import AIProvider
+from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.schemas.ai import (
     AIFeature,
     AIResponse,
@@ -58,9 +58,14 @@ class MockProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
-        """Return deterministic response based on feature type."""
+        """Return deterministic response based on feature type.
+
+        The tier parameter is accepted for interface compatibility but ignored
+        — the mock provider always returns the same deterministic responses.
+        """
         handler = _FEATURE_HANDLERS.get(feature, _handle_complete)
         return handler(prompt, context)
 
@@ -68,6 +73,8 @@ class MockProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Return deterministic scoring response."""

--- a/src/career_os/ai/ollama_provider.py
+++ b/src/career_os/ai/ollama_provider.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from career_os.ai.base import AIProvider
+from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.ai.openrouter_provider import _system_prompt_for_feature, _try_parse_structured
 from career_os.schemas.ai import AIFeature, AIResponse
 
@@ -73,9 +73,14 @@ class OllamaProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
-        """Send a completion request to Ollama."""
+        """Send a completion request to Ollama.
+
+        The tier parameter is accepted for interface compatibility but ignored
+        — Ollama uses a single local model for all tiers.
+        """
         messages = [{"role": "user", "content": prompt}]
 
         system_msg = _system_prompt_for_feature(feature)
@@ -198,6 +203,8 @@ class OllamaProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via Ollama."""

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -10,7 +10,7 @@ import re
 
 import httpx
 
-from career_os.ai.base import AIProvider
+from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.schemas.ai import (
     AIFeature,
     AIResponse,
@@ -54,6 +54,13 @@ def _extract_error_detail(response: httpx.Response) -> str:
         return ""
 
 
+_TIER_MODELS: dict[ComplexityTier, str] = {
+    ComplexityTier.SIMPLE: "anthropic/claude-haiku-4-5",
+    ComplexityTier.STANDARD: "anthropic/claude-sonnet-4",
+    ComplexityTier.COMPLEX: "anthropic/claude-opus-4",
+}
+
+
 class OpenRouterProvider(AIProvider):
     """AI provider backed by OpenRouter API."""
 
@@ -73,16 +80,30 @@ class OpenRouterProvider(AIProvider):
     def name(self) -> str:
         return "openrouter"
 
+    def _resolve_model(self, tier: ComplexityTier | None) -> str:
+        """Return the model to use for a request.
+
+        If the provider was constructed with an explicit model override,
+        that always wins.  Otherwise, the tier selects the model from
+        ``_TIER_MODELS``.  If tier is None, STANDARD is used.
+        """
+        if self._model != DEFAULT_MODEL:
+            return self._model
+        effective_tier = tier or ComplexityTier.STANDARD
+        return _TIER_MODELS[effective_tier]
+
     async def complete(
         self,
         prompt: str,
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         max_retries: int = 1,
         **kwargs: object,
     ) -> AIResponse:
         """Send a completion request to OpenRouter."""
+        model = self._resolve_model(tier)
         expects_structured = feature in _SCHEMA_MAP
 
         for attempt in range(1, max_retries + 2):  # 1-based, up to max_retries+1
@@ -103,7 +124,7 @@ class OpenRouterProvider(AIProvider):
                 messages.insert(0, {"role": "system", "content": system_msg})
 
             payload = {
-                "model": self._model,
+                "model": model,
                 "messages": messages,
             }
 
@@ -161,6 +182,8 @@ class OpenRouterProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via OpenRouter."""
@@ -185,7 +208,7 @@ class OpenRouterProvider(AIProvider):
             f"Job Description:\n{job_description}\n\n"
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )
-        return await self.complete(prompt, feature=AIFeature.score)
+        return await self.complete(prompt, feature=AIFeature.score, tier=tier)
 
 
 def _system_prompt_for_feature(feature: AIFeature) -> str | None:

--- a/src/career_os/ai/pii_masking.py
+++ b/src/career_os/ai/pii_masking.py
@@ -19,7 +19,7 @@ import json
 import re
 from dataclasses import dataclass, field
 
-from career_os.ai.base import AIProvider
+from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.schemas.ai import AIFeature, AIResponse
 
 # ---------------------------------------------------------------------------
@@ -152,11 +152,12 @@ class MaskedProvider(AIProvider):
         *,
         feature: AIFeature = AIFeature.complete,
         context: dict | None = None,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         masked_prompt, mapping = self._masker.mask(prompt)
         response = await self._inner.complete(
-            masked_prompt, feature=feature, context=context, **kwargs
+            masked_prompt, feature=feature, context=context, tier=tier, **kwargs
         )
         return self._unmask_response(response, mapping)
 
@@ -164,6 +165,8 @@ class MaskedProvider(AIProvider):
         self,
         job_description: str,
         profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
         **kwargs: object,
     ) -> AIResponse:
         masked_jd, jd_mapping = self._masker.mask(job_description)
@@ -177,7 +180,7 @@ class MaskedProvider(AIProvider):
         combined.placeholder_to_original.update(jd_mapping.placeholder_to_original)
         combined.placeholder_to_original.update(profile_mapping.placeholder_to_original)
 
-        response = await self._inner.score(masked_jd, masked_profile, **kwargs)
+        response = await self._inner.score(masked_jd, masked_profile, tier=tier, **kwargs)
         return self._unmask_response(response, combined)
 
     # -- helpers -------------------------------------------------------------

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -33,6 +33,56 @@ class AIFeature(StrEnum):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Feature → default complexity tier mapping
+# ---------------------------------------------------------------------------
+# Lazy import to avoid circular dependency — ComplexityTier lives in
+# career_os.ai.base which imports AIFeature from this module.  We define the
+# map as a module-level function so callers import it after both modules have
+# loaded.
+
+
+def _build_feature_tier_map() -> dict:  # noqa: UP006 — deferred type
+    """Build the AIFeature → ComplexityTier mapping.
+
+    Called lazily at first access via :func:`get_feature_tier_map` to avoid
+    circular imports between ``schemas.ai`` and ``ai.base``.
+    """
+    from career_os.ai.base import ComplexityTier
+
+    return {
+        AIFeature.score: ComplexityTier.STANDARD,
+        AIFeature.gap_analysis: ComplexityTier.STANDARD,
+        AIFeature.coaching: ComplexityTier.STANDARD,
+        AIFeature.goal_recalibration: ComplexityTier.STANDARD,
+        AIFeature.interview_prep: ComplexityTier.STANDARD,
+        AIFeature.company_research: ComplexityTier.STANDARD,
+        AIFeature.learning_recommendations: ComplexityTier.SIMPLE,
+        AIFeature.interview_format: ComplexityTier.SIMPLE,
+        AIFeature.interview_patterns: ComplexityTier.SIMPLE,
+        AIFeature.complete: ComplexityTier.STANDARD,
+        AIFeature.voice_cover_letter: ComplexityTier.STANDARD,
+        AIFeature.voice_coaching: ComplexityTier.STANDARD,
+        AIFeature.voice_job_evaluation: ComplexityTier.STANDARD,
+    }
+
+
+_FEATURE_TIER_MAP_CACHE: dict | None = None
+
+
+def get_feature_tier_map() -> dict:
+    """Return the AIFeature → ComplexityTier mapping (cached after first call)."""
+    global _FEATURE_TIER_MAP_CACHE  # noqa: PLW0603
+    if _FEATURE_TIER_MAP_CACHE is None:
+        _FEATURE_TIER_MAP_CACHE = _build_feature_tier_map()
+    return _FEATURE_TIER_MAP_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
 class AICompleteRequest(BaseModel):
     """Request body for POST /api/ai/complete."""
 

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,330 @@
+"""Tests for task-based model routing with ComplexityTier.
+
+Covers:
+- ComplexityTier enum values and membership
+- Provider model selection per tier (Anthropic, OpenRouter)
+- Default tier behaviour (None -> STANDARD)
+- Env-var model override takes precedence over tier
+- FEATURE_TIER_MAP completeness (all AIFeature members covered)
+- CachedProvider and MaskedProvider pass tier through
+- MockProvider and OllamaProvider accept tier without error
+"""
+
+import pytest
+
+from career_os.ai.base import ComplexityTier
+from career_os.ai.mock_provider import MockProvider
+from career_os.schemas.ai import AIFeature, get_feature_tier_map
+
+# ---------------------------------------------------------------------------
+# ComplexityTier enum
+# ---------------------------------------------------------------------------
+
+
+class TestComplexityTier:
+    """ComplexityTier enum basics."""
+
+    def test_values(self):
+        assert ComplexityTier.SIMPLE == "simple"
+        assert ComplexityTier.STANDARD == "standard"
+        assert ComplexityTier.COMPLEX == "complex"
+
+    def test_member_count(self):
+        assert len(ComplexityTier) == 3
+
+    def test_str_enum(self):
+        """ComplexityTier members are strings (StrEnum)."""
+        assert isinstance(ComplexityTier.SIMPLE, str)
+
+    def test_from_value(self):
+        assert ComplexityTier("simple") is ComplexityTier.SIMPLE
+        assert ComplexityTier("standard") is ComplexityTier.STANDARD
+        assert ComplexityTier("complex") is ComplexityTier.COMPLEX
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider model routing
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicProviderRouting:
+    """AnthropicProvider._resolve_model selects the right model per tier."""
+
+    def _make_provider(self, model: str | None = None):
+        from career_os.ai.anthropic_provider import DEFAULT_MODEL, AnthropicProvider
+
+        return AnthropicProvider(
+            api_key="sk-ant-test-key",
+            model=model or DEFAULT_MODEL,
+        )
+
+    def test_simple_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.SIMPLE) == "claude-haiku-4-5-20251001"
+
+    def test_standard_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.STANDARD) == "claude-sonnet-4-20250514"
+
+    def test_complex_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.COMPLEX) == "claude-opus-4-20250514"
+
+    def test_none_defaults_to_standard(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(None) == "claude-sonnet-4-20250514"
+
+    def test_env_var_override_wins(self):
+        """When an explicit model is set (not the default), tier is ignored."""
+        provider = self._make_provider(model="claude-custom-model")
+        # Even with SIMPLE tier, the custom model should be returned
+        assert provider._resolve_model(ComplexityTier.SIMPLE) == "claude-custom-model"
+        assert provider._resolve_model(ComplexityTier.COMPLEX) == "claude-custom-model"
+        assert provider._resolve_model(None) == "claude-custom-model"
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter provider model routing
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterProviderRouting:
+    """OpenRouterProvider._resolve_model selects the right model per tier."""
+
+    def _make_provider(self, model: str | None = None):
+        from career_os.ai.openrouter_provider import DEFAULT_MODEL, OpenRouterProvider
+
+        return OpenRouterProvider(
+            api_key="or-test-key",
+            model=model or DEFAULT_MODEL,
+        )
+
+    def test_simple_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.SIMPLE) == "anthropic/claude-haiku-4-5"
+
+    def test_standard_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.STANDARD) == "anthropic/claude-sonnet-4"
+
+    def test_complex_tier(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(ComplexityTier.COMPLEX) == "anthropic/claude-opus-4"
+
+    def test_none_defaults_to_standard(self):
+        provider = self._make_provider()
+        assert provider._resolve_model(None) == "anthropic/claude-sonnet-4"
+
+    def test_env_var_override_wins(self):
+        """When an explicit model is set (not the default), tier is ignored."""
+        provider = self._make_provider(model="openai/gpt-4o")
+        assert provider._resolve_model(ComplexityTier.SIMPLE) == "openai/gpt-4o"
+        assert provider._resolve_model(ComplexityTier.COMPLEX) == "openai/gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# MockProvider accepts tier without error
+# ---------------------------------------------------------------------------
+
+
+class TestMockProviderTier:
+    """MockProvider accepts the tier parameter gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_complete_with_tier(self):
+        provider = MockProvider()
+        response = await provider.complete(
+            "Hello", feature=AIFeature.complete, tier=ComplexityTier.SIMPLE
+        )
+        assert response.provider == "mock"
+
+    @pytest.mark.asyncio
+    async def test_complete_without_tier(self):
+        provider = MockProvider()
+        response = await provider.complete("Hello", feature=AIFeature.complete)
+        assert response.provider == "mock"
+
+    @pytest.mark.asyncio
+    async def test_score_with_tier(self):
+        provider = MockProvider()
+        response = await provider.score(
+            "Job description", {"skills": []}, tier=ComplexityTier.COMPLEX
+        )
+        assert response.provider == "mock"
+
+    @pytest.mark.asyncio
+    async def test_score_without_tier(self):
+        provider = MockProvider()
+        response = await provider.score("Job description", {"skills": []})
+        assert response.provider == "mock"
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider accepts tier without error
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaProviderTierSignature:
+    """OllamaProvider accepts the tier parameter in its signature."""
+
+    def test_complete_signature_accepts_tier(self):
+        """Verify OllamaProvider.complete accepts tier kwarg (no network call)."""
+        import inspect
+
+        from career_os.ai.ollama_provider import OllamaProvider
+
+        sig = inspect.signature(OllamaProvider.complete)
+        assert "tier" in sig.parameters
+
+    def test_score_signature_accepts_tier(self):
+        """Verify OllamaProvider.score accepts tier kwarg (no network call)."""
+        import inspect
+
+        from career_os.ai.ollama_provider import OllamaProvider
+
+        sig = inspect.signature(OllamaProvider.score)
+        assert "tier" in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# FEATURE_TIER_MAP completeness
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureTierMap:
+    """FEATURE_TIER_MAP covers all AIFeature members."""
+
+    def test_all_features_covered(self):
+        tier_map = get_feature_tier_map()
+        for feature in AIFeature:
+            assert feature in tier_map, f"AIFeature.{feature.name} missing from FEATURE_TIER_MAP"
+
+    def test_values_are_complexity_tiers(self):
+        tier_map = get_feature_tier_map()
+        for feature, tier in tier_map.items():
+            assert isinstance(tier, ComplexityTier), (
+                f"FEATURE_TIER_MAP[{feature}] = {tier!r} is not a ComplexityTier"
+            )
+
+    def test_simple_features(self):
+        """Certain features should be SIMPLE (cheap classification tasks)."""
+        tier_map = get_feature_tier_map()
+        simple_features = [
+            AIFeature.learning_recommendations,
+            AIFeature.interview_format,
+            AIFeature.interview_patterns,
+        ]
+        for feature in simple_features:
+            assert tier_map[feature] == ComplexityTier.SIMPLE, (
+                f"Expected AIFeature.{feature.name} to be SIMPLE"
+            )
+
+    def test_standard_features(self):
+        """Core features should default to STANDARD."""
+        tier_map = get_feature_tier_map()
+        standard_features = [
+            AIFeature.score,
+            AIFeature.gap_analysis,
+            AIFeature.coaching,
+            AIFeature.complete,
+        ]
+        for feature in standard_features:
+            assert tier_map[feature] == ComplexityTier.STANDARD, (
+                f"Expected AIFeature.{feature.name} to be STANDARD"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CachedProvider passes tier through
+# ---------------------------------------------------------------------------
+
+
+class TestCachedProviderTier:
+    """CachedProvider delegates tier to the inner provider."""
+
+    @pytest.mark.asyncio
+    async def test_complete_passes_tier(self, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from career_os.ai.cache import CachedProvider
+
+        inner = MockProvider()
+        cached = CachedProvider(inner, db_path=tmp_path / "test_cache.db")
+
+        with patch.object(inner, "complete", new_callable=AsyncMock) as mock_complete:
+            mock_complete.return_value = await MockProvider().complete("test")
+            await cached.complete("test", tier=ComplexityTier.SIMPLE)
+            mock_complete.assert_called_once()
+            _, kwargs = mock_complete.call_args
+            assert kwargs["tier"] is ComplexityTier.SIMPLE
+
+    @pytest.mark.asyncio
+    async def test_score_passes_tier(self, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from career_os.ai.cache import CachedProvider
+
+        inner = MockProvider()
+        cached = CachedProvider(inner, db_path=tmp_path / "test_cache.db")
+
+        with patch.object(inner, "score", new_callable=AsyncMock) as mock_score:
+            mock_score.return_value = await MockProvider().score("jd", {})
+            await cached.score("jd", {}, tier=ComplexityTier.COMPLEX)
+            mock_score.assert_called_once()
+            _, kwargs = mock_score.call_args
+            assert kwargs["tier"] is ComplexityTier.COMPLEX
+
+
+# ---------------------------------------------------------------------------
+# MaskedProvider passes tier through
+# ---------------------------------------------------------------------------
+
+
+class TestMaskedProviderTier:
+    """MaskedProvider delegates tier to the inner provider."""
+
+    @pytest.mark.asyncio
+    async def test_complete_passes_tier(self):
+        from unittest.mock import AsyncMock, patch
+
+        from career_os.ai.pii_masking import MaskedProvider
+
+        inner = MockProvider()
+        masked = MaskedProvider(inner)
+
+        with patch.object(inner, "complete", new_callable=AsyncMock) as mock_complete:
+            mock_complete.return_value = await MockProvider().complete("test")
+            await masked.complete("test", tier=ComplexityTier.COMPLEX)
+            mock_complete.assert_called_once()
+            _, kwargs = mock_complete.call_args
+            assert kwargs["tier"] is ComplexityTier.COMPLEX
+
+    @pytest.mark.asyncio
+    async def test_score_passes_tier(self):
+        from unittest.mock import AsyncMock, patch
+
+        from career_os.ai.pii_masking import MaskedProvider
+
+        inner = MockProvider()
+        masked = MaskedProvider(inner)
+
+        with patch.object(inner, "score", new_callable=AsyncMock) as mock_score:
+            mock_score.return_value = await MockProvider().score("jd", {})
+            await masked.score("jd", {}, tier=ComplexityTier.SIMPLE)
+            mock_score.assert_called_once()
+            _, kwargs = mock_score.call_args
+            assert kwargs["tier"] is ComplexityTier.SIMPLE
+
+
+# ---------------------------------------------------------------------------
+# Export from package __init__
+# ---------------------------------------------------------------------------
+
+
+class TestPackageExport:
+    """ComplexityTier is exported from the ai package."""
+
+    def test_import_from_package(self):
+        from career_os.ai import ComplexityTier as CT
+
+        assert CT is ComplexityTier


### PR DESCRIPTION
## Summary
- Add `ComplexityTier` enum (SIMPLE/STANDARD/COMPLEX) for routing AI calls to appropriate models based on task complexity
- SIMPLE (Haiku) for classification/extraction — 3x cheaper input/output
- STANDARD (Sonnet) for generation/analysis — default
- COMPLEX (Opus) for deep reasoning
- All 4 providers + CachedProvider + MaskedProvider support tier parameter
- `FEATURE_TIER_MAP` maps each AIFeature to its default tier
- Env var model override still takes precedence over tier routing

## Files changed
- `ai/base.py` — ComplexityTier enum, tier param on complete()/score()
- `ai/anthropic_provider.py` — tier→model routing (haiku/sonnet/opus)
- `ai/openrouter_provider.py` — same with OpenRouter model names
- `ai/ollama_provider.py`, `ai/mock_provider.py` — accept+ignore tier
- `ai/cache.py`, `ai/pii_masking.py` — pass tier through
- `schemas/ai.py` — FEATURE_TIER_MAP for all 13 features
- `ai/__init__.py` — export ComplexityTier

## Test plan
- [x] 29 new tests in test_model_routing.py
- [x] Full suite passes (2826 tests)
- [ ] Verify cost reduction in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)