### PR TITLE
feat(G-291): port robust JSON scoring parser from CareerOS

### DIFF
--- a/tests/test_parse_scoring_response.py
+++ b/tests/test_parse_scoring_response.py
@@ -1,0 +1,150 @@
+"""Tests for the robust parse_scoring_response() JSON parser."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure tools/ is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from job_scorer import parse_scoring_response
+
+VALID_PAYLOAD = {
+    "score": 7,
+    "reasoning": "Good match for the role requirements.",
+    "estimated_salary": "120k-150k EUR",
+    "effort_flag": "medium",
+    "prep_level": 2,
+    "prep_notes": "Review domain knowledge.",
+}
+
+
+class TestParseValidJSON:
+    """Test parsing of well-formed JSON."""
+
+    def test_clean_json(self):
+        raw = json.dumps(VALID_PAYLOAD)
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+        assert result["reasoning"] == "Good match for the role requirements."
+
+    def test_json_with_whitespace(self):
+        raw = "  \n" + json.dumps(VALID_PAYLOAD) + "\n  "
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+
+class TestCodeFencedJSON:
+    """Test parsing of JSON wrapped in markdown code fences."""
+
+    def test_json_code_fence(self):
+        raw = "```json\n" + json.dumps(VALID_PAYLOAD) + "\n```"
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+    def test_plain_code_fence(self):
+        raw = "```\n" + json.dumps(VALID_PAYLOAD) + "\n```"
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+    def test_code_fence_with_trailing_whitespace(self):
+        raw = "```json\n" + json.dumps(VALID_PAYLOAD) + "\n```  \n"
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+
+class TestTrailingCommas:
+    """Test parsing of JSON with trailing commas (common LLM quirk)."""
+
+    def test_trailing_comma_in_object(self):
+        raw = '{"score": 7, "reasoning": "Good match",}'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+    def test_trailing_comma_in_nested(self):
+        raw = '{"score": 7, "tags": ["a", "b",], "reasoning": "OK",}'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+
+class TestSurroundingText:
+    """Test extraction of JSON from surrounding explanatory text."""
+
+    def test_text_before_json(self):
+        raw = 'Here is my analysis: {"score": 8, "reasoning": "Strong fit"}'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 8
+
+    def test_text_after_json(self):
+        raw = '{"score": 6, "reasoning": "Partial match"} Let me know if you need more.'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 6
+
+    def test_text_both_sides(self):
+        raw = 'Result: {"score": 9, "reasoning": "Excellent"} - done.'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 9
+
+    def test_nested_object_extraction(self):
+        raw = 'Here: {"score": 5, "details": {"note": "nested"}, "reasoning": "OK"} end'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 5
+        assert result["details"]["note"] == "nested"
+
+
+class TestSingleQuotes:
+    """Test parsing of JSON with single quotes instead of double quotes."""
+
+    def test_single_quotes(self):
+        raw = "{'score': 7, 'reasoning': 'Good match'}"
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+
+class TestEmptyAndNoneInput:
+    """Test handling of empty, None, and invalid input."""
+
+    def test_none_input(self):
+        assert parse_scoring_response(None) is None
+
+    def test_empty_string(self):
+        assert parse_scoring_response("") is None
+
+    def test_whitespace_only(self):
+        assert parse_scoring_response("   \n\t  ") is None
+
+    def test_completely_invalid_text(self):
+        assert parse_scoring_response("I cannot score this job posting.") is None
+
+    def test_truncated_json(self):
+        assert parse_scoring_response('{"score": 7, "reason') is None
+
+
+class TestEdgeCases:
+    """Test edge cases and combined quirks."""
+
+    def test_code_fence_with_trailing_comma(self):
+        raw = '```json\n{"score": 7, "reasoning": "OK",}\n```'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 7
+
+    def test_surrounding_text_with_trailing_comma(self):
+        raw = 'Result: {"score": 4, "reasoning": "Weak",} - end'
+        result = parse_scoring_response(raw)
+        assert result is not None
+        assert result["score"] == 4

--- a/tests/test_parse_scoring_response.py
+++ b/tests/test_parse_scoring_response.py
@@ -4,8 +4,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 # Ensure tools/ is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -161,7 +161,8 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
 
         if not description or description == "nan":
             # Use title + company + tags as description proxy
-            description = f"Title: {title}\nCompany: {company}\nLocation: {location}\nTags: {', '.join(job.get('tags', []))}"
+            tags = ", ".join(job.get("tags", []))
+            description = f"Title: {title}\nCompany: {company}\nLocation: {location}\nTags: {tags}"
 
         desc_truncated = description[:3000]
 
@@ -172,7 +173,13 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
                     {"role": "system", "content": SCORING_SYSTEM_PROMPT_WITH_REVIEW},
                     {
                         "role": "user",
-                        "content": f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\nADDITIONAL CONTEXT:\n{profile_context[:1000]}\n\nJOB POSTING:\nTitle: {title}\nCompany: {company}\nDescription: {desc_truncated}",
+                        "content": (
+                            f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\n"
+                            f"ADDITIONAL CONTEXT:\n{profile_context[:1000]}\n\n"
+                            f"JOB POSTING:\nTitle: {title}\n"
+                            f"Company: {company}\n"
+                            f"Description: {desc_truncated}"
+                        ),
                     },
                 ],
                 temperature=0.1,
@@ -422,7 +429,10 @@ def step_generate_digest(
     lines = [
         f"# Daily Job Scan — {config.date}",
         "",
-        f"**Pipeline mode:** {config.mode} | **Min score:** {config.min_score} | **Hours old:** {config.hours_old}h",
+        (
+            f"**Pipeline mode:** {config.mode} | **Min score:** "
+            f"{config.min_score} | **Hours old:** {config.hours_old}h"
+        ),
         "",
     ]
 
@@ -439,7 +449,10 @@ def step_generate_digest(
             f"- **Total scraped:** {len(all_scraped)}",
             f"- **After dedup + scoring:** {len(scored)}",
             f"- **Score >= {config.min_score} (new):** {len(filtered)}",
-            f"- **Score distribution:** {' | '.join(f'{s}/10: {c}' for s, c in sorted(score_dist.items(), reverse=True))}",
+            (
+                "- **Score distribution:** "
+                + " | ".join(f"{s}/10: {c}" for s, c in sorted(score_dist.items(), reverse=True))
+            ),
             "",
         ]
     )
@@ -465,7 +478,8 @@ def step_generate_digest(
             url = j.get("url", "")
             url_display = f"[Link]({url})" if url else "—"
             lines.append(
-                f"| {score}/10 | {company} | {title} | {loc} | {salary} | {effort} | {source} | {url_display} |"
+                f"| {score}/10 | {company} | {title} | {loc} "
+                f"| {salary} | {effort} | {source} | {url_display} |"
             )
 
         lines.append("")
@@ -480,9 +494,10 @@ def step_generate_digest(
         )
         for j in top5:
             url = j.get("url", "N/A")
-            lines.append(
-                f"- [{j.get('fit_score', '?')}/10] {j.get('company', '?')} — {j.get('title', '?')}: {url}"
-            )
+            score = j.get("fit_score", "?")
+            co = j.get("company", "?")
+            ttl = j.get("title", "?")
+            lines.append(f"- [{score}/10] {co} — {ttl}: {url}")
         lines.append("")
 
         # Reasoning details
@@ -493,9 +508,10 @@ def step_generate_digest(
             ]
         )
         for j in filtered[:15]:
-            lines.append(
-                f"**[{j.get('fit_score', '?')}/10] {j.get('company', '?')} — {j.get('title', '?')}**"
-            )
+            score = j.get("fit_score", "?")
+            co = j.get("company", "?")
+            ttl = j.get("title", "?")
+            lines.append(f"**[{score}/10] {co} — {ttl}**")
             lines.append(f"  - {j.get('fit_reasoning', 'No reasoning')}")
             if j.get("prep_notes"):
                 lines.append(f"  - Prep ({j.get('prep_level', '?')}/5): {j.get('prep_notes', '')}")
@@ -600,13 +616,14 @@ def run_pipeline() -> int:
     filtered = step_filter(config, new_jobs)
 
     # Step 5: Generate digest
-    digest = step_generate_digest(config, all_scraped, scored, filtered)
+    step_generate_digest(config, all_scraped, scored, filtered)
 
     # Print summary to stdout
     print("\n" + "=" * 60)
     print(f"DAILY PIPELINE COMPLETE — {config.date}")
     print(
-        f"Scraped: {len(all_scraped)} | Scored: {len(scored)} | New: {len(new_jobs)} | Above threshold: {len(filtered)}"
+        f"Scraped: {len(all_scraped)} | Scored: {len(scored)} "
+        f"| New: {len(new_jobs)} | Above threshold: {len(filtered)}"
     )
     print(f"Digest: {config.digest_path}")
     print("=" * 60)

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -127,6 +127,7 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
         PROFILE_CRITERIA,
         SCORING_SYSTEM_PROMPT_WITH_REVIEW,
         apply_hard_caps,
+        parse_scoring_response,
         pre_filter_job,
     )
 
@@ -178,11 +179,9 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
             )
 
             raw = response.choices[0].message.content.strip()
-            try:
-                result = json.loads(raw)
-            except json.JSONDecodeError:
-                # Handle single quotes from some models
-                result = json.loads(raw.replace("'", '"'))
+            result = parse_scoring_response(raw)
+            if result is None:
+                raise ValueError(f"Could not parse scoring response: {raw[:200]}")
 
             ai_score = int(result.get("score", 2))
 

--- a/tools/job_scorer.py
+++ b/tools/job_scorer.py
@@ -21,6 +21,123 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+
+# --------------------------------------------------------------------------
+# Robust JSON response parser
+# --------------------------------------------------------------------------
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before } or ] (common LLM output quirk)."""
+    return re.sub(r",\s*([}\]])", r"\1", text)
+
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Extract the first top-level JSON object using brace-depth counting.
+
+    Handles nested objects/arrays correctly, unlike a simple regex.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape_next = False
+
+    for i in range(start, len(text)):
+        ch = text[i]
+
+        if escape_next:
+            escape_next = False
+            continue
+
+        if ch == "\\":
+            if in_string:
+                escape_next = True
+            continue
+
+        if ch == '"':
+            in_string = not in_string
+            continue
+
+        if in_string:
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+
+    return None
+
+
+def parse_scoring_response(raw: str) -> dict | None:
+    """Parse AI scoring response, handling common LLM quirks.
+
+    Handles:
+    - Markdown code blocks (```json ... ```)
+    - Single quotes instead of double quotes
+    - Trailing commas before } or ]
+    - Extra text before/after JSON
+    - Nested objects (brace-depth counting)
+
+    Returns parsed dict or None on failure.
+    """
+    if not raw or not raw.strip():
+        return None
+
+    text = raw.strip()
+
+    # Strip markdown code fences
+    if text.startswith("```"):
+        # Remove opening fence (```json or ```)
+        first_newline = text.find("\n")
+        if first_newline > 0:
+            text = text[first_newline + 1 :]
+        # Remove closing fence
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3].rstrip()
+
+    # Try direct parse first (fast path)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try stripping trailing commas
+    try:
+        return json.loads(_strip_trailing_commas(text))
+    except json.JSONDecodeError:
+        pass
+
+    # Try replacing single quotes
+    try:
+        return json.loads(text.replace("'", '"'))
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting JSON object from surrounding text (handles nested objects)
+    extracted = _extract_first_json_object(text)
+    if extracted:
+        try:
+            return json.loads(extracted)
+        except json.JSONDecodeError:
+            # Try with trailing comma removal
+            try:
+                return json.loads(_strip_trailing_commas(extracted))
+            except json.JSONDecodeError:
+                # Try with single quote replacement
+                try:
+                    return json.loads(extracted.replace("'", '"'))
+                except json.JSONDecodeError:
+                    pass
+
+    return None
+
+
 # --------------------------------------------------------------------------
 # Profile loading -- reads from config/personal.yaml with generic defaults
 # --------------------------------------------------------------------------
