### PR TITLE
feat(G-394): rename CLI entry point from career to kestrel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Database (database.py, config.py)   → SQLite (WAL mode), async via aiosqlite
 - **Discovery Engine** (`src/career_os/discovery/`): Scrapes multiple job boards via python-jobspy. Adapters normalize results. Scheduler runs as asyncio background task during app lifespan.
 - **Application State Machine**: Status transitions enforced in `src/career_os/schemas/applications.py` via `VALID_TRANSITIONS` dict (not in service layer).
 - **Schemas parallel API routes**: Each domain (applications, skills, contacts...) has matching files in `api/`, `services/`, `models/`, `schemas/`.
-- **CLI** (`src/career_os/cli/`): Typer-based, entry points `kestrel` and `career` in pyproject.toml. Subcommands: pipeline, skills, goals, interview-prep, contacts.
+- **CLI** (`src/career_os/cli/`): Typer-based, primary entry point `kestrel` with `career` as a backward-compatible alias (both in pyproject.toml). Subcommands: pipeline, skills, goals, interview-prep, contacts.
 - **Auto-migration**: Alembic runs automatically on app startup via `_auto_migrate()` in `main.py`.
 
 ### Web Frontend

--- a/docs/validation-contract-m2-skills.md
+++ b/docs/validation-contract-m2-skills.md
@@ -149,24 +149,24 @@ When a user completes learning items or achieves goals, the coaching suggestions
 ## CLI Commands
 
 ### VAL-CLI-SKILL-001: List skills via CLI
-`career skills list` outputs the full skills inventory in a formatted table with columns: Name, Category, Proficiency, Source. Supports `--category technical` and `--source cv.yaml` filters.
-**Evidence:** Running `career skills list --category technical` prints a table containing only technical skills; exit code 0.
+`kestrel skills list` outputs the full skills inventory in a formatted table with columns: Name, Category, Proficiency, Source. Supports `--category technical` and `--source cv.yaml` filters.
+**Evidence:** Running `kestrel skills list --category technical` prints a table containing only technical skills; exit code 0.
 
 ### VAL-CLI-SKILL-002: Gap analysis via CLI
-`career skills gaps --application <id>` outputs the gap report for a specific application: skill name, required level, current level, severity, distance. Supports `--severity critical` to filter.
-**Evidence:** Running `career skills gaps --application 1 --severity critical` prints only critical gaps; exit code 0.
+`kestrel skills gaps --application <id>` outputs the gap report for a specific application: skill name, required level, current level, severity, distance. Supports `--severity critical` to filter.
+**Evidence:** Running `kestrel skills gaps --application 1 --severity critical` prints only critical gaps; exit code 0.
 
 ### VAL-CLI-SKILL-003: Career goals via CLI
-`career goals` lists all active goals with title, type, target date, and overall progress percentage. `career goals show <id>` displays the full reality map for a specific goal.
-**Evidence:** Running `career goals` prints a goals table; `career goals show 1` prints the reality map with current vs. required state; exit code 0.
+`kestrel goals` lists all active goals with title, type, target date, and overall progress percentage. `kestrel goals show <id>` displays the full reality map for a specific goal.
+**Evidence:** Running `kestrel goals` prints a goals table; `kestrel goals show 1` prints the reality map with current vs. required state; exit code 0.
 
 ### VAL-CLI-SKILL-004: Coaching via CLI
-`career coach` outputs the top 5 coaching suggestions with effort estimates. `career coach --all` shows the full list.
-**Evidence:** Running `career coach` prints 5 prioritized suggestions with effort hours; exit code 0.
+`kestrel coach` outputs the top 5 coaching suggestions with effort estimates. `kestrel coach --all` shows the full list.
+**Evidence:** Running `kestrel coach` prints 5 prioritized suggestions with effort hours; exit code 0.
 
 ### VAL-CLI-SKILL-005: Aggregate gaps via CLI
-`career skills gaps --aggregate` outputs the cross-application gap summary: most common missing skills ranked by frequency and severity.
-**Evidence:** Running `career skills gaps --aggregate` prints a ranked table of skills appearing as gaps across applications; exit code 0.
+`kestrel skills gaps --aggregate` outputs the cross-application gap summary: most common missing skills ranked by frequency and severity.
+**Evidence:** Running `kestrel skills gaps --aggregate` prints a ranked table of skills appearing as gaps across applications; exit code 0.
 
 ---
 

