### PR TITLE
fix(G-382): resolve frontend TS build errors blocking PyPI publish

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ScoreRadarChart.tsx
+++ b/frontend/src/components/ScoreRadarChart.tsx
@@ -101,9 +101,10 @@ export function ScoreRadarChart({ scores }: ScoreRadarChartProps) {
                 borderRadius: 8,
                 border: "1px solid #e2e8f0",
               }}
-              formatter={(value: number, _name, payload) => {
-                const full = payload?.payload?.full as string | undefined;
-                return [`${value.toFixed(1)} / 10`, full ?? "Score"];
+              formatter={(value, _name, props) => {
+                const v = Number(value);
+                const full = props?.payload?.full as string | undefined;
+                return [`${v.toFixed(1)} / 10`, full ?? "Score"];
               }}
             />
             <Bar dataKey="value" radius={[0, 4, 4, 0]}>
@@ -139,9 +140,10 @@ export function ScoreRadarChart({ scores }: ScoreRadarChartProps) {
               borderRadius: 8,
               border: "1px solid #e2e8f0",
             }}
-            formatter={(value: number, _name, payload) => {
-              const full = payload?.payload?.full as string | undefined;
-              return [`${value.toFixed(1)} / 10`, full ?? "Score"];
+            formatter={(value, _name, props) => {
+              const v = Number(value);
+              const full = props?.payload?.full as string | undefined;
+              return [`${v.toFixed(1)} / 10`, full ?? "Score"];
             }}
           />
         </RadarChart>

--- a/frontend/src/components/StarStoriesSection.tsx
+++ b/frontend/src/components/StarStoriesSection.tsx
@@ -297,7 +297,7 @@ function StoryCard({
 
       {(matchingSkills?.length ?? 0) > 0 && !expanded && (
         <p className="text-xs text-green-600 mt-1 pl-6">
-          Matches: {matchingSkills.join(", ")}
+          Matches: {matchingSkills!.join(", ")}
         </p>
       )}
     </div>

--- a/frontend/src/components/analytics/ConversionFunnel.tsx
+++ b/frontend/src/components/analytics/ConversionFunnel.tsx
@@ -69,10 +69,10 @@ export function ConversionFunnel({ data }: Props) {
                 allowDecimals={false}
               />
               <Tooltip
-                formatter={(value, _name, { payload }: { payload: { percentage: number } }) => [
-                  `${value} (${payload.percentage}%)`,
-                  "Count",
-                ]}
+                formatter={(value, _name, props) => {
+                  const entry = props.payload as { percentage: number } | undefined;
+                  return [`${value} (${entry?.percentage ?? 0}%)`, "Count"];
+                }}
                 contentStyle={{
                   borderRadius: "8px",
                   border: "1px solid #e2e8f0",

--- a/frontend/src/components/analytics/TimeInStage.tsx
+++ b/frontend/src/components/analytics/TimeInStage.tsx
@@ -81,8 +81,9 @@ export function TimeInStage({ data }: Props) {
                 }}
               />
               <Tooltip
-                formatter={(value, _name, { payload }: { payload: { hasData: boolean } }) => {
-                  if (!payload.hasData) return ["No data", "Avg. Days"];
+                formatter={(value, _name, props) => {
+                  const entry = props.payload as { hasData: boolean } | undefined;
+                  if (!entry?.hasData) return ["No data", "Avg. Days"];
                   return [`${Number(value).toFixed(1)} days`, "Avg. Days"];
                 }}
                 contentStyle={{

--- a/frontend/src/pages/ContactsPage.tsx
+++ b/frontend/src/pages/ContactsPage.tsx
@@ -74,7 +74,7 @@ function ContactCard({
 
       {(contact.tags?.length ?? 0) > 0 && (
         <div className="mt-2 flex flex-wrap gap-1">
-          {contact.tags.map((tag) => (
+          {contact.tags!.map((tag) => (
             <span
               key={tag}
               className="rounded bg-gray-50 px-1.5 py-0.5 text-xs text-gray-500"

--- a/frontend/src/pages/Learning.tsx
+++ b/frontend/src/pages/Learning.tsx
@@ -445,7 +445,7 @@ function GapSection({
   } else if ((data?.recommendations?.length ?? 0) > 0) {
     gapContent = (
       <div className="space-y-3">
-        {data.recommendations.map((resource) => (
+        {data!.recommendations.map((resource) => (
           <ResourceCard
             key={resource.id}
             resource={resource}
@@ -801,7 +801,7 @@ export function Learning() {
       )}
 
       {/* All requirements met */}
-      {applicationId && gapData?.total_requirements > 0 && gapsWithIds.length === 0 && (
+      {applicationId && (gapData?.total_requirements ?? 0) > 0 && gapsWithIds.length === 0 && (
         <div className="rounded-lg border-2 border-dashed border-gray-300 bg-white py-8 text-center">
           <CheckCircle2 className="mx-auto h-10 w-10 text-green-500" />
           <h2 className="mt-3 text-lg font-semibold text-gray-900">


### PR DESCRIPTION
## Summary

- Fix all TypeScript strict null check errors that were causing `npm run build` (specifically `tsc -b`) to fail during the PyPI publish workflow
- Every PyPI publish since v0.2.0 has failed due to these TS errors, leaving PyPI stuck at v0.1.0
- Bump frontend version from 0.3.1 → 0.5.0 to match current release

## Changes

**Recharts Tooltip formatter type fixes** (3 components):
- `TimeInStage.tsx` — destructured `payload` from Recharts' `Payload<>` type where `payload` is optional
- `ConversionFunnel.tsx` — same pattern
- `ScoreRadarChart.tsx` — same pattern (2 Tooltip instances: bar chart + radar chart), plus `value` typed as `number` but Recharts passes `ValueType | undefined`

**Null safety fixes** (3 components):
- `ContactsPage.tsx:77` — `contact.tags` possibly null (guarded by length check but TS can't narrow)
- `Learning.tsx:448` — `data` possibly undefined (guarded by length check)
- `Learning.tsx:804` — `gapData?.total_requirements` needs nullish coalescing
- `StarStoriesSection.tsx:300` — `matchingSkills` possibly undefined (guarded by length check)

## Impact

Once merged, release-please PR #217 (v0.5.1) will include these fixes. When that merges and tags, the publish workflow will finally succeed and PyPI will update from 0.1.0 → 0.5.1.

Also resolves G-381 (Frontend TS build errors).

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [x] Pre-existing tests unaffected (20/22 test files pass; 2 KanbanBoard failures are pre-existing localStorage mock issue)
- [ ] CI passes on this PR
- [ ] After merge: verify release-please PR #217 includes this commit
- [ ] After v0.5.1 tag: verify publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)