### PR TITLE
G-385: return zeroed demo scores from mock AI provider

### DIFF
--- a/src/career_os/ai/mock_provider.py
+++ b/src/career_os/ai/mock_provider.py
@@ -126,178 +126,78 @@ def _handle_complete(prompt: str, context: dict | None) -> AIResponse:
     )
 
 
-def _compute_career_alignment(base: float, prompt: str, context: dict | None) -> float:
-    """Compute career_alignment incorporating active goals (VAL-SCORE-003).
-
-    If profile data contains goals, we check keyword overlap between each
-    goal's title/description and the job prompt.  More overlap → higher
-    career_alignment (up to 10.0).  No goals → base value unchanged.
-    """
-    goals: list[dict] = []
-    if context and "profile" in context:
-        goals = context["profile"].get("goals", [])
-    elif context:
-        goals = context.get("goals", [])
-
-    if not goals:
-        return base
-
-    prompt_lower = prompt.lower()
-
-    # Count how many goals have meaningful keyword overlap with the prompt
-    matching_goals = 0
-    for goal in goals:
-        goal_text = f"{goal.get('title', '')} {goal.get('description', '')}".lower()
-        goal_words = {w for w in goal_text.split() if len(w) > 3}  # skip short words
-        if any(word in prompt_lower for word in goal_words):
-            matching_goals += 1
-
-    if matching_goals == 0:
-        return base
-
-    # Boost: +1.5 per matching goal, capped at 10.0
-    boost = matching_goals * 1.5
-    return min(10.0, round(base + boost, 1))
-
-
 def _handle_score(prompt: str, context: dict | None) -> AIResponse:
-    """Scoring response with deterministic but varied scores.
+    """Scoring response returning zeroed-out demo scores.
 
-    Different job descriptions produce different (but deterministic) scores.
-    The seed is derived from the prompt content, so the same job always gets
-    the same score, but different jobs get different scores.
+    All numeric scores are set to 0 with clear "demo mode" reasoning so
+    users understand these are not real AI-generated scores. This prevents
+    misleading users who haven't configured an API key yet.
 