--- a/docs/validation/M1_VALIDATION_CONTRACT.md
+++ b/docs/validation/M1_VALIDATION_CONTRACT.md
@@ -22,7 +22,7 @@ On first startup, the backend creates (or migrates) a SQLite database file at th
 **Evidence:** `sqlite3 data/career_os.db ".tables"` lists all expected tables. No migration errors in backend logs.
 
 ### VAL-INFRA-004: Typer CLI is installable and responds to --help
-Running `career --help` (or `python -m career_os --help`) prints the top-level command group with subcommands including `pipeline`, and exits 0.  
+Running `kestrel --help` (or `career --help` as alias) (or `python -m career_os --help`) prints the top-level command group with subcommands including `pipeline`, and exits 0.  
 **Evidence:** Terminal output shows help text with `pipeline` subcommand listed. Exit code is 0.
 
 ### VAL-INFRA-005: Docker Compose orchestrates full stack
@@ -145,36 +145,36 @@ Loading the analytics page with zero applications shows placeholder messages or 
 
 ## CLI Pipeline Commands (VAL-CLI-PIPE)
 
-### VAL-CLI-PIPE-001: `career pipeline list` shows all applications
-Running `career pipeline list` prints a table of all applications with columns: ID, Company, Role, Status, Fit Score, Date Applied. The output is sorted by date (newest first) by default. With migrated data, shows 42+ rows.  
+### VAL-CLI-PIPE-001: `kestrel pipeline list` shows all applications
+Running `kestrel pipeline list` prints a table of all applications with columns: ID, Company, Role, Status, Fit Score, Date Applied. The output is sorted by date (newest first) by default. With migrated data, shows 42+ rows.  
 **Evidence:** Terminal output showing the table. Row count matches database. Columns are aligned and readable.
 
-### VAL-CLI-PIPE-002: `career pipeline list --status applied` filters by status
-Running `career pipeline list --status applied` shows only applications with status "applied". The count matches the number of applied applications in the database.  
+### VAL-CLI-PIPE-002: `kestrel pipeline list --status applied` filters by status
+Running `kestrel pipeline list --status applied` shows only applications with status "applied". The count matches the number of applied applications in the database.  
 **Evidence:** Terminal output filtered to "applied" only. Cross-check with `sqlite3 data/career_os.db "SELECT COUNT(*) FROM applications WHERE status='applied'"`.
 
-### VAL-CLI-PIPE-003: `career pipeline add` creates a new application
-Running `career pipeline add --company "TestCorp" --role "Engineer" --url "https://example.com" --source "manual"` creates a new application in "discovered" status. The CLI confirms creation with the new application ID. The application appears in the web UI Kanban board.  
-**Evidence:** CLI output shows "Application created: ID=XX". `career pipeline list` shows the new entry. Web UI Kanban board shows the card in "Discovered" column after refresh.
+### VAL-CLI-PIPE-003: `kestrel pipeline add` creates a new application
+Running `kestrel pipeline add --company "TestCorp" --role "Engineer" --url "https://example.com" --source "manual"` creates a new application in "discovered" status. The CLI confirms creation with the new application ID. The application appears in the web UI Kanban board.  
+**Evidence:** CLI output shows "Application created: ID=XX". `kestrel pipeline list` shows the new entry. Web UI Kanban board shows the card in "Discovered" column after refresh.
 
-### VAL-CLI-PIPE-004: `career pipeline update` changes application fields
-Running `career pipeline update <id> --status interested --notes "Great fit"` updates the application's status and notes. The change is reflected in both `career pipeline list` and the web UI.  
-**Evidence:** CLI output confirms update. `career pipeline list` shows new status. Web UI detail page shows updated notes and status. Activity log records the CLI-initiated change with `source=cli`.
+### VAL-CLI-PIPE-004: `kestrel pipeline update` changes application fields
+Running `kestrel pipeline update <id> --status interested --notes "Great fit"` updates the application's status and notes. The change is reflected in both `kestrel pipeline list` and the web UI.  
+**Evidence:** CLI output confirms update. `kestrel pipeline list` shows new status. Web UI detail page shows updated notes and status. Activity log records the CLI-initiated change with `source=cli`.
 