@@ -692,26 +809,30 @@ def score_job(
         temperature=0.3,
     )
 
-    try:
-        result = json.loads(response.choices[0].message.content)
-        return (
-            int(result["score"]),
-            result["reasoning"],
-            result.get("estimated_salary", "unknown"),
-            result.get("effort_flag", "unknown"),
-            int(result.get("prep_level", 0)),
-            result.get("prep_notes", "unknown"),
-        )
-    except (json.JSONDecodeError, KeyError, ValueError):
-        # Fallback to 2 (not 5) -- unknown jobs should not pass the filter
-        return (
-            2,
-            f"Parse error: {response.choices[0].message.content[:100]}",
-            "unknown",
-            "unknown",
-            0,
-            "unknown",
-        )
+    raw_content = response.choices[0].message.content
+    result = parse_scoring_response(raw_content)
+    if result is not None:
+        try:
+            return (
+                int(result["score"]),
+                result["reasoning"],
+                result.get("estimated_salary", "unknown"),
+                result.get("effort_flag", "unknown"),
+                int(result.get("prep_level", 0)),
+                result.get("prep_notes", "unknown"),
+            )
+        except (KeyError, ValueError):
+            pass
+
+    # Fallback to 2 (not 5) -- unknown jobs should not pass the filter
+    return (
+        2,
+        f"Parse error: {(raw_content or '')[:100]}",
+        "unknown",
+        "unknown",
+        0,
+        "unknown",
+    )
 
 
 def main():

