### PR TITLE
feat(G-427): cache break detection — alert on prompt cache invalidation

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -13,6 +13,7 @@ import logging
 import httpx
 
 from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
+from career_os.ai.cache_monitor import record_cache_event
 from career_os.ai.observability import observe, update_current_generation
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
@@ -179,6 +180,9 @@ class AnthropicProvider(AIProvider):
                 cache_creation_input_tokens=usage_data.get("cache_creation_input_tokens", 0),
                 cache_read_input_tokens=usage_data.get("cache_read_input_tokens", 0),
             )
+
+            # Track cache hit/miss for break detection
+            record_cache_event(feature, usage)
 
             # Try to parse structured data for known features
             structured = _try_parse_structured(content, feature)

--- a/src/career_os/ai/cache_monitor.py
+++ b/src/career_os/ai/cache_monitor.py
@@ -1,0 +1,138 @@
+"""Cache break detection for Anthropic prompt caching.
+
+Tracks cache hit/miss ratios per AIFeature over a sliding window.
+Logs warnings when the cache hit ratio drops below a configurable
+threshold, indicating that the cached system prompt prefix is being
+invalidated between calls (a "cache break").
+
+Usage:
+    from career_os.ai.cache_monitor import record_cache_event, get_cache_stats
+
+    # After each Anthropic response:
+    record_cache_event(feature, usage)
+
+    # Query stats:
+    stats = get_cache_stats()
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from career_os.schemas.ai import AIFeature, TokenUsage
+
+logger = logging.getLogger(__name__)
+
+# Sliding window size and alert threshold
+_WINDOW_SIZE = 100
+_ALERT_THRESHOLD = 0.80  # Warn if hit ratio drops below 80%
+
+
+@dataclass
+class _FeatureWindow:
+    """Sliding window of cache hit/miss events for a single feature."""
+
+    events: deque[bool] = field(default_factory=lambda: deque(maxlen=_WINDOW_SIZE))
+    total_hits: int = 0
+    total_misses: int = 0
+    alert_fired: bool = False
+
+    @property
+    def hit_ratio(self) -> float:
+        """Cache hit ratio over the current window (0.0 to 1.0)."""
+        if not self.events:
+            return 1.0  # No data yet — assume healthy
+        return sum(self.events) / len(self.events)
+
+    @property
+    def window_size(self) -> int:
+        return len(self.events)
+
+
+# Per-feature sliding windows (module-level state, reset via _reset())
+_windows: dict[str, _FeatureWindow] = {}
+
+
+def record_cache_event(feature: AIFeature, usage: TokenUsage | None) -> None:
+    """Record a cache hit or miss from an Anthropic API response.
+
+    A cache **hit** means cache_read_input_tokens > 0.
+    A cache **miss** means cache_creation_input_tokens > 0 and
+    cache_read_input_tokens == 0.
+    Calls with no cache tokens (non-Anthropic providers) are ignored.
+
+    Logs a warning when the hit ratio drops below the alert threshold.
+    """
+    if usage is None:
+        return
+
+    # Only track calls that interacted with the cache system
+    has_cache_activity = usage.cache_read_input_tokens > 0 or usage.cache_creation_input_tokens > 0
+    if not has_cache_activity:
+        return
+
+    is_hit = usage.cache_read_input_tokens > 0
+    key = feature.value
+
+    if key not in _windows:
+        _windows[key] = _FeatureWindow()
+
+    w = _windows[key]
+    w.events.append(is_hit)
+    if is_hit:
+        w.total_hits += 1
+    else:
+        w.total_misses += 1
+
+    # Check alert threshold once we have enough data
+    if w.window_size >= 10 and w.hit_ratio < _ALERT_THRESHOLD:
+        if not w.alert_fired:
+            logger.warning(
+                "Cache break detected for feature=%s: hit ratio %.0f%% "
+                "(threshold %.0f%%, window=%d events, %d hits, %d misses)",
+                key,
+                w.hit_ratio * 100,
+                _ALERT_THRESHOLD * 100,
+                w.window_size,
+                sum(w.events),
+                w.window_size - sum(w.events),
+            )
+            w.alert_fired = True
+    else:
+        w.alert_fired = False  # Reset alert when ratio recovers
+
+
+@dataclass
+class CacheStats:
+    """Cache statistics for a single feature."""
+
+    feature: str
+    hit_ratio: float
+    window_size: int
+    total_hits: int
+    total_misses: int
+    alert_active: bool
+
+
+def get_cache_stats() -> list[CacheStats]:
+    """Return cache statistics for all tracked features."""
+    return [
+        CacheStats(
+            feature=key,
+            hit_ratio=w.hit_ratio,
+            window_size=w.window_size,
+            total_hits=w.total_hits,
+            total_misses=w.total_misses,
+            alert_active=w.alert_fired,
+        )
+        for key, w in sorted(_windows.items())
+    ]
+
+
+def _reset() -> None:
+    """Reset all tracking state (for testing)."""
+    _windows.clear()

--- a/tests/test_cache_break_detection.py
+++ b/tests/test_cache_break_detection.py
@@ -1,0 +1,182 @@
+"""Tests for cache break detection (G-427).
+
+Covers:
+- record_cache_event() tracks hits and misses
+- Hit ratio computed correctly over sliding window
+- Warning logged when ratio drops below threshold
+- No alert on healthy cache usage
+- Events without cache activity are ignored
+- get_cache_stats() returns per-feature data
+"""
+
+import logging
+
+import pytest
+
+from career_os.ai.cache_monitor import (
+    _WINDOW_SIZE,
+    _reset,
+    get_cache_stats,
+    record_cache_event,
+)
+from career_os.schemas.ai import AIFeature, TokenUsage
+
+
+@pytest.fixture(autouse=True)
+def reset_monitor():
+    """Reset cache monitor state between tests."""
+    _reset()
+    yield
+    _reset()
+
+
+def _hit_usage(read_tokens: int = 500) -> TokenUsage:
+    """Create a TokenUsage representing a cache hit."""
+    return TokenUsage(
+        input_tokens=100,
+        output_tokens=200,
+        cache_read_input_tokens=read_tokens,
+        cache_creation_input_tokens=0,
+    )
+
+
+def _miss_usage(creation_tokens: int = 500) -> TokenUsage:
+    """Create a TokenUsage representing a cache miss (new creation)."""
+    return TokenUsage(
+        input_tokens=600,
+        output_tokens=200,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=creation_tokens,
+    )
+
+
+def _no_cache_usage() -> TokenUsage:
+    """Create a TokenUsage with no cache activity (non-Anthropic provider)."""
+    return TokenUsage(
+        input_tokens=500,
+        output_tokens=200,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+
+
+class TestRecordCacheEvent:
+    """record_cache_event() correctly categorizes hits and misses."""
+
+    def test_hit_increments_counter(self) -> None:
+        record_cache_event(AIFeature.score, _hit_usage())
+        stats = get_cache_stats()
+        assert len(stats) == 1
+        assert stats[0].total_hits == 1
+        assert stats[0].total_misses == 0
+
+    def test_miss_increments_counter(self) -> None:
+        record_cache_event(AIFeature.score, _miss_usage())
+        stats = get_cache_stats()
+        assert stats[0].total_hits == 0
+        assert stats[0].total_misses == 1
+
+    def test_ignores_none_usage(self) -> None:
+        record_cache_event(AIFeature.score, None)
+        assert get_cache_stats() == []
+
+    def test_ignores_no_cache_activity(self) -> None:
+        record_cache_event(AIFeature.score, _no_cache_usage())
+        assert get_cache_stats() == []
+
+    def test_tracks_per_feature(self) -> None:
+        record_cache_event(AIFeature.score, _hit_usage())
+        record_cache_event(AIFeature.gap_analysis, _miss_usage())
+        stats = get_cache_stats()
+        assert len(stats) == 2
+        score_stats = next(s for s in stats if s.feature == "score")
+        gap_stats = next(s for s in stats if s.feature == "gap_analysis")
+        assert score_stats.total_hits == 1
+        assert gap_stats.total_misses == 1
+
+
+class TestHitRatio:
+    """Hit ratio is computed correctly over the sliding window."""
+
+    def test_all_hits_ratio_is_one(self) -> None:
+        for _ in range(20):
+            record_cache_event(AIFeature.score, _hit_usage())
+        stats = get_cache_stats()
+        assert stats[0].hit_ratio == pytest.approx(1.0)
+
+    def test_all_misses_ratio_is_zero(self) -> None:
+        for _ in range(20):
+            record_cache_event(AIFeature.score, _miss_usage())
+        stats = get_cache_stats()
+        assert stats[0].hit_ratio == pytest.approx(0.0)
+
+    def test_mixed_ratio(self) -> None:
+        # 8 hits + 2 misses = 80% hit ratio
+        for _ in range(8):
+            record_cache_event(AIFeature.score, _hit_usage())
+        for _ in range(2):
+            record_cache_event(AIFeature.score, _miss_usage())
+        stats = get_cache_stats()
+        assert stats[0].hit_ratio == pytest.approx(0.8)
+
+    def test_window_size_limit(self) -> None:
+        # Fill window with hits, then add misses beyond window size
+        for _ in range(_WINDOW_SIZE):
+            record_cache_event(AIFeature.score, _hit_usage())
+        stats = get_cache_stats()
+        assert stats[0].window_size == _WINDOW_SIZE
+
+
+class TestCacheBreakAlert:
+    """Warning logged when cache hit ratio drops below threshold."""
+
+    def test_alert_fires_below_threshold(self, caplog) -> None:
+        """Warning logged when hit ratio drops below 80%."""
+        # 10 events: 5 hits + 5 misses = 50% (below 80% threshold)
+        for _ in range(5):
+            record_cache_event(AIFeature.score, _hit_usage())
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.cache_monitor"):
+            for _ in range(5):
+                record_cache_event(AIFeature.score, _miss_usage())
+
+        assert "Cache break detected" in caplog.text
+        assert "feature=score" in caplog.text
+        stats = get_cache_stats()
+        assert stats[0].alert_active is True
+
+    def test_no_alert_above_threshold(self, caplog) -> None:
+        """No warning when hit ratio is healthy."""
+        # 9 hits + 1 miss = 90% (above 80% threshold)
+        for _ in range(9):
+            record_cache_event(AIFeature.score, _hit_usage())
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.cache_monitor"):
+            record_cache_event(AIFeature.score, _miss_usage())
+
+        assert "Cache break detected" not in caplog.text
+
+    def test_no_alert_with_insufficient_data(self, caplog) -> None:
+        """No alert when window has < 10 events (not enough data)."""
+        # 5 events all misses — but too few for alert
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.cache_monitor"):
+            for _ in range(5):
+                record_cache_event(AIFeature.score, _miss_usage())
+
+        assert "Cache break detected" not in caplog.text
+
+    def test_alert_resets_when_ratio_recovers(self) -> None:
+        """Alert clears when ratio goes back above threshold."""
+        # Drop below threshold
+        for _ in range(5):
+            record_cache_event(AIFeature.score, _hit_usage())
+        for _ in range(5):
+            record_cache_event(AIFeature.score, _miss_usage())
+
+        stats = get_cache_stats()
+        assert stats[0].alert_active is True
+
+        # Recover with lots of hits
+        for _ in range(20):
+            record_cache_event(AIFeature.score, _hit_usage())
+
+        stats = get_cache_stats()
+        assert stats[0].alert_active is False


### PR DESCRIPTION
## Summary

- New `cache_monitor.py` module tracks Anthropic cache hit/miss ratios per feature
- Sliding window of 100 events with 80% hit ratio alert threshold
- Logs `WARNING` when cache breaks are detected (prefix invalidation)
- Wired into `anthropic_provider.py` after token usage extraction
- Alert auto-resets when ratio recovers

## How it works

```
Anthropic response → extract cache_read/cache_creation tokens
                   → record_cache_event(feature, usage)
                   → sliding window tracks hit ratio
                   → WARNING if ratio < 80% over 10+ events
```

## Why this matters

A cache break on a batch of 50 jobs means the profile+system prompt
(~2000 tokens) is re-processed 50 times instead of once. At Sonnet
pricing that's ~$0.30 wasted per batch. Detection enables rapid
diagnosis of what changed in the prompt prefix.

## Test plan

- [x] 13 new tests pass (hit/miss tracking, ratio, alerts, recovery)
- [x] 252 existing provider tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)