### PR TITLE
refactor(G-404): extract shared scoring prompt template from 4 AI providers

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -16,6 +16,7 @@ from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
 from career_os.ai.observability import observe, update_current_generation
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
+    _scoring_user_prompt,
     _system_prompt_for_feature,
     _try_parse_structured,
 )
@@ -233,26 +234,7 @@ class AnthropicProvider(AIProvider):
         block — enabling cross-call cache reuse when scoring multiple jobs
         for the same user.
         """
-        prompt = (
-            "Score this job against the candidate profile. "
-            "Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
-            "estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
-            "readiness_score (0-100), career_alignment (0-10), "
-            "score_breakdown (array of >=3 objects, each with: factor (string), "
-            "contribution (positive or negative float), description (string)), "
-            "dimensional_scores (object with 6 floats 0-10: technical_fit, "
-            "seniority_alignment, compensation_fit, location_fit, career_trajectory, "
-            "company_fit), "
-            "ats_keywords (array of 10-15 objects, each with: keyword (string), "
-            "category (one of technical/soft_skill/tool/certification/domain), "
-            "matched (boolean -- true if the profile demonstrates this keyword)), "
-            "desire_score (0-10, how much the candidate would WANT this job -- "
-            "considering company reputation, growth potential, culture signals, "
-            "role excitement, compensation attractiveness, work-life balance), "
-            "desire_reasoning (string explaining what makes this job desirable "
-            f"or undesirable from the candidate's perspective).\n\n"
-            f"Job Description:\n{job_description}"
-        )
+        prompt = _scoring_user_prompt(job_description)
         return await self.complete(prompt, feature=AIFeature.score, context=profile_data, tier=tier)
 
     async def batch_score(
@@ -292,25 +274,7 @@ class AnthropicProvider(AIProvider):
 
         requests: list[dict] = []
         for job in jobs:
-            prompt = (
-                "Score this job against the candidate profile. "
-                "Return a JSON object with: fit_score (0-10), reasoning "
-                "(detailed, >=100 chars), "
-                "estimated_salary (string), effort_flag (low/medium/high), "
-                "prep_level, prep_notes, "
-                "readiness_score (0-100), career_alignment (0-10), "
-                "score_breakdown (array of >=3 objects, each with: factor "
-                "(string), contribution (positive or negative float), "
-                "description (string)), "
-                "dimensional_scores (object with 6 floats 0-10: technical_fit, "
-                "seniority_alignment, compensation_fit, location_fit, "
-                "career_trajectory, company_fit), "
-                "ats_keywords (array of 10-15 objects, each with: keyword "
-                "(string), category (one of technical/soft_skill/tool/"
-                "certification/domain), matched (boolean)), "
-                f"desire_score (0-10), desire_reasoning (string).\n\n"
-                f"Job Description:\n{job['description']}"
-            )
+            prompt = _scoring_user_prompt(job["description"])
 
             params: dict = {
                 "model": self._model,

--- a/src/career_os/ai/ollama_provider.py
+++ b/src/career_os/ai/ollama_provider.py
@@ -12,7 +12,11 @@ import httpx
 
 from career_os.ai.base import AIProvider, ComplexityTier
 from career_os.ai.observability import observe, update_current_generation
-from career_os.ai.openrouter_provider import _system_prompt_for_feature, _try_parse_structured
+from career_os.ai.openrouter_provider import (
+    _scoring_user_prompt,
+    _system_prompt_for_feature,
+    _try_parse_structured,
+)
 from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
 
 logger = logging.getLogger(__name__)
@@ -233,20 +237,7 @@ class OllamaProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via Ollama."""
-        prompt = (
-            f"Score this job against the candidate profile. "
-            f"Return a JSON object with: fit_score (0-10), reasoning (detailed, ≥100 chars), "
-            f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
-            f"readiness_score (0-100), career_alignment (0-10), "
-            f"score_breakdown (array of ≥3 objects, each with: factor (string), "
-            f"contribution (positive or negative float), description (string)), "
-            f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
-            f"seniority_alignment, compensation_fit, location_fit, career_trajectory, "
-            f"company_fit), "
-            f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
-            f"category (one of technical/soft_skill/tool/certification/domain), "
-            f"matched (boolean — true if the profile demonstrates this keyword)).\n\n"
-            f"Job Description:\n{job_description}\n\n"
-            f"Profile:\n{json.dumps(profile_data, separators=_COMPACT)}"
+        prompt = _scoring_user_prompt(
+            job_description, json.dumps(profile_data, separators=_COMPACT)
         )
         return await self.complete(prompt, feature=AIFeature.score)

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -211,28 +211,41 @@ class OpenRouterProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via OpenRouter."""
-        prompt = (
-            f"Score this job against the candidate profile. "
-            f"Return a JSON object with: fit_score (0-10), reasoning (detailed, ≥100 chars), "
-            f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
-            f"readiness_score (0-100), career_alignment (0-10), "
-            f"score_breakdown (array of ≥3 objects, each with: factor (string), "
-            f"contribution (positive or negative float), description (string)), "
-            f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
-            f"seniority_alignment, compensation_fit, location_fit, career_trajectory, "
-            f"company_fit), "
-            f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
-            f"category (one of technical/soft_skill/tool/certification/domain), "
-            f"matched (boolean — true if the profile demonstrates this keyword)), "
-            f"desire_score (0-10, how much the candidate would WANT this job — "
-            f"considering company reputation, growth potential, culture signals, "
-            f"role excitement, compensation attractiveness, work-life balance), "
-            f"desire_reasoning (string explaining what makes this job desirable "
-            f"or undesirable from the candidate's perspective).\n\n"
-            f"Job Description:\n{job_description}\n\n"
-            f"Profile:\n{json.dumps(profile_data, separators=_COMPACT)}"
+        prompt = _scoring_user_prompt(
+            job_description, json.dumps(profile_data, separators=_COMPACT)
         )
         return await self.complete(prompt, feature=AIFeature.score, tier=tier)
+
+
+def _scoring_user_prompt(job_description: str, profile_json: str | None = None) -> str:
+    """Build the user-message scoring prompt with job and optional profile.
+
+    Shared across all providers to avoid prompt drift between implementations.
+    The Anthropic provider passes profile_json=None (profile is in system block).
+    """
+    preamble = (
+        "Score this job against the candidate profile. "
+        "Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
+        "estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
+        "readiness_score (0-100), career_alignment (0-10), "
+        "score_breakdown (array of >=3 objects, each with: factor (string), "
+        "contribution (positive or negative float), description (string)), "
+        "dimensional_scores (object with 6 floats 0-10: technical_fit, "
+        "seniority_alignment, compensation_fit, location_fit, career_trajectory, "
+        "company_fit), "
+        "ats_keywords (array of 10-15 objects, each with: keyword (string), "
+        "category (one of technical/soft_skill/tool/certification/domain), "
+        "matched (boolean -- true if the profile demonstrates this keyword)), "
+        "desire_score (0-10, how much the candidate would WANT this job -- "
+        "considering company reputation, growth potential, culture signals, "
+        "role excitement, compensation attractiveness, work-life balance), "
+        "desire_reasoning (string explaining what makes this job desirable "
+        "or undesirable from the candidate's perspective)."
+    )
+    parts = [preamble, f"\n\nJob Description:\n{job_description}"]
+    if profile_json is not None:
+        parts.append(f"\n\nProfile:\n{profile_json}")
+    return "".join(parts)
 
 
 def _system_prompt_for_feature(feature: AIFeature) -> str | None:

--- a/src/career_os/ai/together_provider.py
+++ b/src/career_os/ai/together_provider.py
@@ -15,6 +15,7 @@ from career_os.ai.base import AIProvider, ProviderQuotaError
 from career_os.ai.observability import observe, update_current_generation
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
+    _scoring_user_prompt,
     _system_prompt_for_feature,
     _try_parse_structured,
 )
@@ -151,26 +152,8 @@ class TogetherProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via the Together.ai API."""
-        prompt = (
-            f"Score this job against the candidate profile. "
-            f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
-            f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
-            f"readiness_score (0-100), career_alignment (0-10), "
-            f"score_breakdown (array of >=3 objects, each with: factor (string), "
-            f"contribution (positive or negative float), description (string)), "
-            f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
-            f"seniority_alignment, compensation_fit, location_fit, career_trajectory, "
-            f"company_fit), "
-            f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
-            f"category (one of technical/soft_skill/tool/certification/domain), "
-            f"matched (boolean -- true if the profile demonstrates this keyword)), "
-            f"desire_score (0-10, how much the candidate would WANT this job -- "
-            f"considering company reputation, growth potential, culture signals, "
-            f"role excitement, compensation attractiveness, work-life balance), "
-            f"desire_reasoning (string explaining what makes this job desirable "
-            f"or undesirable from the candidate's perspective).\n\n"
-            f"Job Description:\n{job_description}\n\n"
-            f"Profile:\n{json.dumps(profile_data, separators=_COMPACT)}"
+        prompt = _scoring_user_prompt(
+            job_description, json.dumps(profile_data, separators=_COMPACT)
         )
         return await self.complete(prompt, feature=AIFeature.score)
 

--- a/tests/test_round2_residuals.py
+++ b/tests/test_round2_residuals.py
@@ -178,14 +178,11 @@ class TestOpenRouterScoreBreakdown:
         assert "contribution" in system_prompt
 
     def test_score_method_prompt_contains_score_breakdown(self):
-        """The user-facing prompt in score() should mention score_breakdown."""
-        from career_os.ai.openrouter_provider import OpenRouterProvider
+        """The scoring prompt template should mention score_breakdown."""
+        from career_os.ai.openrouter_provider import _scoring_user_prompt
 
-        provider = OpenRouterProvider(api_key="test-key")
-        import inspect
-
-        source = inspect.getsource(provider.score)
-        assert "score_breakdown" in source
+        prompt = _scoring_user_prompt("test job description")
+        assert "score_breakdown" in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New `_scoring_user_prompt(job_description, profile_json=None)` function
- Single source of truth for the scoring prompt template
- All 4 providers + batch_score() now use it (net -49 lines)
- Eliminates prompt drift between providers

## Test plan

- [x] 444 scoring/provider tests pass
- [x] 38 batch/anthropic tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)