### PR TITLE
feat(G-351): add Batch API support for discovery scoring sweeps

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -23,6 +23,7 @@ from career_os.schemas.ai import AIFeature, AIResponse
 logger = logging.getLogger(__name__)
 
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_BATCH_API_URL = "https://api.anthropic.com/v1/messages/batches"
 DEFAULT_MODEL = "claude-sonnet-4-20250514"
 ANTHROPIC_VERSION = "2023-06-01"
 
@@ -182,6 +183,167 @@ class AnthropicProvider(AIProvider):
             f"Profile:\n{json.dumps(profile_data, indent=2)}"
         )
         return await self.complete(prompt, feature=AIFeature.score)
+
+    async def batch_score(
+        self,
+        jobs: list[dict],
+        profile_data: dict,
+        **kwargs: object,
+    ) -> str:
+        """Submit a batch of jobs for scoring via Anthropic Batch API.
+
+        Builds one scoring request per job and POSTs to the Message Batches
+        endpoint. Each request reuses the same system prompt and scoring
+        prompt format as the real-time ``score()`` path.
+
+        Args:
+            jobs: List of dicts, each with at least 'id' and 'description' keys.
+            profile_data: User profile data dict.
+
+        Returns:
+            Batch ID string for polling results.
+        """
+        system_msg = _system_prompt_for_feature(AIFeature.score)
+        system_blocks: list[dict] | None = None
+        if system_msg:
+            system_blocks = [
+                {
+                    "type": "text",
+                    "text": system_msg,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+
+        requests: list[dict] = []
+        for job in jobs:
+            prompt = (
+                f"Score this job against the candidate profile. "
+                f"Return a JSON object with: fit_score (0-10), reasoning "
+                f"(detailed, >=100 chars), "
+                f"estimated_salary (string), effort_flag (low/medium/high), "
+                f"prep_level, prep_notes, "
+                f"readiness_score (0-100), career_alignment (0-10), "
+                f"score_breakdown (array of >=3 objects, each with: factor "
+                f"(string), contribution (positive or negative float), "
+                f"description (string)), "
+                f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
+                f"seniority_alignment, compensation_fit, location_fit, "
+                f"career_trajectory, company_fit), "
+                f"ats_keywords (array of 10-15 objects, each with: keyword "
+                f"(string), category (one of technical/soft_skill/tool/"
+                f"certification/domain), matched (boolean)), "
+                f"desire_score (0-10), desire_reasoning (string).\n\n"
+                f"Job Description:\n{job['description']}\n\n"
+                f"Profile:\n{json.dumps(profile_data, indent=2)}"
+            )
+
+            params: dict = {
+                "model": self._model,
+                "max_tokens": 4096,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+            if system_blocks:
+                params["system"] = system_blocks
+
+            requests.append(
+                {
+                    "custom_id": str(job["id"]),
+                    "params": params,
+                }
+            )
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                ANTHROPIC_BATCH_API_URL,
+                headers={
+                    "x-api-key": self._api_key,
+                    "anthropic-version": ANTHROPIC_VERSION,
+                    "Content-Type": "application/json",
+                },
+                json={"requests": requests},
+            )
+            if response.status_code in (402, 429):
+                detail = _extract_error_detail(response)
+                raise ProviderQuotaError("anthropic", response.status_code, detail)
+            response.raise_for_status()
+            data = response.json()
+
+        batch_id = data["id"]
+        logger.info("Submitted batch %s with %d scoring requests", batch_id, len(requests))
+        return batch_id
+
+    async def get_batch_results(self, batch_id: str) -> dict:
+        """Poll batch status and retrieve results when complete.
+
+        GETs the batch status from the Anthropic API. When the batch has
+        ended, fetches the JSONL results from ``results_url`` and parses
+        each line into an :class:`AIResponse`.
+
+        Returns:
+            Dict with 'status' key ('in_progress', 'ended', etc.) and
+            'results' key (list of AIResponse objects keyed by custom_id)
+            when status is 'ended'.
+        """
+        headers = {
+            "x-api-key": self._api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+        }
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.get(
+                f"{ANTHROPIC_BATCH_API_URL}/{batch_id}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        status = data.get("processing_status", "unknown")
+        if status != "ended":
+            return {"status": status, "results": {}}
+
+        results_url = data.get("results_url")
+        if not results_url:
+            return {"status": status, "results": {}}
+
+        # Fetch JSONL results
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            results_response = await client.get(results_url, headers=headers)
+            results_response.raise_for_status()
+
+        parsed_results: dict[str, AIResponse] = {}
+        for line in results_response.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            custom_id = entry.get("custom_id", "")
+            result = entry.get("result", {})
+
+            if result.get("type") != "succeeded":
+                logger.warning(
+                    "Batch result for %s was not successful: %s",
+                    custom_id,
+                    result.get("type"),
+                )
+                continue
+
+            message = result.get("message", {})
+            content_blocks = message.get("content", [])
+            content = "".join(
+                block.get("text", "") for block in content_blocks if block.get("type") == "text"
+            )
+            model_used = message.get("model", self._model)
+            structured = _try_parse_structured(content, AIFeature.score)
+
+            parsed_results[custom_id] = AIResponse(
+                content=content,
+                provider="anthropic",
+                feature=AIFeature.score,
+                structured=structured,
+                model=model_used,
+            )
+
+        logger.info("Batch %s completed: %d results parsed", batch_id, len(parsed_results))
+        return {"status": status, "results": parsed_results}
 
 
 def _extract_error_detail(response: httpx.Response) -> str:

--- a/src/career_os/ai/base.py
+++ b/src/career_os/ai/base.py
@@ -79,6 +79,41 @@ class AIProvider(ABC):
         """
         ...
 
+    async def batch_score(
+        self,
+        jobs: list[dict],
+        profile_data: dict,
+        **kwargs: object,
+    ) -> str:
+        """Submit batch scoring request. Returns batch ID.
+
+        Default implementation raises NotImplementedError. Providers that
+        support batch scoring (Anthropic) override this method.
+
+        Args:
+            jobs: List of dicts, each with at least 'id' and 'description' keys.
+            profile_data: User profile data dict.
+
+        Returns:
+            Batch ID string for polling results.
+        """
+        raise NotImplementedError(f"{self.name} provider does not support batch scoring")
+
+    async def get_batch_results(self, batch_id: str) -> dict:
+        """Get results of a batch scoring request.
+
+        Default implementation raises NotImplementedError. Providers that
+        support batch scoring (Anthropic) override this method.
+
+        Args:
+            batch_id: The batch ID returned by batch_score().
+
+        Returns:
+            Dict with 'status' key and 'results' key (list of AIResponse)
+            when status is 'ended'.
+        """
+        raise NotImplementedError(f"{self.name} provider does not support batch results")
+
     async def embed(self, text: str, **kwargs: object) -> list[float]:
         """Generate an embedding vector for the given text.
 

--- a/src/career_os/services/discovery.py
+++ b/src/career_os/services/discovery.py
@@ -20,6 +20,10 @@ from career_os.services.salary import parse_salary_range
 
 logger = logging.getLogger(__name__)
 
+# Minimum number of jobs before routing through Anthropic Batch API
+# instead of sequential real-time scoring.
+BATCH_SCORING_THRESHOLD = 10
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -214,25 +218,96 @@ def _create_discovered_job(db: Session, profile_id: int, merged: dict, key: tupl
         return None, False
 
 
+async def _try_batch_score(
+    new_jobs_list: list[DiscoveredJob],
+    profile_data: dict,
+) -> str | None:
+    """Attempt to submit jobs for batch scoring via the Anthropic Batch API.
+
+    Returns a batch ID if submission succeeded, or None if batch scoring is
+    not available or the provider does not support it.
+    """
+    from career_os.ai.factory import get_ai_provider
+
+    provider = get_ai_provider()
+    if provider.name != "anthropic":
+        return None
+
+    jobs_payload = [
+        {
+            "id": str(dj.id),
+            "description": (dj.description or f"{dj.title} at {dj.company} in {dj.location}"),
+        }
+        for dj in new_jobs_list
+    ]
+
+    try:
+        batch_id = await provider.batch_score(jobs_payload, profile_data)
+        logger.info(
+            "Submitted %d jobs for batch scoring (batch %s)",
+            len(jobs_payload),
+            batch_id,
+        )
+        return batch_id
+    except NotImplementedError:
+        return None
+    except Exception as exc:
+        logger.warning("Batch score submission failed: %s — falling back to sequential", exc)
+        return None
+
+
 async def _auto_score_and_refresh(db, profile_id, new_jobs_list, warnings):
-    """Auto-score discovered jobs and refresh market intelligence."""
+    """Auto-score discovered jobs and refresh market intelligence.
+
+    When the number of new jobs exceeds ``BATCH_SCORING_THRESHOLD`` and the
+    active AI provider is Anthropic, jobs are submitted via the Batch API
+    for 50% cost savings.  The batch ID is returned in the warnings list
+    for downstream polling.  If batch submission fails (or the provider
+    doesn't support it), falls back to sequential real-time scoring.
+    """
     if new_jobs_list:
-        try:
-            from career_os.services.scoring import batch_score_discovery
+        batch_id: str | None = None
 
-            await batch_score_discovery(
-                db,
-                profile_id,
-                discovered_job_ids=[dj.id for dj in new_jobs_list],
+        # Try batch scoring for large sweeps with Anthropic provider
+        if len(new_jobs_list) > BATCH_SCORING_THRESHOLD:
+            profile = db.query(Profile).filter(Profile.id == profile_id).first()
+            profile_data = {"name": profile.name, "location": profile.location} if profile else {}
+            batch_id = await _try_batch_score(new_jobs_list, profile_data)
+
+        if batch_id:
+            logger.info(
+                "Batch scoring submitted for %d jobs (batch %s) — results available via polling",
+                len(new_jobs_list),
+                batch_id,
             )
-            logger.info("Auto-scored %d discovered jobs", len(new_jobs_list))
+            warnings.append(
+                {
+                    "source": "batch_scoring",
+                    "batch_id": batch_id,
+                    "message": (
+                        f"Submitted {len(new_jobs_list)} jobs for batch scoring. "
+                        f"Poll batch {batch_id} for results."
+                    ),
+                }
+            )
+        else:
+            # Fall back to sequential real-time scoring
+            try:
+                from career_os.services.scoring import batch_score_discovery
 
-            propagated = propagate_discovery_scores(db, profile_id)
-            if propagated:
-                logger.info("Propagated scores to %d linked applications", propagated)
-        except Exception as exc:
-            logger.warning("Auto-scoring failed: %s", exc)
-            warnings.append({"source": "auto_scoring", "error": str(exc)})
+                await batch_score_discovery(
+                    db,
+                    profile_id,
+                    discovered_job_ids=[dj.id for dj in new_jobs_list],
+                )
+                logger.info("Auto-scored %d discovered jobs", len(new_jobs_list))
+
+                propagated = propagate_discovery_scores(db, profile_id)
+                if propagated:
+                    logger.info("Propagated scores to %d linked applications", propagated)
+            except Exception as exc:
+                logger.warning("Auto-scoring failed: %s", exc)
+                warnings.append({"source": "auto_scoring", "error": str(exc)})
 
     try:
         from career_os.services.market import refresh_market_data

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -1,0 +1,637 @@
+"""Tests for Anthropic Batch API support — batch scoring for discovery sweeps.
+
+Covers:
+- batch_score() builds correct request payload and sends to Batch API endpoint
+- batch_score() returns batch ID from response
+- get_batch_results() handles in_progress status
+- get_batch_results() parses completed results into AIResponse objects
+- Base AIProvider raises NotImplementedError for batch methods
+- Discovery service uses batch when threshold is met
+- Discovery service falls back to sequential below threshold
+- Error handling: batch submission failure falls back to sequential
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from career_os.ai.anthropic_provider import (
+    ANTHROPIC_BATCH_API_URL,
+    ANTHROPIC_VERSION,
+    AnthropicProvider,
+)
+from career_os.ai.base import AIProvider
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+from career_os.services.discovery import BATCH_SCORING_THRESHOLD
+
+# Fake credentials — not real.
+_TEST_KEY = "test-fake-anthropic-key"  # noqa: S105
+
+# Reusable test data
+_SAMPLE_JOBS = [
+    {"id": "job-1", "description": "Software Engineer at Acme Corp"},
+    {"id": "job-2", "description": "Product Manager at Widget Inc"},
+    {"id": "job-3", "description": "Data Scientist at DataCo"},
+]
+
+_SAMPLE_PROFILE = {"name": "Jane Doe", "location": "Berlin"}
+
+_SCORE_JSON = json.dumps(
+    {
+        "fit_score": 7.5,
+        "reasoning": "x" * 100,
+        "estimated_salary": "120k EUR",
+        "effort_flag": "medium",
+        "prep_level": "moderate",
+        "prep_notes": "Study distributed systems.",
+        "readiness_score": 72.0,
+        "career_alignment": 8.0,
+        "score_breakdown": [
+            {"factor": "Technical", "contribution": 2.0, "description": "Strong match"},
+            {"factor": "Culture", "contribution": 1.5, "description": "Good alignment"},
+            {"factor": "Location", "contribution": -0.5, "description": "Remote preference"},
+        ],
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock httpx response
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int, json_data: dict, headers: dict | None = None):
+    """Create a mock httpx.Response."""
+    return httpx.Response(
+        status_code,
+        json=json_data,
+        headers=headers or {},
+        request=httpx.Request("POST", ANTHROPIC_BATCH_API_URL),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider.batch_score() tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchScore:
+    """Test batch_score() builds correct payload and submits to Batch API."""
+
+    @pytest.mark.asyncio
+    async def test_builds_correct_request_payload(self) -> None:
+        """batch_score() builds one request per job with correct structure."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+        captured_payload: dict = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json or {})
+            return _mock_response(200, {"id": "batch_abc123"})
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.batch_score(_SAMPLE_JOBS, _SAMPLE_PROFILE)
+
+        assert "requests" in captured_payload
+        requests = captured_payload["requests"]
+        assert len(requests) == 3
+
+        # Check first request structure
+        req = requests[0]
+        assert req["custom_id"] == "job-1"
+        assert req["params"]["model"] == provider._model
+        assert req["params"]["max_tokens"] == 4096
+        assert len(req["params"]["messages"]) == 1
+        assert req["params"]["messages"][0]["role"] == "user"
+        assert "Software Engineer at Acme Corp" in req["params"]["messages"][0]["content"]
+        assert "Jane Doe" in req["params"]["messages"][0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_sends_to_batch_api_endpoint(self) -> None:
+        """batch_score() POSTs to the correct Batch API URL."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+        captured_url = ""
+        captured_headers: dict = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            nonlocal captured_url
+            captured_url = url
+            captured_headers.update(headers or {})
+            return _mock_response(200, {"id": "batch_xyz"})
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.batch_score(_SAMPLE_JOBS, _SAMPLE_PROFILE)
+
+        assert captured_url == ANTHROPIC_BATCH_API_URL
+        assert captured_headers["x-api-key"] == _TEST_KEY
+        assert captured_headers["anthropic-version"] == ANTHROPIC_VERSION
+
+    @pytest.mark.asyncio
+    async def test_returns_batch_id(self) -> None:
+        """batch_score() returns the batch ID from the API response."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return _mock_response(200, {"id": "batch_return_test"})
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            batch_id = await provider.batch_score(_SAMPLE_JOBS, _SAMPLE_PROFILE)
+
+        assert batch_id == "batch_return_test"
+
+    @pytest.mark.asyncio
+    async def test_includes_system_blocks_with_cache_control(self) -> None:
+        """batch_score() includes system prompt with cache_control in each request."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+        captured_payload: dict = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json or {})
+            return _mock_response(200, {"id": "batch_sys"})
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.batch_score(_SAMPLE_JOBS, _SAMPLE_PROFILE)
+
+        # Score feature has a system prompt — verify it's in params
+        req = captured_payload["requests"][0]
+        assert "system" in req["params"]
+        system_blocks = req["params"]["system"]
+        assert len(system_blocks) == 1
+        assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_402_raises_provider_quota_error(self) -> None:
+        """batch_score() raises ProviderQuotaError on HTTP 402."""
+        from career_os.ai.base import ProviderQuotaError
+
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return _mock_response(
+                402,
+                {"error": {"message": "Insufficient credits"}},
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError) as exc_info:
+                await provider.batch_score(_SAMPLE_JOBS, _SAMPLE_PROFILE)
+            assert exc_info.value.status_code == 402
+
+    @pytest.mark.asyncio
+    async def test_converts_job_ids_to_strings(self) -> None:
+        """batch_score() converts integer job IDs to strings for custom_id."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+        captured_payload: dict = {}
+
+        jobs_with_int_ids = [
+            {"id": 42, "description": "Engineer"},
+            {"id": 99, "description": "Manager"},
+        ]
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json or {})
+            return _mock_response(200, {"id": "batch_int"})
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.batch_score(jobs_with_int_ids, _SAMPLE_PROFILE)
+
+        custom_ids = [r["custom_id"] for r in captured_payload["requests"]]
+        assert custom_ids == ["42", "99"]
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider.get_batch_results() tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetBatchResults:
+    """Test get_batch_results() polling and result parsing."""
+
+    @pytest.mark.asyncio
+    async def test_in_progress_status(self) -> None:
+        """get_batch_results() returns status without results when in_progress."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        async def mock_get(url, headers=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "batch_poll",
+                    "processing_status": "in_progress",
+                    "request_counts": {"processing": 3, "succeeded": 0, "errored": 0},
+                },
+                request=httpx.Request("GET", url),
+            )
+
+        with patch("httpx.AsyncClient.get", side_effect=mock_get):
+            result = await provider.get_batch_results("batch_poll")
+
+        assert result["status"] == "in_progress"
+        assert result["results"] == {}
+
+    @pytest.mark.asyncio
+    async def test_parses_completed_results(self) -> None:
+        """get_batch_results() parses JSONL results into AIResponse objects."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        jsonl_lines = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "custom_id": "job-1",
+                        "result": {
+                            "type": "succeeded",
+                            "message": {
+                                "content": [{"type": "text", "text": _SCORE_JSON}],
+                                "model": "claude-sonnet-4-20250514",
+                            },
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "custom_id": "job-2",
+                        "result": {
+                            "type": "succeeded",
+                            "message": {
+                                "content": [{"type": "text", "text": _SCORE_JSON}],
+                                "model": "claude-sonnet-4-20250514",
+                            },
+                        },
+                    }
+                ),
+            ]
+        )
+
+        call_count = 0
+
+        async def mock_get(url, headers=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: batch status
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "batch_done",
+                        "processing_status": "ended",
+                        "results_url": "https://api.anthropic.com/results/batch_done",
+                    },
+                    request=httpx.Request("GET", url),
+                )
+            else:
+                # Second call: JSONL results
+                return httpx.Response(
+                    200,
+                    text=jsonl_lines,
+                    request=httpx.Request("GET", url),
+                )
+
+        with patch("httpx.AsyncClient.get", side_effect=mock_get):
+            result = await provider.get_batch_results("batch_done")
+
+        assert result["status"] == "ended"
+        assert len(result["results"]) == 2
+        assert "job-1" in result["results"]
+        assert "job-2" in result["results"]
+
+        # Check parsed AIResponse
+        resp = result["results"]["job-1"]
+        assert isinstance(resp, AIResponse)
+        assert resp.provider == "anthropic"
+        assert resp.feature == AIFeature.score
+        assert resp.structured is not None
+        assert isinstance(resp.structured, ScoreResult)
+        assert resp.structured.fit_score == 7.5
+
+    @pytest.mark.asyncio
+    async def test_skips_failed_results(self) -> None:
+        """get_batch_results() skips results with type != 'succeeded'."""
+        provider = AnthropicProvider(api_key=_TEST_KEY)
+
+        jsonl_lines = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "custom_id": "job-ok",
+                        "result": {
+                            "type": "succeeded",
+                            "message": {
+                                "content": [{"type": "text", "text": _SCORE_JSON}],
+                                "model": "claude-sonnet-4-20250514",
+                            },
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "custom_id": "job-fail",
+                        "result": {
+                            "type": "errored",
+                            "error": {"message": "Internal error"},
+                        },
+                    }
+                ),
+            ]
+        )
+
+        call_count = 0
+
+        async def mock_get(url, headers=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "batch_partial",
+                        "processing_status": "ended",
+                        "results_url": "https://api.anthropic.com/results/batch_partial",
+                    },
+                    request=httpx.Request("GET", url),
+                )
+            else:
+                return httpx.Response(
+                    200,
+                    text=jsonl_lines,
+                    request=httpx.Request("GET", url),
+                )
+
+        with patch("httpx.AsyncClient.get", side_effect=mock_get):
+            result = await provider.get_batch_results("batch_partial")
+
+        assert len(result["results"]) == 1
+        assert "job-ok" in result["results"]
+        assert "job-fail" not in result["results"]
+
+
+# ---------------------------------------------------------------------------
+# Base AIProvider — NotImplementedError tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaseProviderBatchMethods:
+    """Test that base AIProvider raises NotImplementedError for batch methods."""
+
+    @pytest.mark.asyncio
+    async def test_batch_score_raises_not_implemented(self) -> None:
+        """Base AIProvider.batch_score() raises NotImplementedError."""
+
+        class MinimalProvider(AIProvider):
+            @property
+            def name(self) -> str:
+                return "minimal"
+
+            async def complete(self, prompt, *, feature=AIFeature.complete, **kwargs):
+                return AIResponse(content="ok", provider="minimal", feature=feature)
+
+            async def score(self, job_description, profile_data, **kwargs):
+                return AIResponse(content="ok", provider="minimal", feature=AIFeature.score)
+
+        provider = MinimalProvider()
+        with pytest.raises(NotImplementedError, match="minimal.*batch scoring"):
+            await provider.batch_score([], {})
+
+    @pytest.mark.asyncio
+    async def test_get_batch_results_raises_not_implemented(self) -> None:
+        """Base AIProvider.get_batch_results() raises NotImplementedError."""
+
+        class MinimalProvider(AIProvider):
+            @property
+            def name(self) -> str:
+                return "minimal"
+
+            async def complete(self, prompt, *, feature=AIFeature.complete, **kwargs):
+                return AIResponse(content="ok", provider="minimal", feature=feature)
+
+            async def score(self, job_description, profile_data, **kwargs):
+                return AIResponse(content="ok", provider="minimal", feature=AIFeature.score)
+
+        provider = MinimalProvider()
+        with pytest.raises(NotImplementedError, match="minimal.*batch results"):
+            await provider.get_batch_results("batch_123")
+
+
+# ---------------------------------------------------------------------------
+# Discovery service — batch vs sequential routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryBatchRouting:
+    """Test that discovery service routes to batch or sequential scoring."""
+
+    @pytest.mark.asyncio
+    async def test_batch_used_above_threshold(self) -> None:
+        """_try_batch_score() is called when job count exceeds threshold."""
+        from career_os.services.discovery import _try_batch_score
+
+        # Create mock discovered jobs above threshold
+        mock_jobs = []
+        for i in range(BATCH_SCORING_THRESHOLD + 5):
+            job = MagicMock()
+            job.id = i
+            job.title = f"Job {i}"
+            job.company = f"Company {i}"
+            job.location = "Berlin"
+            job.description = f"Description for job {i}"
+            mock_jobs.append(job)
+
+        mock_provider = MagicMock()
+        mock_provider.name = "anthropic"
+        mock_provider.batch_score = AsyncMock(return_value="batch_threshold_test")
+
+        with patch(
+            "career_os.ai.factory.get_ai_provider",
+            return_value=mock_provider,
+        ):
+            batch_id = await _try_batch_score(mock_jobs, _SAMPLE_PROFILE)
+
+        assert batch_id == "batch_threshold_test"
+        mock_provider.batch_score.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_batch_skipped_for_non_anthropic_provider(self) -> None:
+        """_try_batch_score() returns None for non-Anthropic providers."""
+        from career_os.services.discovery import _try_batch_score
+
+        mock_jobs = [MagicMock() for _ in range(20)]
+
+        mock_provider = MagicMock()
+        mock_provider.name = "openrouter"
+
+        with patch(
+            "career_os.ai.factory.get_ai_provider",
+            return_value=mock_provider,
+        ):
+            batch_id = await _try_batch_score(mock_jobs, _SAMPLE_PROFILE)
+
+        assert batch_id is None
+
+    @pytest.mark.asyncio
+    async def test_batch_fallback_on_submission_error(self) -> None:
+        """_try_batch_score() returns None when batch submission fails."""
+        from career_os.services.discovery import _try_batch_score
+
+        mock_jobs = []
+        for i in range(15):
+            job = MagicMock()
+            job.id = i
+            job.title = f"Job {i}"
+            job.company = f"Company {i}"
+            job.location = "Berlin"
+            job.description = f"Description {i}"
+            mock_jobs.append(job)
+
+        mock_provider = MagicMock()
+        mock_provider.name = "anthropic"
+        mock_provider.batch_score = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server error",
+                request=httpx.Request("POST", ANTHROPIC_BATCH_API_URL),
+                response=httpx.Response(500),
+            )
+        )
+
+        with patch(
+            "career_os.ai.factory.get_ai_provider",
+            return_value=mock_provider,
+        ):
+            batch_id = await _try_batch_score(mock_jobs, _SAMPLE_PROFILE)
+
+        assert batch_id is None
+
+    @pytest.mark.asyncio
+    async def test_auto_score_uses_batch_above_threshold(self) -> None:
+        """_auto_score_and_refresh() uses batch scoring for large sweeps."""
+        from career_os.services.discovery import _auto_score_and_refresh
+
+        mock_jobs = []
+        for i in range(BATCH_SCORING_THRESHOLD + 5):
+            job = MagicMock()
+            job.id = i
+            job.title = f"Job {i}"
+            job.company = f"Company {i}"
+            job.location = "Berlin"
+            job.description = f"Description {i}"
+            mock_jobs.append(job)
+
+        mock_profile = MagicMock()
+        mock_profile.name = "Jane"
+        mock_profile.location = "Berlin"
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_profile
+
+        warnings: list = []
+
+        with patch(
+            "career_os.services.discovery._try_batch_score",
+            new_callable=AsyncMock,
+            return_value="batch_auto",
+        ) as mock_batch:
+            await _auto_score_and_refresh(mock_db, 1, mock_jobs, warnings)
+
+        mock_batch.assert_called_once()
+        # Should have a batch_scoring warning entry
+        batch_warnings = [w for w in warnings if w.get("source") == "batch_scoring"]
+        assert len(batch_warnings) == 1
+        assert batch_warnings[0]["batch_id"] == "batch_auto"
+
+    @pytest.mark.asyncio
+    async def test_auto_score_sequential_below_threshold(self) -> None:
+        """_auto_score_and_refresh() uses sequential scoring below threshold."""
+        from career_os.services.discovery import _auto_score_and_refresh
+
+        mock_jobs = []
+        for i in range(BATCH_SCORING_THRESHOLD - 2):
+            job = MagicMock()
+            job.id = i
+            mock_jobs.append(job)
+
+        warnings: list = []
+
+        with (
+            patch(
+                "career_os.services.discovery._try_batch_score",
+                new_callable=AsyncMock,
+            ) as mock_batch,
+            patch(
+                "career_os.services.scoring.batch_score_discovery",
+                new_callable=AsyncMock,
+            ) as mock_sequential,
+            patch(
+                "career_os.services.discovery.propagate_discovery_scores",
+                return_value=0,
+            ),
+            patch(
+                "career_os.services.market.refresh_market_data",
+            ),
+        ):
+            await _auto_score_and_refresh(MagicMock(), 1, mock_jobs, warnings)
+
+        # Batch should NOT be called (below threshold)
+        mock_batch.assert_not_called()
+        # Sequential scoring should be called
+        mock_sequential.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_score_falls_back_when_batch_fails(self) -> None:
+        """_auto_score_and_refresh() falls back to sequential if batch returns None."""
+        from career_os.services.discovery import _auto_score_and_refresh
+
+        mock_jobs = []
+        for i in range(BATCH_SCORING_THRESHOLD + 5):
+            job = MagicMock()
+            job.id = i
+            mock_jobs.append(job)
+
+        mock_profile = MagicMock()
+        mock_profile.name = "Jane"
+        mock_profile.location = "Berlin"
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_profile
+
+        warnings: list = []
+
+        with (
+            patch(
+                "career_os.services.discovery._try_batch_score",
+                new_callable=AsyncMock,
+                return_value=None,  # batch failed
+            ),
+            patch(
+                "career_os.services.scoring.batch_score_discovery",
+                new_callable=AsyncMock,
+            ) as mock_sequential,
+            patch(
+                "career_os.services.discovery.propagate_discovery_scores",
+                return_value=0,
+            ),
+            patch(
+                "career_os.services.market.refresh_market_data",
+            ),
+        ):
+            await _auto_score_and_refresh(mock_db, 1, mock_jobs, warnings)
+
+        # Sequential should be called as fallback
+        mock_sequential.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# BATCH_SCORING_THRESHOLD constant test
+# ---------------------------------------------------------------------------
+
+
+class TestBatchScoringThreshold:
+    """Test the batch scoring threshold constant."""
+
+    def test_threshold_is_positive_integer(self) -> None:
+        """BATCH_SCORING_THRESHOLD is a positive integer."""
+        assert isinstance(BATCH_SCORING_THRESHOLD, int)
+        assert BATCH_SCORING_THRESHOLD > 0
+
+    def test_threshold_default_value(self) -> None:
+        """BATCH_SCORING_THRESHOLD defaults to 10."""
+        assert BATCH_SCORING_THRESHOLD == 10


### PR DESCRIPTION
## Summary
- Add Anthropic Message Batches API integration for 50% cost reduction on bulk scoring
- Discovery sweeps with >10 jobs automatically route through batch processing
- Automatic fallback to sequential scoring if batch submission fails or provider doesn't support it
- 19 new tests covering batch submission, polling, result parsing, and discovery routing

## Files changed
- `ai/base.py` — add batch_score() and get_batch_results() with default NotImplementedError
- `ai/anthropic_provider.py` — implement batch_score() (POST to /v1/messages/batches) and get_batch_results() (poll + JSONL parsing)
- `services/discovery.py` — BATCH_SCORING_THRESHOLD=10, auto-route to batch when Anthropic + enough jobs
- `tests/test_batch_api.py` — 19 tests

## Cost impact
- Batch API: 50% discount on all Anthropic models
- Combined with prompt caching (90%): up to 95% savings on bulk scoring
- Only affects discovery sweeps, real-time scoring path untouched

## Test plan
- [x] 19 new tests pass
- [x] Full suite passes (2816 pass, 20 skip)
- [ ] Verify with real batch submission in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)