### PR TITLE
chore(G-385): gitignore GSD and BMAD dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,12 +94,18 @@ htmlcov/
 frontend/coverage/
 lcov.info
 
-# BMAD output artifacts (branch-specific, not infrastructure)
+# BMAD (local dev tooling, not shipped to users)
 _bmad-output/
+_bmad/
 
-# GSD state (per-session, not infrastructure)
+# GSD (local dev tooling, not shipped to users)
 .planning/
 GSD-CLAUDE.md
+.claude/commands/gsd/
+.claude/get-shit-done/
+.claude/agents/gsd-*
+.claude/hooks/gsd-*
+gsd-local-patches/
 
 # Internal business docs
 docs/pricing-strategy.md


### PR DESCRIPTION
## Summary

- Add `_bmad/` (BMAD module config) to .gitignore
- Add GSD framework directories (`.claude/commands/gsd/`, `.claude/get-shit-done/`, `.claude/agents/gsd-*`, `.claude/hooks/gsd-*`, `gsd-local-patches/`)
- These are local development workflow tools with zero value for Kestrel users or contributors

## Test plan

- [x] No tracked files affected (these dirs don't exist in the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)