-### VAL-CLI-PIPE-005: `career pipeline stats` shows summary statistics
-Running `career pipeline stats` prints a summary including: total applications, count per status, average fit score, top companies by application count, and date range of applications.  
+### VAL-CLI-PIPE-005: `kestrel pipeline stats` shows summary statistics
+Running `kestrel pipeline stats` prints a summary including: total applications, count per status, average fit score, top companies by application count, and date range of applications.  
 **Evidence:** Terminal output showing all summary fields. Numbers match database aggregates.
 
-### VAL-CLI-PIPE-006: `career pipeline follow-ups` lists due follow-ups
-Running `career pipeline follow-ups` (or `career follow-ups`) lists all follow-ups due today or overdue, with: application company/role, due date, type, and days overdue. With no due follow-ups, prints "No follow-ups due. You're all caught up!".  
+### VAL-CLI-PIPE-006: `kestrel pipeline follow-ups` lists due follow-ups
+Running `kestrel pipeline follow-ups` (or `kestrel follow-ups`) lists all follow-ups due today or overdue, with: application company/role, due date, type, and days overdue. With no due follow-ups, prints "No follow-ups due. You're all caught up!".  
 **Evidence:** With an overdue follow-up in the system, the CLI output shows it with correct days-overdue count. With none due, shows the friendly message.
 
 ### VAL-CLI-PIPE-007: CLI error handling for invalid input
-Running `career pipeline add` without required arguments prints a clear usage error message with the required fields listed (not a Python traceback). Running `career pipeline update 99999 --status applied` with a nonexistent ID prints "Application not found" (not a crash).  
+Running `kestrel pipeline add` without required arguments prints a clear usage error message with the required fields listed (not a Python traceback). Running `kestrel pipeline update 99999 --status applied` with a nonexistent ID prints "Application not found" (not a crash).  
 **Evidence:** Terminal output for both error cases shows user-friendly messages. Exit codes are non-zero. No Python tracebacks visible.
 
 ### VAL-CLI-PIPE-008: CLI and web UI share the same database
-An application created via CLI (`career pipeline add`) is immediately visible in the web UI (after page refresh). An application created via web UI is immediately visible via CLI (`career pipeline list`). Both use the same SQLite database file.  
+An application created via CLI (`kestrel pipeline add`) is immediately visible in the web UI (after page refresh). An application created via web UI is immediately visible via CLI (`kestrel pipeline list`). Both use the same SQLite database file.  
 **Evidence:** Create via CLI → verify in web UI. Create via web UI → verify in CLI. Both reference the same `data/career_os.db` file.
 
 ---

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -1,4 +1,4 @@
-"""Career OS CLI — main entry point."""
+"""Kestrel CLI — main entry point."""
 
 from __future__ import annotations
 
@@ -28,8 +28,8 @@ console = Console()
 _HELP_OUTPUT_FORMAT = "Output format: table or json"
 
 app = typer.Typer(
-    name="career",
-    help="Career OS — AI-Powered Job Search & Career Strategy Platform",
+    name="kestrel",
+    help="Kestrel — AI-Powered Job Search & Career Strategy Platform",
     no_args_is_help=True,
 )
 
