### PR TITLE
fix(G-379): sync all version artifacts with release-please

### DIFF
--- a/docs/sessions/2026-04-14_scoring-evolution.md
+++ b/docs/sessions/2026-04-14_scoring-evolution.md
@@ -1,0 +1,63 @@
+---
+title: Scoring Evolution
+---
+
+# Session: Scoring Evolution — 11 Epics in 2 Days
+**Date:** 2026-04-14 to 2026-04-15
+**Branch:** main (all merged)
+**Tickets:** G-268 (master), G-269 through G-279 (11 sub-epics), G-282, G-283, G-284 (follow-ups)
+
+## What was done
+- Cleaned up 8 local + 29 remote stale branches
+- Ran 3 parallel deep research agents (competitors, academic, engineering)
+- Synthesized research into `private/research-scoring-deep-dive-2026-04-14.md`
+- Designed 11-epic roadmap across 5 phases in `docs/scoring-evolution-epics.md`
+- Created 12 Linear tickets (G-268 master + G-269 through G-279)
+- Orchestrated 11 agent executions on Mac Mini via tmux (3 sessions Day 1, 2 sessions Day 2)
+- Reviewed all 7 Day 1 branches with parallel review agents
+- Fixed G-274 calibration injection gap (agent on Mac Mini)
+- Resolved Alembic migration conflicts across 4 branches (revision chain + ID collisions)
+- Merged all 11 PRs (#177-#187) to main
+- Closed all 12 Linear tickets as Done
+- Created 3 follow-up tickets (G-282 edutainment doc, G-283 alembic consolidation, G-284 test fix)
+
+## Features shipped
+- Scoring rubric with 3 calibration examples + golden set (G-269)
+- Ghost job detection from discovery history (G-270)
+- Score percentiles and context (G-271)
+- Embedding pre-filter with Ollama shadow mode (G-272)
+- Borderline 2-pass scoring for 4.0-6.5 zone (G-273)
+- User feedback loop with calibration injection (G-274)
+- Dual-score: fit_score + desire_score with quadrant classification (G-275)
+- ESCO skill normalization with 3-pass matching (G-276)
+- WARN Act layoff red flags from public data (G-277)
+- Uncertainty ranges for sparse profiles (G-278)
+- Bayesian preference learning from feedback (G-279)
+
+## Decisions made
+- Opus for judgment-heavy epics (rubric, embeddings, dual-score, Bayesian), Sonnet for execution
+- Mac Mini + tmux + `--dangerously-skip-permissions` for agent execution
+- Option B (AI-generated) as default desire_score method, Option A (derived) as fallback
+- No sqlite-vec C extension — pure Python cosine similarity for now
+- Feedback calibration gated behind feature flag, requires ≥10 corrections
+- Shadow mode default for embedding pre-filter (log similarities, don't filter yet)
+
+## Open items
+- G-282: Edutainment doc "How Kestrel Scores"
+- G-283: Consolidate dual Alembic migration directories
+- G-284: Fix pre-existing test_md_to_pdf.py failures
+- Integration testing across all 11 features combined
+- Phase 4 session prompt for Mac Mini still in `private/agent-prompts.md`
+
+## PRs merged
+- #175: docs(G-268): scoring evolution epic specs
+- #177: feat(G-269): scoring rubric & few-shot calibration
+- #178: feat(G-270): ghost job detection
+- #179: feat(G-271): score context & percentiles
+- #180: feat(G-275): dual-score architecture
+- #181: feat(G-274): user feedback loop
+- #182: feat(G-276): ESCO skill normalization
+- #183: feat(G-277): WARN Act layoff integration
+- #184: feat(G-278): uncertainty ranges
+- #185: feat(G-279): Bayesian preference learning
+- #187: feat(G-273): borderline 2-pass scoring (includes G-272 embeddings)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,6 +27,11 @@
           "type": "json",
           "path": "npm-package/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "frontend/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/src/career_os/main.py
+++ b/src/career_os/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from career_os import __version__
 from career_os.api.ai import router as ai_router
 from career_os.api.analytics import router as analytics_router
 from career_os.api.applications import router as applications_router
@@ -132,7 +133,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title=settings.app_name,
     description="AI-Powered Job Search & Career Strategy Platform",
-    version="0.1.0",
+    version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=lifespan,


### PR DESCRIPTION
## Summary

- **FastAPI app version**: was hardcoded `"0.1.0"` since scaffold — now imports `__version__` from `career_os` package, so `/docs` and `/openapi.json` reflect the actual release
- **frontend/package.json**: bumped from `0.0.0` → `0.3.1` to match current release
- **release-please-config.json**: added `frontend/package.json` to `extra-files` so future release cuts automatically bump the frontend version

All version artifacts now report `0.3.1` and will stay in sync on future releases.

## Verification

```bash
# All show 0.3.1:
grep 'version' pyproject.toml | head -1
grep '__version__' src/career_os/__init__.py
grep 'version' npm-package/package.json | head -1
grep 'version' frontend/package.json | head -1
python3 -c "import ast; ast.parse(open('src/career_os/main.py').read()); print('syntax OK')"
python3 -c "import json; json.load(open('release-please-config.json')); print('valid JSON')"
```

## Test plan

- [x] All changed files validate (Python AST, JSON parse)
- [x] Pre-existing test failures confirmed unrelated (G-380: rapidfuzz venv, G-381: frontend TS types)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)