--- a/tools/job_scorer.py
+++ b/tools/job_scorer.py
@@ -166,13 +166,20 @@ def _load_profile():
         "location": cfg.get("location", _DEFAULT_PROFILE["location"]),
         "salary_min": cfg.get("salary_range", _DEFAULT_PROFILE["salary_range"]).get("min", 80000),
         "salary_max": cfg.get("salary_range", _DEFAULT_PROFILE["salary_range"]).get("max", 140000),
-        "salary_currency": cfg.get("salary_range", _DEFAULT_PROFILE["salary_range"]).get("currency", "EUR"),
+        "salary_currency": cfg.get("salary_range", _DEFAULT_PROFILE["salary_range"]).get(
+            "currency", "EUR"
+        ),
         "languages": cfg.get("languages", _DEFAULT_PROFILE["languages"]),
         "values": cfg.get("values", _DEFAULT_PROFILE["values"]),
     }
 
 
 _PROFILE = _load_profile()
+
+_salary_min_k = _PROFILE["salary_min"] // 1000
+_salary_max_k = _PROFILE["salary_max"] // 1000
+_salary_floor_k = _PROFILE["salary_min"] * 3 // 4 // 1000
+_salary_cur = _PROFILE["salary_currency"]
 
 PROFILE_CRITERIA = f"""
 Ideal candidate profile for job scoring:
@@ -200,14 +207,15 @@ RED FLAGS (score down):
 - "Must have 10+ years in [narrow specialty]"
 
 SALARY & EFFORT CONTEXT:
-- Target: {_PROFILE["salary_min"]//1000}-{_PROFILE["salary_max"]//1000}k {_PROFILE["salary_currency"]} base. Below {_PROFILE["salary_min"]*3//4//1000}k is a dealbreaker unless exceptional trajectory.
+- Target: {_salary_min_k}-{_salary_max_k}k {_salary_cur} base. \
+Below {_salary_floor_k}k is a dealbreaker unless exceptional trajectory.
 - Sweet spot: Staff/Lead at Series B-D (PMF achieved, reasonable hours, real equity).
 - Green flags: "sustainable pace", "work-life balance", 4-day week, async-first.
 - If salary not posted, estimate based on company stage, role level, and location.
 
 SALARY SCORING:
-- Include 'estimated_salary' (string, e.g. "110-130k EUR") in your response.
-- Include 'effort_flag' (string: "sweet-spot", "moderate", "high-intensity", or "unknown") in your response.
+- Include 'estimated_salary' (string, e.g. "110-130k EUR") in response.
+- Include 'effort_flag' ("sweet-spot", "moderate", "high-intensity", or "unknown").
 
 PREPARATION TOUGHNESS:
 - Include 'prep_level' (integer 1-5) estimating interview prep needed:
@@ -232,7 +240,7 @@ SCORING_SYSTEM_PROMPT_BASE = (
     "- Building AI tools: LLM pipelines, MCP servers, agentic systems\n"
     f"- Target roles: {', '.join(_PROFILE['target_roles'])}\n"
     f"- Location: {_PROFILE['location']}. Remote EU/EMEA OK.\n"
-    f"- Salary: {_PROFILE['salary_min']//1000}-{_PROFILE['salary_max']//1000}k {_PROFILE['salary_currency']} base\n"
+    f"- Salary: {_salary_min_k}-{_salary_max_k}k {_salary_cur} base\n"
     f"- Languages: {_PROFILE['languages']}\n"
     f"- Values: {', '.join(_PROFILE['values'])}\n\n"
     "TARGET DISTRIBUTION (enforce strictly):\n"
@@ -251,7 +259,7 @@ SCORING_SYSTEM_PROMPT_BASE = (
     "  (a) AI-native company OR company with strong AI-first mandate\n"
     f"  (b) Exact role match: {', '.join(_PROFILE['target_roles'][:4])}\n"
     f"  (c) {_PROFILE['location']} or fully remote EU\n"
-    f"  (d) {_PROFILE['salary_min']//1000}k+ {_PROFILE['salary_currency']} realistic salary\n"
+    f"  (d) {_PROFILE['salary_min'] // 1000}k+ {_PROFILE['salary_currency']} realistic salary\n"
     "  (e) High autonomy signals: small team, builder culture, ships product\n"
     f"  (f) Values alignment: {', '.join(_PROFILE['values'][:3])}\n"
     "Missing even ONE of (a)-(d) means it CANNOT be 9-10.\n\n"
@@ -260,7 +268,7 @@ SCORING_SYSTEM_PROMPT_BASE = (
     "  (a) AI/ML is central to the role or company\n"
     "  (b) Role type matches target roles\n"
     f"  (c) EU-compatible location ({_PROFILE['location']}, remote EU)\n"
-    f"  (d) Salary {_PROFILE['salary_min']//1000}k+ {_PROFILE['salary_currency']} realistic\n"
+    f"  (d) Salary {_PROFILE['salary_min'] // 1000}k+ {_PROFILE['salary_currency']} realistic\n"
     "  (e) Autonomy/builder signals in JD\n"
     "A role at a great company but in the wrong function is NOT 7-8.\n"
     "A perfect role type at a non-tech company is NOT 7-8.\n\n"
@@ -557,7 +565,6 @@ EU_LOCATIONS: list[str] = [
 ]
 
 
-
 # --------------------------------------------------------------------------
 # Hard caps -- post-scoring enforcement AFTER AI or fallback scoring
 # --------------------------------------------------------------------------
@@ -568,17 +575,41 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # Sales/finance/HR/legal/healthcare/support titles: MAX 1
     (
         [
-            "sales", "account executive", "sdr", "bdr",
-            "accountant", "accounting", "bookkeeper", "payroll",
-            "tax ", "auditor", "treasury", "financial analyst",
-            "fincrime", "financial crime",
-            "hr specialist", "hr manager", "hr generalist", "recruiter",
-            "talent acquisition", "people ops",
-            "paralegal", "legal counsel", "compliance officer",
-            "nurse", "nursing", "physician", "therapist", "pharmacist",
+            "sales",
+            "account executive",
+            "sdr",
+            "bdr",
+            "accountant",
+            "accounting",
+            "bookkeeper",
+            "payroll",
+            "tax ",
+            "auditor",
+            "treasury",
+            "financial analyst",
+            "fincrime",
+            "financial crime",
+            "hr specialist",
+            "hr manager",
+            "hr generalist",
+            "recruiter",
+            "talent acquisition",
+            "people ops",
+            "paralegal",
+            "legal counsel",
+            "compliance officer",
+            "nurse",
+            "nursing",
+            "physician",
+            "therapist",
+            "pharmacist",
             "clinical",
-            "customer support", "customer service", "help desk",
-            "support analyst", "support specialist", "support technician",
+            "customer support",
+            "customer service",
+            "help desk",
+            "support analyst",
+            "support specialist",
+            "support technician",
         ],
         1,
         "sales_finance_hr_legal_healthcare_support",
@@ -592,12 +623,20 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # Marketing/media/SEO/CRM/content titles: MAX 2
     (
         [
-            "marketing manager", "seo ", "seo specialist",
-            "content writer", "copywriter", "social media",
-            "content reviewer", "content moderator",
-            "crm manager", "crm specialist",
-            "media buyer", "media planner",
-            "affiliate marketing", "marketing operations",
+            "marketing manager",
+            "seo ",
+            "seo specialist",
+            "content writer",
+            "copywriter",
+            "social media",
+            "content reviewer",
+            "content moderator",
+            "crm manager",
+            "crm specialist",
+            "media buyer",
+            "media planner",
+            "affiliate marketing",
+            "marketing operations",
         ],
         2,
         "marketing_media_seo_crm",
@@ -606,9 +645,14 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # Allowlist: if title also contains "product", skip this cap
     (
         [
-            "graphic designer", "visual designer", "ui designer",
-            "ux designer", "ux researcher", "interaction designer",
-            "motion designer", "brand designer",
+            "graphic designer",
+            "visual designer",
+            "ui designer",
+            "ux designer",
+            "ux researcher",
+            "interaction designer",
+            "motion designer",
+            "brand designer",
         ],
         3,
         "design_ux_no_product",
@@ -616,8 +660,13 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # Junior/entry-level: MAX 1
     (
         [
-            "junior ", "entry level", "entry-level", "intern ",
-            "internship", "werkstudent", "working student",
+            "junior ",
+            "entry level",
+            "entry-level",
+            "intern ",
+            "internship",
+            "werkstudent",
+            "working student",
         ],
         1,
         "junior_entry_level",
@@ -625,8 +674,11 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # DevOps/SRE (no AI/product): MAX 3
     (
         [
-            "devops", "site reliability", "sre ",
-            "infrastructure engineer", "platform engineer",
+            "devops",
+            "site reliability",
+            "sre ",
+            "infrastructure engineer",
+            "platform engineer",
         ],
         3,
         "devops_sre_no_ai_product",
@@ -634,11 +686,19 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
     # Pure backend/frontend engineer (no PM/product in title): MAX 4
     (
         [
-            "backend engineer", "frontend engineer", "fullstack engineer",
-            "full stack engineer", "full-stack engineer",
-            "software engineer", "software developer",
-            "web developer", "java developer", "python developer",
-            ".net developer", "golang developer", "rust developer",
+            "backend engineer",
+            "frontend engineer",
+            "fullstack engineer",
+            "full stack engineer",
+            "full-stack engineer",
+            "software engineer",
+            "software developer",
+            "web developer",
+            "java developer",
+            "python developer",
+            ".net developer",
+            "golang developer",
+            "rust developer",
         ],
         4,
         "pure_engineer_no_product",
@@ -647,12 +707,22 @@ HARD_CAP_RULES: list[tuple[list[str], int, str]] = [
 
 # Title keywords that exempt a job from certain caps
 PRODUCT_KEYWORDS = [
-    "product", "pm ", "tpm", "program manager",
-    "devrel", "developer advocate", "developer relations",
+    "product",
+    "pm ",
+    "tpm",
+    "program manager",
+    "devrel",
+    "developer advocate",
+    "developer relations",
 ]
 AI_KEYWORDS = [
-    "ai ", "ai/ml", "machine learning", "ml ",
-    "artificial intelligence", "llm", "genai",
+    "ai ",
+    "ai/ml",
+    "machine learning",
+    "ml ",
+    "artificial intelligence",
+    "llm",
+    "genai",
 ]
 
 
@@ -696,8 +766,12 @@ def apply_hard_caps(jobs: list[dict]) -> list[dict]:
             if cap_name == "junior_entry_level":
                 # Don't cap if title also has senior/lead/staff
                 senior_kws = [
-                    "lead", "senior", "staff",
-                    "principal", "head", "director",
+                    "lead",
+                    "senior",
+                    "staff",
+                    "principal",
+                    "head",
+                    "director",
                 ]
                 if any(kw in title_lower for kw in senior_kws):
                     continue
@@ -716,17 +790,14 @@ def apply_hard_caps(jobs: list[dict]) -> list[dict]:
         if current_score > 3 and not job.get("cap_applied"):
             is_remote = bool(job.get("remote", False))
             has_eu_signal = any(eu in location_lower for eu in EU_LOCATIONS)
-            has_us_signal = any(
-                us in location_lower for us in US_ONLY_LOCATIONS
-            )
+            has_us_signal = any(us in location_lower for us in US_ONLY_LOCATIONS)
             if has_us_signal and not has_eu_signal and not is_remote:
                 job["fit_score"] = 3
                 job["cap_applied"] = True
                 job["cap_reason"] = "us_only_non_remote"
                 job["fit_reasoning"] = (
                     f"Hard-capped from {current_score} to 3 "
-                    f"(us_only_non_remote): "
-                    + (job.get("fit_reasoning") or "")
+                    f"(us_only_non_remote): " + (job.get("fit_reasoning") or "")
                 )
 
     return jobs
@@ -760,9 +831,8 @@ def pre_filter_job(
 
     # 2b. Reject by title with allowlist (skip if qualifying word present)
     for pattern, allowlist in REJECT_WITH_ALLOWLIST.items():
-        if pattern in title_lower:
-            if not any(q in title_lower for q in allowlist):
-                return True, f"Rejected title pattern: '{pattern}' in '{title}'", None
+        if pattern in title_lower and not any(q in title_lower for q in allowlist):
+            return True, f"Rejected title pattern: '{pattern}' in '{title}'", None
 
     # 2c. Reject by regex (word-boundary patterns)
     for rx in REJECT_TITLE_REGEX:
@@ -773,11 +843,10 @@ def pre_filter_job(
     if any(
         kw in title_lower
         for kw in ["junior ", "intern ", "internship", "werkstudent", "working student"]
+    ) and not any(
+        kw in title_lower for kw in ["lead", "senior", "staff", "principal", "head", "director"]
     ):
-        if not any(
-            kw in title_lower for kw in ["lead", "senior", "staff", "principal", "head", "director"]
-        ):
-            return True, f"Junior role: {title}", None
+        return True, f"Junior role: {title}", None
 
     # 4. US-only location cap (unless explicitly remote)
     if not remote and not any(eu in location_lower for eu in EU_LOCATIONS):
@@ -791,7 +860,10 @@ def pre_filter_job(
 def score_job(
     client, title: str, company: str, description: str
 ) -> tuple[int, str, str, str, int, str]:
-    """Score a single job posting. Returns (score, reasoning, salary, effort, prep_level, prep_notes)."""
+    """Score a single job posting.
+
+    Returns (score, reasoning, salary, effort, prep_level, prep_notes).
+    """
     if not description or pd.isna(description):
         return 0, "No description available", "unknown", "unknown", 0, ""
 
@@ -803,7 +875,12 @@ def score_job(
             {"role": "system", "content": SCORING_SYSTEM_PROMPT},
             {
                 "role": "user",
-                "content": f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\nJOB POSTING:\nTitle: {title}\nCompany: {company}\nDescription: {desc_truncated}",
+                "content": (
+                    f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\n"
+                    f"JOB POSTING:\nTitle: {title}\n"
+                    f"Company: {company}\n"
+                    f"Description: {desc_truncated}"
+                ),
             },
         ],
         temperature=0.3,
@@ -872,7 +949,7 @@ def main():
     prep_notes_list = []
 
     skipped = 0
-    for i, row in df.iterrows():
+    for _i, row in df.iterrows():
         title = row.get("title", "Unknown")
         company = row.get("company", "Unknown")
         location = row.get("location", "")


### PR DESCRIPTION
## Summary
- Port `parse_scoring_response()` from CareerOS to Kestrel as a shared utility in `tools/job_scorer.py`
- Handles common LLM output quirks: markdown code fences, trailing commas, single quotes, surrounding text, and nested JSON objects via brace-depth counting
- Wire into both `score_job()` (job_scorer.py) and `step_score()` (daily_pipeline.py), replacing fragile `json.loads()` calls

## Test plan
- [x] 18 test cases in `tests/test_parse_scoring_response.py` covering valid JSON, code-fenced, trailing commas, surrounding text, nested objects, single quotes, empty/None
- [x] All 42 tests pass (`pytest tests/test_parse_scoring_response.py tests/test_daily_pipeline.py -x -q --timeout=30`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)