### PR TITLE
G-345: Add job family keyword presets for discovery

### DIFF
--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -1033,10 +1033,25 @@ def discover(
     try:
         profile = _get_default_profile(db)
 
-        # Parse keywords
+        # Parse keywords — if none supplied, auto-select from profile's job family
         kw_list: list[str] | None = None
         if keywords:
             kw_list = [k.strip() for k in keywords.split(",") if k.strip()]
+        else:
+            # Auto-select keywords based on the profile's job_family
+            from tools.scraper import get_keywords_for_profile
+
+            job_family = getattr(profile, "job_family", None)
+            auto_keywords = get_keywords_for_profile(job_family=job_family)
+            # Only use auto keywords if they differ from the hardcoded defaults
+            from tools.scraper import DEFAULT_KEYWORDS
+
+            if auto_keywords != DEFAULT_KEYWORDS:
+                kw_list = auto_keywords
+                console.print(
+                    f"[dim]Using keywords for job family '{job_family}': "
+                    f"{', '.join(kw_list[:3])}{'...' if len(kw_list) > 3 else ''}[/dim]"
+                )
 
         loc_list: list[str] | None = None
         if location:

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -9,6 +9,9 @@ from scraper import (
     DEFAULT_LOCATION,
     DEFAULT_RESULTS_PER_KEYWORD,
     DEFAULT_SITES,
+    JOB_FAMILY_KEYWORDS,
+    _match_job_family,
+    get_keywords_for_profile,
     scrape_all,
 )
 
@@ -197,3 +200,154 @@ class TestScrapeAll:
         scrape_all(keywords=["kw1"])
 
         assert mock_scrape.call_args.kwargs["country_indeed"] == "Germany"
+
+
+# ---------------------------------------------------------------------------
+# JOB_FAMILY_KEYWORDS
+# ---------------------------------------------------------------------------
+
+
+class TestJobFamilyKeywords:
+    def test_all_values_are_lists_of_strings(self):
+        for family, keywords in JOB_FAMILY_KEYWORDS.items():
+            assert isinstance(keywords, list), f"{family} keywords is not a list"
+            assert len(keywords) > 0, f"{family} has empty keywords"
+            for kw in keywords:
+                assert isinstance(kw, str), f"{family} has non-string keyword: {kw}"
+
+    def test_no_empty_keywords(self):
+        for family, keywords in JOB_FAMILY_KEYWORDS.items():
+            for kw in keywords:
+                assert kw.strip(), f"{family} has blank keyword"
+
+    def test_core_scoring_families_have_keyword_presets(self):
+        """Core tech/product job families from scoring should have keyword presets.
+
+        JOB_FAMILY_WEIGHTS has 280+ families across all industries. Keyword
+        presets cover the most common tech/product families. Uncovered families
+        fall back to using the role title itself as a search keyword via
+        get_keywords_for_profile().
+        """
+        core_families = [
+            "TPM", "SWE", "Product Engineer", "DevRel", "AI Program Lead",
+            "Backend Engineer", "Frontend Engineer", "Full-Stack Developer",
+            "DevOps Engineer", "ML Engineer", "Data Engineer", "Data Scientist",
+            "Engineering Manager", "Product Manager", "UX Designer",
+        ]
+        for family in core_families:
+            assert family in JOB_FAMILY_KEYWORDS, (
+                f"Core family '{family}' missing from JOB_FAMILY_KEYWORDS"
+            )
+
+    def test_tpm_keywords_present(self):
+        assert "TPM" in JOB_FAMILY_KEYWORDS
+        kws = JOB_FAMILY_KEYWORDS["TPM"]
+        assert any("Technical Program Manager" in kw for kw in kws)
+
+    def test_devrel_keywords_present(self):
+        assert "DevRel" in JOB_FAMILY_KEYWORDS
+        kws = JOB_FAMILY_KEYWORDS["DevRel"]
+        assert any("Developer Advocate" in kw for kw in kws)
+
+    def test_swe_keywords_present(self):
+        assert "SWE" in JOB_FAMILY_KEYWORDS
+        kws = JOB_FAMILY_KEYWORDS["SWE"]
+        assert any("Software Engineer" in kw for kw in kws)
+
+
+# ---------------------------------------------------------------------------
+# _match_job_family
+# ---------------------------------------------------------------------------
+
+
+class TestMatchJobFamily:
+    def test_exact_match(self):
+        assert _match_job_family("TPM") == "TPM"
+
+    def test_case_insensitive_match(self):
+        assert _match_job_family("tpm") == "TPM"
+        assert _match_job_family("devrel") == "DevRel"
+
+    def test_substring_match(self):
+        assert _match_job_family("Senior TPM") == "TPM"
+
+    def test_no_match_returns_none(self):
+        assert _match_job_family("Underwater Basket Weaver") is None
+
+    def test_exact_key_preferred_over_substring(self):
+        result = _match_job_family("Product Engineer")
+        assert result == "Product Engineer"
+
+    def test_whitespace_stripped(self):
+        assert _match_job_family("  TPM  ") == "TPM"
+
+
+# ---------------------------------------------------------------------------
+# get_keywords_for_profile
+# ---------------------------------------------------------------------------
+
+
+class TestGetKeywordsForProfile:
+    def test_no_args_returns_defaults(self):
+        result = get_keywords_for_profile()
+        assert result == DEFAULT_KEYWORDS
+
+    def test_job_family_returns_preset(self):
+        result = get_keywords_for_profile(job_family="TPM")
+        assert result == JOB_FAMILY_KEYWORDS["TPM"]
+
+    def test_job_family_case_insensitive(self):
+        result = get_keywords_for_profile(job_family="devrel")
+        assert result == JOB_FAMILY_KEYWORDS["DevRel"]
+
+    def test_unknown_job_family_returns_defaults(self):
+        result = get_keywords_for_profile(job_family="Nonexistent Role")
+        assert result == DEFAULT_KEYWORDS
+
+    def test_target_roles_single_match(self):
+        result = get_keywords_for_profile(target_roles=["TPM"])
+        assert result == JOB_FAMILY_KEYWORDS["TPM"]
+
+    def test_target_roles_multiple_match(self):
+        result = get_keywords_for_profile(target_roles=["TPM", "DevRel"])
+        # Should contain keywords from both families
+        for kw in JOB_FAMILY_KEYWORDS["TPM"]:
+            assert kw in result
+        for kw in JOB_FAMILY_KEYWORDS["DevRel"]:
+            assert kw in result
+
+    def test_target_roles_deduplication(self):
+        result = get_keywords_for_profile(target_roles=["TPM", "TPM"])
+        # Should not have duplicates
+        assert len(result) == len(set(kw.lower() for kw in result))
+
+    def test_target_roles_unrecognized_used_as_keyword(self):
+        result = get_keywords_for_profile(target_roles=["Chief Llama Wrangler"])
+        assert "Chief Llama Wrangler" in result
+
+    def test_target_roles_mixed_recognized_and_unrecognized(self):
+        result = get_keywords_for_profile(
+            target_roles=["TPM", "Chief Llama Wrangler"]
+        )
+        # TPM keywords should be present
+        assert any("Technical Program Manager" in kw for kw in result)
+        # Unrecognized role used as-is
+        assert "Chief Llama Wrangler" in result
+
+    def test_target_roles_takes_precedence_over_job_family(self):
+        result = get_keywords_for_profile(
+            target_roles=["DevRel"],
+            job_family="TPM",
+        )
+        # Should use target_roles, not job_family
+        assert result == JOB_FAMILY_KEYWORDS["DevRel"]
+
+    def test_empty_target_roles_falls_through_to_job_family(self):
+        result = get_keywords_for_profile(target_roles=[], job_family="TPM")
+        assert result == JOB_FAMILY_KEYWORDS["TPM"]
+
+    def test_returns_new_list_not_reference(self):
+        result = get_keywords_for_profile(job_family="TPM")
+        result.append("extra")
+        # Original should be unmodified
+        assert "extra" not in JOB_FAMILY_KEYWORDS["TPM"]

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -229,10 +229,21 @@ class TestJobFamilyKeywords:
         get_keywords_for_profile().
         """
         core_families = [
-            "TPM", "SWE", "Product Engineer", "DevRel", "AI Program Lead",
-            "Backend Engineer", "Frontend Engineer", "Full-Stack Developer",
-            "DevOps Engineer", "ML Engineer", "Data Engineer", "Data Scientist",
-            "Engineering Manager", "Product Manager", "UX Designer",
+            "TPM",
+            "SWE",
+            "Product Engineer",
+            "DevRel",
+            "AI Program Lead",
+            "Backend Engineer",
+            "Frontend Engineer",
+            "Full-Stack Developer",
+            "DevOps Engineer",
+            "ML Engineer",
+            "Data Engineer",
+            "Data Scientist",
+            "Engineering Manager",
+            "Product Manager",
+            "UX Designer",
         ]
         for family in core_families:
             assert family in JOB_FAMILY_KEYWORDS, (
@@ -326,9 +337,7 @@ class TestGetKeywordsForProfile:
         assert "Chief Llama Wrangler" in result
 
     def test_target_roles_mixed_recognized_and_unrecognized(self):
-        result = get_keywords_for_profile(
-            target_roles=["TPM", "Chief Llama Wrangler"]
-        )
+        result = get_keywords_for_profile(target_roles=["TPM", "Chief Llama Wrangler"])
         # TPM keywords should be present
         assert any("Technical Program Manager" in kw for kw in result)
         # Unrecognized role used as-is

--- a/tools/scraper.py
+++ b/tools/scraper.py
@@ -24,6 +24,472 @@ DEFAULT_KEYWORDS = [
     "Technical Program Manager remote",
 ]
 
+# ---------------------------------------------------------------------------
+# Job family keyword presets — map each scoring job family to discovery search
+# terms so first-time users get relevant results without crafting queries.
+#
+# Keys match JOB_FAMILY_WEIGHTS in career_os.services.scoring.
+# Values are lists of search strings that produce good signal on major boards.
+# ---------------------------------------------------------------------------
+
+JOB_FAMILY_KEYWORDS: dict[str, list[str]] = {
+    # ── Technology ────────────────────────────────────────────────────────
+    "TPM": [
+        "Technical Program Manager",
+        "Technical Program Manager AI",
+        "Senior Technical Program Manager",
+        "Staff Technical Program Manager",
+        "Technical Program Manager remote",
+    ],
+    "SWE": [
+        "Senior Software Engineer",
+        "Staff Software Engineer",
+        "Software Engineer backend",
+        "Software Engineer full stack",
+        "Senior Software Developer",
+    ],
+    "Product Engineer": [
+        "Product Engineer",
+        "Senior Product Engineer",
+        "Staff Product Engineer",
+        "Product Engineer AI",
+        "Product Engineer full stack",
+    ],
+    "DevRel": [
+        "Developer Advocate",
+        "Developer Relations Engineer",
+        "Developer Experience Engineer",
+        "Senior Developer Advocate",
+        "DevRel Engineer",
+    ],
+    "AI Program Lead": [
+        "AI Program Lead",
+        "AI Program Manager",
+        "Head of AI Programs",
+        "Senior AI Program Manager",
+        "AI Transformation Lead",
+    ],
+    "Backend Engineer": [
+        "Senior Backend Engineer",
+        "Staff Backend Engineer",
+        "Backend Engineer Python",
+        "Backend Engineer Go",
+        "Backend Developer senior",
+    ],
+    "Frontend Engineer": [
+        "Senior Frontend Engineer",
+        "Staff Frontend Engineer",
+        "Frontend Engineer React",
+        "Frontend Developer senior",
+        "UI Engineer",
+    ],
+    "Full-Stack Developer": [
+        "Senior Full Stack Engineer",
+        "Full Stack Developer",
+        "Staff Full Stack Engineer",
+        "Full Stack Engineer React",
+        "Full Stack Developer Python",
+    ],
+    "Mobile Developer (iOS)": [
+        "Senior iOS Developer",
+        "iOS Engineer",
+        "Staff iOS Engineer",
+        "Mobile Developer iOS",
+        "Swift Developer senior",
+    ],
+    "Mobile Developer (Android)": [
+        "Senior Android Developer",
+        "Android Engineer",
+        "Staff Android Engineer",
+        "Mobile Developer Android",
+        "Kotlin Developer senior",
+    ],
+    "DevOps Engineer": [
+        "Senior DevOps Engineer",
+        "Staff DevOps Engineer",
+        "DevOps Engineer Kubernetes",
+        "DevOps Engineer AWS",
+        "Infrastructure Engineer",
+    ],
+    "Site Reliability Engineer (SRE)": [
+        "Site Reliability Engineer",
+        "Senior SRE",
+        "Staff SRE",
+        "SRE Engineer",
+        "Reliability Engineer",
+    ],
+    "Platform Engineer": [
+        "Senior Platform Engineer",
+        "Staff Platform Engineer",
+        "Platform Engineer Kubernetes",
+        "Platform Engineer cloud",
+        "Internal Platform Engineer",
+    ],
+    "Cloud Architect": [
+        "Cloud Architect",
+        "Senior Cloud Architect",
+        "Cloud Solutions Architect",
+        "Cloud Infrastructure Architect",
+        "AWS Architect senior",
+    ],
+    "Solutions Architect": [
+        "Solutions Architect",
+        "Senior Solutions Architect",
+        "Technical Solutions Architect",
+        "Solutions Architect cloud",
+        "Pre-Sales Solutions Architect",
+    ],
+    "Security Engineer": [
+        "Senior Security Engineer",
+        "Staff Security Engineer",
+        "Application Security Engineer",
+        "Cloud Security Engineer",
+        "Security Engineer remote",
+    ],
+    "DevSecOps Engineer": [
+        "DevSecOps Engineer",
+        "Senior DevSecOps Engineer",
+        "Security DevOps Engineer",
+        "DevSecOps Architect",
+        "DevSecOps Engineer cloud",
+    ],
+    "QA Engineer": [
+        "Senior QA Engineer",
+        "QA Engineer",
+        "Quality Assurance Engineer",
+        "QA Lead",
+        "Test Engineer senior",
+    ],
+    "QA Automation Engineer": [
+        "QA Automation Engineer",
+        "Senior QA Automation Engineer",
+        "Test Automation Engineer",
+        "Automation Test Engineer",
+        "SDET QA",
+    ],
+    "SDET": [
+        "SDET",
+        "Senior SDET",
+        "Software Development Engineer in Test",
+        "SDET Engineer",
+        "Staff SDET",
+    ],
+    "Data Engineer": [
+        "Senior Data Engineer",
+        "Staff Data Engineer",
+        "Data Engineer Python",
+        "Data Engineer Spark",
+        "Analytics Engineer",
+    ],
+    "ML Engineer": [
+        "Senior ML Engineer",
+        "Machine Learning Engineer",
+        "Staff ML Engineer",
+        "ML Engineer Python",
+        "Applied ML Engineer",
+    ],
+    "MLOps Engineer": [
+        "MLOps Engineer",
+        "Senior MLOps Engineer",
+        "ML Platform Engineer",
+        "Machine Learning Operations Engineer",
+        "MLOps Engineer remote",
+    ],
+    "AI Research Scientist": [
+        "AI Research Scientist",
+        "Senior Research Scientist AI",
+        "Research Scientist Machine Learning",
+        "Applied Research Scientist",
+        "Staff Research Scientist",
+    ],
+    "Data Scientist": [
+        "Senior Data Scientist",
+        "Staff Data Scientist",
+        "Data Scientist ML",
+        "Applied Data Scientist",
+        "Data Scientist Python",
+    ],
+    "Data Analyst": [
+        "Senior Data Analyst",
+        "Data Analyst",
+        "Business Data Analyst",
+        "Data Analyst SQL",
+        "Analytics Analyst senior",
+    ],
+    "Business Intelligence Analyst": [
+        "Business Intelligence Analyst",
+        "Senior BI Analyst",
+        "BI Developer",
+        "Business Intelligence Developer",
+        "BI Analyst senior",
+    ],
+    "Database Administrator": [
+        "Database Administrator",
+        "Senior DBA",
+        "Database Engineer",
+        "DBA PostgreSQL",
+        "Database Administrator senior",
+    ],
+    "Network Engineer": [
+        "Senior Network Engineer",
+        "Network Engineer",
+        "Network Architect",
+        "Network Engineer Cisco",
+        "Network Operations Engineer",
+    ],
+    "Systems Administrator": [
+        "Senior Systems Administrator",
+        "Systems Administrator",
+        "Linux Systems Administrator",
+        "Systems Engineer",
+        "Infrastructure Administrator",
+    ],
+    "IT Support": [
+        "IT Support Engineer",
+        "Senior IT Support",
+        "IT Support Specialist",
+        "Desktop Support Engineer",
+        "IT Help Desk senior",
+    ],
+    "Cybersecurity Analyst": [
+        "Cybersecurity Analyst",
+        "Senior Cybersecurity Analyst",
+        "Information Security Analyst",
+        "SOC Analyst",
+        "Cyber Threat Analyst",
+    ],
+    "Penetration Tester": [
+        "Penetration Tester",
+        "Senior Penetration Tester",
+        "Offensive Security Engineer",
+        "Red Team Engineer",
+        "Ethical Hacker",
+    ],
+    "Embedded Systems Engineer": [
+        "Embedded Systems Engineer",
+        "Senior Embedded Engineer",
+        "Embedded Software Engineer",
+        "Firmware Developer",
+        "Embedded C Developer",
+    ],
+    "Firmware Engineer": [
+        "Firmware Engineer",
+        "Senior Firmware Engineer",
+        "Embedded Firmware Developer",
+        "Firmware Software Engineer",
+        "IoT Firmware Engineer",
+    ],
+    "Game Developer": [
+        "Game Developer",
+        "Senior Game Developer",
+        "Game Programmer",
+        "Unity Developer",
+        "Unreal Engine Developer",
+    ],
+    "Blockchain Developer": [
+        "Blockchain Developer",
+        "Senior Blockchain Engineer",
+        "Smart Contract Developer",
+        "Web3 Developer",
+        "Solidity Developer",
+    ],
+    "Technical Writer (Tech)": [
+        "Technical Writer",
+        "Senior Technical Writer",
+        "Technical Writer API",
+        "Documentation Engineer",
+        "Technical Content Writer",
+    ],
+    "Release Manager": [
+        "Release Manager",
+        "Senior Release Manager",
+        "Release Engineer",
+        "Build and Release Manager",
+        "Configuration Manager",
+    ],
+    "Scrum Master": [
+        "Scrum Master",
+        "Senior Scrum Master",
+        "Agile Coach",
+        "Agile Scrum Master",
+        "Scrum Master remote",
+    ],
+    "Engineering Manager": [
+        "Engineering Manager",
+        "Senior Engineering Manager",
+        "Software Engineering Manager",
+        "Engineering Manager backend",
+        "Head of Engineering",
+    ],
+    "VP Engineering": [
+        "VP Engineering",
+        "Vice President Engineering",
+        "VP of Engineering",
+        "SVP Engineering",
+        "Head of Engineering",
+    ],
+    "CTO": [
+        "CTO",
+        "Chief Technology Officer",
+        "CTO startup",
+        "VP Engineering CTO",
+        "Fractional CTO",
+    ],
+    "Chief Architect": [
+        "Chief Architect",
+        "Principal Architect",
+        "Enterprise Architect",
+        "Chief Software Architect",
+        "Distinguished Engineer",
+    ],
+    # ── Product & Design ──────────────────────────────────────────────────
+    "Product Manager": [
+        "Senior Product Manager",
+        "Product Manager",
+        "Staff Product Manager",
+        "Product Manager AI",
+        "Group Product Manager",
+    ],
+    "Product Owner": [
+        "Product Owner",
+        "Senior Product Owner",
+        "Technical Product Owner",
+        "Product Owner Agile",
+        "Product Owner remote",
+    ],
+    "UX Designer": [
+        "Senior UX Designer",
+        "UX Designer",
+        "UX/UI Designer",
+        "Product Designer",
+        "User Experience Designer",
+    ],
+    "UI Designer": [
+        "UI Designer",
+        "Senior UI Designer",
+        "Visual Designer",
+        "UI/UX Designer",
+        "Interface Designer",
+    ],
+    "UX Researcher": [
+        "UX Researcher",
+        "Senior UX Researcher",
+        "User Research Lead",
+        "Design Researcher",
+        "UX Research Manager",
+    ],
+    # ── Data & Analytics ──────────────────────────────────────────────────
+    "Analytics Engineer": [
+        "Analytics Engineer",
+        "Senior Analytics Engineer",
+        "Data Analytics Engineer",
+        "Analytics Engineer dbt",
+        "Analytics Engineer remote",
+    ],
+    # ── Leadership ────────────────────────────────────────────────────────
+    "Director of Engineering": [
+        "Director of Engineering",
+        "Senior Director Engineering",
+        "Director Software Engineering",
+        "Director Engineering AI",
+        "Engineering Director",
+    ],
+    "Head of Product": [
+        "Head of Product",
+        "VP Product",
+        "Director of Product",
+        "Head of Product Management",
+        "VP Product Management",
+    ],
+    "Founding Engineer": [
+        "Founding Engineer",
+        "First Engineer startup",
+        "Founding Software Engineer",
+        "Founding Full Stack Engineer",
+        "Early Stage Engineer",
+    ],
+}
+
+
+def _normalize_role(role: str) -> str:
+    """Normalize a role title for fuzzy matching against JOB_FAMILY_KEYWORDS keys."""
+    return role.strip().lower()
+
+
+def _match_job_family(role: str) -> str | None:
+    """Match a target role string to a JOB_FAMILY_KEYWORDS key.
+
+    Tries exact match, case-insensitive match, then substring containment.
+    Returns the matching key or None.
+    """
+    normalized = role.strip()
+
+    # Exact match
+    if normalized in JOB_FAMILY_KEYWORDS:
+        return normalized
+
+    # Case-insensitive match
+    lower = _normalize_role(role)
+    for key in JOB_FAMILY_KEYWORDS:
+        if key.lower() == lower:
+            return key
+
+    # Substring match (either direction)
+    for key in JOB_FAMILY_KEYWORDS:
+        if lower in key.lower() or key.lower() in lower:
+            return key
+
+    return None
+
+
+def get_keywords_for_profile(
+    target_roles: list[str] | None = None,
+    job_family: str | None = None,
+) -> list[str]:
+    """Build a keyword list from a user's target roles or job family.
+
+    Resolution order:
+    1. If target_roles is provided, match each role to a job family preset
+       and collect all keywords (deduplicated, order-preserved).
+    2. Else if job_family is provided, look up that single family.
+    3. Else fall back to DEFAULT_KEYWORDS.
+
+    Args:
+        target_roles: List of role titles from config/personal.yaml target_roles.
+        job_family: Single job family string from the profile's job_family field.
+
+    Returns:
+        List of search keyword strings, deduplicated and order-preserved.
+    """
+    keywords: list[str] = []
+    seen: set[str] = set()
+
+    def _add(kw: str) -> None:
+        lower = kw.lower()
+        if lower not in seen:
+            seen.add(lower)
+            keywords.append(kw)
+
+    if target_roles:
+        for role in target_roles:
+            matched_key = _match_job_family(role)
+            if matched_key:
+                for kw in JOB_FAMILY_KEYWORDS[matched_key]:
+                    _add(kw)
+            else:
+                # Use the role title itself as a search keyword
+                _add(role)
+        if keywords:
+            return keywords
+
+    if job_family:
+        matched_key = _match_job_family(job_family)
+        if matched_key:
+            return list(JOB_FAMILY_KEYWORDS[matched_key])
+
+    return list(DEFAULT_KEYWORDS)
+
+
 DEFAULT_SITES = ["linkedin", "indeed", "glassdoor", "google"]
 DEFAULT_LOCATION = "Berlin, Germany"
 DEFAULT_HOURS_OLD = 72


### PR DESCRIPTION
## Summary
- Add `JOB_FAMILY_KEYWORDS` dict to `tools/scraper.py` mapping 55+ job families to curated search keyword lists
- Wire auto-keyword selection into `career discover` CLI command: when no `-k` flag is provided, keywords are auto-selected based on the profile's `job_family` field
- Add `get_keywords_for_profile()` function with fuzzy matching (exact, case-insensitive, substring) and graceful fallback to DEFAULT_KEYWORDS
- 22 new tests (41 total in test_scraper.py)

## Problem
First-time users running `career discover` without `-k` get garbage results (SAP interns, Amazon applied scientist interns) because they don't know what to search for. Kestrel already has job family presets for scoring weights but not for discovery keywords.

## Test plan
- [x] All 41 tests pass: `.venv/bin/python -m pytest tests/test_scraper.py -x -q --timeout=30`
- [ ] Manual: set profile job_family to "TPM", run `career discover`, verify TPM-relevant keywords are used
- [ ] Manual: run `career discover -k "custom term"`, verify explicit keywords override auto-selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)