-    If context contains 'weights', those weights influence the score variation
-    to satisfy VAL-SCORE-005 (weight changes produce different results).
-
-    Career alignment is influenced by active goals: if goal keywords overlap
-    with the job prompt, career_alignment receives a measurable boost
-    (VAL-SCORE-003).
+    Non-score fields (effort_flag, prep_level, estimated_salary) retain
+    placeholder values for UI layout purposes.
     """
-    seed = _deterministic_seed(prompt)
-
-    # Include weights in seed if provided (so weight changes produce different scores)
-    weights_str = ""
-    if context and "profile" in context and "weights" in context["profile"]:
-        weights_str = str(context["profile"]["weights"])
-    elif context and "weights" in context:
-        weights_str = str(context["weights"])
-    if weights_str:
-        seed = (seed + _deterministic_seed(weights_str)) % (2**32)
-
-    fit = round(1.0 + (seed % 90) / 10.0, 1)  # 1.0–9.9
-    fit = min(fit, 10.0)
-    readiness = round(20.0 + (seed % 800) / 10.0, 1)  # 20–99.9
-    readiness = min(readiness, 100.0)
-
-    # Career alignment: base from seed, boosted by goal overlap (VAL-SCORE-003)
-    career_base = round(1.0 + (seed % 90) / 10.0, 1)  # 1.0–9.9
-    career_base = min(career_base, 10.0)
-    career = _compute_career_alignment(career_base, prompt, context)
-
-    # Vary effort and prep level based on seed
-    effort_flags = ["low", "medium", "high"]
-    prep_levels = ["light", "moderate", "intensive"]
-    effort_flag = effort_flags[seed % 3]
-    prep_level = prep_levels[(seed // 3) % 3]
-
-    # Generate salary estimate that varies
-    base_salary = 100000 + (seed % 8) * 10000
-    salary_high = base_salary + 30000
-    estimated_salary = f"{base_salary:,}–{salary_high:,} EUR"
-
-    # Build score breakdown factors (always ≥3 with +/- contributions)
-    breakdown_factors = [
-        ScoreBreakdownFactor(
-            factor="Technical Leadership Skills",
-            contribution=round((seed % 5 + 1) * 0.5, 1),
-            description="Strong alignment on technical leadership skills",
-        ),
-        ScoreBreakdownFactor(
-            factor="AI/ML Program Management",
-            contribution=round((seed % 4 + 1) * 0.3, 1),
-            description="Profile shows relevant AI/ML program management experience",
-        ),
-        ScoreBreakdownFactor(
-            factor="Location Match",
-            contribution=round((seed % 3 + 1) * 0.4, 1),
-            description="Location preference matches target region",
-        ),
-        ScoreBreakdownFactor(
-            factor="Industry Domain Gap",
-            contribution=round(-((seed % 3 + 1) * 0.2), 1),
-            description="Minor gap in specific industry domain",
-        ),
-        ScoreBreakdownFactor(
-            factor="Career Trajectory",
-            contribution=round((seed % 4 + 1) * 0.3, 1),
-            description="Career trajectory alignment with role growth potential",
-        ),
-    ]
-
-    # Build a multi-factor reasoning string (always ≥100 chars, ≥3 factors)
-    factors = [
-        f"Strong alignment on technical leadership skills (+{(seed % 5 + 1) * 0.5:.1f})",
-        f"Profile shows relevant AI/ML program management experience (+{(seed % 4 + 1) * 0.3:.1f})",
-        f"Location preference matches target region (+{(seed % 3 + 1) * 0.4:.1f})",
-        f"Minor gap in specific industry domain (−{(seed % 3 + 1) * 0.2:.1f})",
-        f"Career trajectory alignment with role growth potential (+{(seed % 4 + 1) * 0.3:.1f})",
-    ]
-    reasoning = ". ".join(factors) + f". Overall a solid fit with score {fit}/10."
-
-    # Dimensional sub-scores: six deterministic floats derived from the seed.
-    # Each dimension gets a distinct seed offset so they're not all the same
-    # value, but they're all bounded to [0, 10].
-    def _dim(offset: int) -> float:
-        return round(((seed + offset * 7) % 101) / 10.0, 1)
-
-    dimensional = DimensionalScores(
-        technical_fit=_dim(0),
-        seniority_alignment=_dim(1),
-        compensation_fit=_dim(2),
-        location_fit=_dim(3),
-        career_trajectory=_dim(4),
-        company_fit=_dim(5),
+    _demo_reasoning = (
+        "DEMO MODE - no AI provider configured. All scores are zero and do not reflect "
+        "actual job fit. To enable real AI-powered scoring, add an API key in your "
+        "configuration (OpenRouter, Anthropic, OpenAI, Ollama, or Together). "
+        "Once configured, scores will be generated by analyzing your profile against "
+        "the job description across multiple dimensions."
     )
 
-    # ATS keywords: all 12 from the static pool, with seed-derived matched flag
-    # and the category pre-assigned in the pool.
+    breakdown_factors = [
+        ScoreBreakdownFactor(
+            factor="Not scored (demo)",
+            contribution=0.0,
+            description="Demo mode - no AI provider configured",
+        ),
+        ScoreBreakdownFactor(
+            factor="Not scored (demo)",
+            contribution=0.0,
+            description="Add an API key to enable real scoring",
+        ),
+        ScoreBreakdownFactor(
+            factor="Not scored (demo)",
+            contribution=0.0,
+            description="See docs for supported AI providers",
+        ),
+    ]
+
+    dimensional = DimensionalScores(
+        technical_fit=0.0,
+        seniority_alignment=0.0,
+        compensation_fit=0.0,
+        location_fit=0.0,
+        career_trajectory=0.0,
+        company_fit=0.0,
+    )
+
+    # ATS keywords: all marked as unmatched in demo mode
     ats_keywords = [
         ATSKeyword(
             keyword=keyword,
             category=category,  # type: ignore[arg-type]
-            matched=((seed + idx) % 2 == 0),
+            matched=False,
         )
-        for idx, (keyword, category) in enumerate(_MOCK_ATS_KEYWORDS)
+        for _idx, (keyword, category) in enumerate(_MOCK_ATS_KEYWORDS)
     ]
 
-    # Desire score (Option B: AI-generated) — deterministic from seed
-    desire = round(1.0 + ((seed + 42) % 90) / 10.0, 1)
-    desire = min(desire, 10.0)
-    desire_reasoning = (
-        f"Company culture aligns well with candidate preferences. "
-        f"Growth potential rated {desire}/10 based on role trajectory and industry outlook."
-    )
-
     structured = ScoreResult(
-        fit_score=fit,
-        reasoning=reasoning,
-        estimated_salary=estimated_salary,
-        effort_flag=effort_flag,
-        prep_level=prep_level,
-        prep_notes=(
-            f"Brush up on domain-specific terminology and prepare {(seed % 3) + 2} STAR stories."
-        ),
-        readiness_score=readiness,
-        career_alignment=career,
+        fit_score=0.0,
+        reasoning=_demo_reasoning,
+        estimated_salary="Not estimated (demo mode)",
+        effort_flag="low",
+        prep_level="light",
+        prep_notes="Demo mode - add an API key to get real preparation recommendations.",
+        readiness_score=0.0,
+        career_alignment=0.0,
         score_breakdown=breakdown_factors,
         dimensional_scores=dimensional,
         ats_keywords=ats_keywords,
-        desire_score=desire,
-        desire_reasoning=desire_reasoning,
+        desire_score=0.0,
+        desire_reasoning="Demo mode - not scored. Add an API key to enable AI scoring.",
     )
     return AIResponse(
-        content=structured.reasoning,
+        content=_demo_reasoning,
         provider="mock",
         feature=AIFeature.score,
         structured=structured,

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -92,15 +92,17 @@ class TestMockProvider:
         assert r1.structured.fit_score == r2.structured.fit_score
 
     @pytest.mark.asyncio
-    async def test_score_varied(self, provider: MockProvider) -> None:
-        """Different jobs produce different scores."""
+    async def test_score_demo_mode(self, provider: MockProvider) -> None:
+        """Mock provider returns zeroed demo scores regardless of input."""
         r1 = await provider.score("Frontend Developer at Small Startup", {"name": "V"})
         r2 = await provider.score("VP Engineering at Enterprise Corp", {"name": "V"})
-        # At least one field should differ (with different input text the hash seed differs)
-        assert (
-            r1.structured.fit_score != r2.structured.fit_score
-            or r1.structured.readiness_score != r2.structured.readiness_score
-        )
+        # Demo mode: all scores are zero for any input
+        assert r1.structured.fit_score == 0.0
+        assert r2.structured.fit_score == 0.0
+        assert r1.structured.readiness_score == 0.0
+        assert r2.structured.readiness_score == 0.0
+        assert "DEMO MODE" in r1.structured.reasoning
+        assert "DEMO MODE" in r2.structured.reasoning
 
     @pytest.mark.asyncio
     async def test_gap_analysis(self, provider: MockProvider) -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -253,8 +253,8 @@ class TestScoreEndpoint:
         assert "profile_id" in data
         assert "is_stale" in data
 
-        # Value ranges
-        assert 1.0 <= data["fit_score"] <= 10.0
+        # Value ranges (mock provider returns 0.0 demo scores)
+        assert 0.0 <= data["fit_score"] <= 10.0
         assert 0.0 <= data["readiness_score"] <= 100.0
         assert 0.0 <= data["career_alignment"] <= 10.0
         assert data["profile_id"] == 1
@@ -274,7 +274,7 @@ class TestScoreEndpoint:
         # Verify in DB
         scored = db_session.query(ScoredJob).filter(ScoredJob.profile_id == 1).first()
         assert scored is not None
-        assert scored.fit_score > 0
+        assert scored.fit_score >= 0  # mock provider returns 0.0 (demo mode)
 
     def test_score_response_surfaces_red_flags(self, client):
         """A staffing-agency JD should produce a red_flags entry (#73)."""
@@ -731,8 +731,8 @@ class TestScoringExplanation:
         reasoning = resp.json()["reasoning"]
         assert len(reasoning) >= 100
 
-    def test_reasoning_contains_at_least_3_factors(self, client, db_session):
-        """Explanation must contain ≥3 specific factors."""
+    def test_reasoning_indicates_demo_mode(self, client, db_session):
+        """Mock provider reasoning clearly indicates demo mode."""
         resp = client.post(
             "/api/score",
             json={
@@ -743,14 +743,12 @@ class TestScoringExplanation:
         assert resp.status_code == 201
         reasoning = resp.json()["reasoning"]
 
-        # Count distinct factor markers (+ and -)
-        positive_factors = reasoning.count("(+")
-        negative_factors = reasoning.count("(−") + reasoning.count("(-")
-        total_factors = positive_factors + negative_factors
-        assert total_factors >= 3, f"Expected ≥3 factors but found {total_factors} in: {reasoning}"
+        # Demo mode reasoning must clearly indicate no real scoring occurred
+        assert "DEMO MODE" in reasoning
+        assert "API key" in reasoning or "provider" in reasoning
 
-    def test_reasoning_is_not_generic(self, client, db_session):
-        """Different jobs produce different reasoning strings."""
+    def test_reasoning_is_consistent_in_demo_mode(self, client, db_session):
+        """Demo mode returns same reasoning for all jobs (no fake variation)."""
         resp_a = client.post(
             "/api/score",
             json={
@@ -768,8 +766,8 @@ class TestScoringExplanation:
         assert resp_a.status_code == 201
         assert resp_b.status_code == 201
 
-        # Different jobs should produce different reasoning
-        assert resp_a.json()["reasoning"] != resp_b.json()["reasoning"]
+        # Demo mode: same reasoning for all jobs (no misleading variation)
+        assert resp_a.json()["reasoning"] == resp_b.json()["reasoning"]
 
 
 # ===========================================================================
@@ -1088,8 +1086,8 @@ class TestMockScoring:
         assert resp1.json()["readiness_score"] == resp2.json()["readiness_score"]
         assert resp1.json()["career_alignment"] == resp2.json()["career_alignment"]
 
-    def test_mock_different_jobs_different_scores(self, client, db_session):
-        """Different job descriptions produce different scores."""
+    def test_mock_returns_demo_zero_scores(self, client, db_session):
+        """Mock provider returns zeroed demo scores for any job description."""
         resp_a = client.post(
             "/api/score",
             json={
@@ -1107,12 +1105,13 @@ class TestMockScoring:
         assert resp_a.status_code == 201
         assert resp_b.status_code == 201
 
-        # At least one score field should differ
-        assert (
-            resp_a.json()["fit_score"] != resp_b.json()["fit_score"]
-            or resp_a.json()["readiness_score"] != resp_b.json()["readiness_score"]
-            or resp_a.json()["career_alignment"] != resp_b.json()["career_alignment"]
-        ), "Different jobs should produce at least one different score component"
+        # Demo mode: all scores are zero regardless of input
+        for resp in (resp_a, resp_b):
+            data = resp.json()
+            assert data["fit_score"] == 0.0
+            assert data["readiness_score"] == 0.0
+            assert data["career_alignment"] == 0.0
+            assert "DEMO MODE" in data["reasoning"]
 
     def test_mock_effort_flag_valid_values(self, client, db_session):
         """effort_flag is one of low/medium/high."""
@@ -1256,7 +1255,7 @@ class TestGoalsInformScoring:
         assert resp.status_code == 201
         data = resp.json()
         assert "career_alignment" in data
-        assert data["career_alignment"] > 0
+        assert data["career_alignment"] >= 0  # mock provider returns 0.0 (demo mode)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Mock AI provider now returns all-zero scores with clear "DEMO MODE" reasoning instead of realistic-looking fake numbers that mislead users
- Removed `_compute_career_alignment` helper (no longer needed with static zero scores)
- Updated 5 tests across `test_ai_provider.py` and `test_scoring.py` to match new demo behavior

## Problem

Users in demo mode (no API key) saw scores like 9.9, 5.2 that looked real but were completely fabricated from hash seeds. When they configured a real AI provider, scores changed dramatically, eroding trust in the platform.

## Test plan

- [x] All 2967 passing tests still pass (2 pre-existing failures in unrelated `test_md_to_pdf.py`)
- [x] `test_score_demo_mode` verifies zero scores and "DEMO MODE" label
- [x] `test_mock_returns_demo_zero_scores` verifies API endpoint returns zeroed demo scores
- [x] `test_reasoning_indicates_demo_mode` verifies reasoning contains demo mode indicator
- [x] `test_reasoning_is_consistent_in_demo_mode` verifies no fake variation between jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)