@@ -58,7 +58,7 @@ goals_app = typer.Typer(
 app.add_typer(goals_app, name="goals")
 
 # Interview-prep subcommand group (uses Click Group to handle both
-# `career interview-prep <id>` and `career interview-prep stories <subcmd>`)
+# `kestrel interview-prep <id>` and `kestrel interview-prep stories <subcmd>`)
 
 
 class InterviewPrepGroup(typer_core.TyperGroup):
@@ -118,7 +118,7 @@ def _get_default_profile(db: Session) -> Profile:
 
 
 # ---------------------------------------------------------------------------
-# career pipeline list
+# kestrel pipeline list
 # ---------------------------------------------------------------------------
 
 
@@ -179,7 +179,7 @@ def pipeline_list(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline add
+# kestrel pipeline add
 # ---------------------------------------------------------------------------
 
 
@@ -227,7 +227,7 @@ def pipeline_add(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline update
+# kestrel pipeline update
 # ---------------------------------------------------------------------------
 
 
@@ -329,7 +329,7 @@ def pipeline_update(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline stats
+# kestrel pipeline stats
 # ---------------------------------------------------------------------------
 
 
@@ -420,7 +420,7 @@ def pipeline_stats() -> None:
 
 
 # ---------------------------------------------------------------------------
-# career pipeline follow-ups
+# kestrel pipeline follow-ups
 # ---------------------------------------------------------------------------
 
 
@@ -486,7 +486,7 @@ def pipeline_follow_ups() -> None:
 
 
 # ---------------------------------------------------------------------------
-# career skills list
+# kestrel skills list
 # ---------------------------------------------------------------------------
 
 
@@ -552,7 +552,7 @@ def skills_list(
 
 
 # ---------------------------------------------------------------------------
-# career skills gaps
+# kestrel skills gaps
 # ---------------------------------------------------------------------------
 
 
@@ -736,7 +736,7 @@ def _show_aggregate_gaps(db: Session, profile_id: int, aggregate_fn) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career goals (list + show)
+# kestrel goals (list + show)
 # ---------------------------------------------------------------------------
 
 
@@ -868,7 +868,7 @@ def goals_show(
 
 
 # ---------------------------------------------------------------------------
-# career coach
+# kestrel coach
 # ---------------------------------------------------------------------------
 
 
@@ -998,7 +998,7 @@ def _is_valid_url(url: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# career discover
+# kestrel discover
 # ---------------------------------------------------------------------------
 
 
@@ -1222,7 +1222,7 @@ def _handle_schedule(
 
 
 # ---------------------------------------------------------------------------
-# career score <url>
+# kestrel score <url>
 # ---------------------------------------------------------------------------
 
 
@@ -1436,7 +1436,7 @@ def _score_output_json(scored) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career market
+# kestrel market
 # ---------------------------------------------------------------------------
 
 
@@ -1477,7 +1477,7 @@ def market(
         if not has_data:
             console.print(
                 "[yellow]No market data available. "
-                "Run `career discover` first to populate market intelligence.[/yellow]"
+                "Run `kestrel discover` first to populate market intelligence.[/yellow]"
             )
             return
 
@@ -1675,7 +1675,7 @@ def _run_interview_prep_async(
 
 
 # ---------------------------------------------------------------------------
-# career research <company>
+# kestrel research <company>
 # ---------------------------------------------------------------------------
 
 
@@ -1825,7 +1825,7 @@ def _render_research_report(report) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career interview-prep <application_id> (default command)
+# kestrel interview-prep <application_id> (default command)
 # ---------------------------------------------------------------------------
 
 
@@ -1974,7 +1974,7 @@ def _render_interview_prep(prep) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career interview-prep stories (list / add / view / edit)
+# kestrel interview-prep stories (list / add / view / edit)
 # ---------------------------------------------------------------------------
 
 
@@ -2010,7 +2010,7 @@ def stories_list_default(ctx: typer.Context) -> None:
         if not stories:
             console.print(
                 "[yellow]No STAR stories yet. "
-                "Add one with: career interview-prep stories add[/yellow]"
+                "Add one with: kestrel interview-prep stories add[/yellow]"
             )
             return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,14 +44,14 @@ def db_session(monkeypatch, tmp_path):
 
 
 def test_career_help() -> None:
-    """career --help exits 0 and shows help text."""
+    """kestrel --help exits 0 and shows help text."""
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "Career OS" in result.output
+    assert "Kestrel" in result.output
 
 
 def test_pipeline_subcommand_present() -> None:
-    """career --help lists pipeline as a subcommand."""
+    """kestrel --help lists pipeline as a subcommand."""
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "pipeline" in result.output


### PR DESCRIPTION
## Summary

- Renames the primary CLI entry point from `career` to `kestrel` to match the project name
- Keeps `career` as a backward-compatible alias (both defined in pyproject.toml `[project.scripts]`)
- Updates Typer app name/help text, all code comments, test assertions, and validation docs

## Files changed

- `src/career_os/cli/main.py` - app name, help text, section comments
- `tests/test_cli.py` - help text assertion updated
- `CLAUDE.md` - documents kestrel as primary, career as alias
- `docs/validation/M1_VALIDATION_CONTRACT.md` - CLI examples use `kestrel`
- `docs/validation-contract-m2-skills.md` - CLI examples use `kestrel`

## Test plan

- [x] All 6 CLI tests pass (`pytest tests/test_cli.py`)
- [x] Full test suite: 1389 passed (2 pre-existing failures unrelated)
- [ ] `pip install -e .` and verify both `kestrel --help` and `career --help` work

Generated with [Claude Code](https://claude.com/claude-code)