### PR TITLE
fix(G-385): add load_dotenv for reliable .env file reading

### DIFF
--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -2,8 +2,14 @@
 
 from pathlib import Path
 
+from dotenv import load_dotenv
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+# Ensure .env vars are in os.environ before pydantic-settings reads them.
+# pydantic-settings 2.13.1 silently fails to load some variables from .env;
+# explicit load_dotenv fixes this.
+load_dotenv(override=True)
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary

- pydantic-settings 2.13.1 silently fails to load some `.env` variables, causing crashes when `AI_PROVIDER` is set but the corresponding API key field stays empty
- Added explicit `load_dotenv(override=True)` before the `Settings` class definition to ensure all `.env` vars are in `os.environ` before pydantic-settings reads them
- `python-dotenv` is already a declared dependency (`>=1.1.0` in pyproject.toml)

## Test plan

- [x] `pytest tests/test_daily_pipeline.py` passes (23 tests)
- [ ] Manual: set `AI_PROVIDER=openrouter` and `OPENROUTER_API_KEY=sk-or-...` in `.env`, verify app starts without "API key required" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)