### PR TITLE
feat(G-405): provider fallback chain — automatic retry on quota/timeout

### DIFF
--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -106,6 +106,40 @@ class UnsupportedProviderError(Exception):
         )
 
 
+def _build_fallback_chain() -> list[AIProvider] | None:
+    """Build a fallback chain from AI_PROVIDER_FALLBACK env var.
+
+    Expected format: comma-separated provider names, e.g.
+    "openrouter,together,ollama". Providers that can't be instantiated
+    (missing API key) are silently skipped.
+
+    Returns None if no fallback is configured or only one provider resolves.
+    """
+    fallback_str = os.getenv("AI_PROVIDER_FALLBACK", "").strip()
+    if not fallback_str:
+        return None
+
+    names = [n.strip().lower() for n in fallback_str.split(",") if n.strip()]
+    if len(names) < 2:
+        return None
+
+    chain: list[AIProvider] = []
+    for name in names:
+        factory_fn = _PROVIDER_REGISTRY.get(name)
+        if factory_fn is None:
+            logger.warning("Fallback chain: skipping unknown provider '%s'", name)
+            continue
+        try:
+            chain.append(factory_fn())
+        except (ValueError, KeyError) as exc:
+            # Missing API key or config — skip this provider
+            logger.info("Fallback chain: skipping %s (%s)", name, exc)
+
+    if len(chain) < 2:
+        return None
+    return chain
+
+
 def get_ai_provider(provider_name: str | None = None) -> AIProvider:
     """Create and return the configured AI provider.
 
@@ -113,6 +147,9 @@ def get_ai_provider(provider_name: str | None = None) -> AIProvider:
     1. Explicit `provider_name` argument
     2. AI_PROVIDER env var
     3. Default: "mock"
+
+    If AI_PROVIDER_FALLBACK is set (comma-separated list of provider names),
+    wraps the result in a FallbackProvider for automatic retry on quota/timeout.
 
     Both "mock" and "demo" resolve to MockProvider — "demo" is a friendlier
     user-facing alias so non-technical users don't think "mock" means broken.
@@ -125,4 +162,12 @@ def get_ai_provider(provider_name: str | None = None) -> AIProvider:
     factory_fn = _PROVIDER_REGISTRY.get(name)
     if factory_fn is None:
         raise UnsupportedProviderError(name)
+
+    # Check for fallback chain
+    fallback_chain = _build_fallback_chain()
+    if fallback_chain:
+        from career_os.ai.fallback import FallbackProvider
+
+        return FallbackProvider(fallback_chain)
+
     return factory_fn()

--- a/src/career_os/ai/fallback.py
+++ b/src/career_os/ai/fallback.py
@@ -1,0 +1,107 @@
+"""Provider fallback chain — automatic retry with next provider on failure.
+
+Wraps an ordered list of AI providers. On ProviderQuotaError or timeout,
+transparently retries with the next provider in the chain. If all providers
+fail, raises the last error.
+
+Composition example:
+    CachedProvider(MaskedProvider(FallbackProvider([openrouter, together, ollama])))
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
+from career_os.schemas.ai import AIFeature, AIResponse
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackProvider(AIProvider):
+    """AI provider that tries a chain of providers in order.
+
+    Falls back to the next provider when the current one raises
+    ProviderQuotaError (402/429) or httpx.TimeoutException.
+    """
+
+    def __init__(self, chain: list[AIProvider]) -> None:
+        if not chain:
+            raise ValueError("FallbackProvider requires at least one provider in the chain")
+        self._chain = chain
+
+    @property
+    def name(self) -> str:
+        return f"fallback({','.join(p.name for p in self._chain)})"
+
+    @property
+    def privacy_tier(self) -> str:
+        return self._chain[0].privacy_tier
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        feature: AIFeature = AIFeature.complete,
+        context: dict | None = None,
+        tier: ComplexityTier | None = None,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Try each provider in order until one succeeds."""
+        return await self._try_chain(
+            "complete",
+            lambda p: p.complete(prompt, feature=feature, context=context, tier=tier, **kwargs),
+        )
+
+    async def score(
+        self,
+        job_description: str,
+        profile_data: dict,
+        *,
+        tier: ComplexityTier | None = None,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Try each provider in order until one succeeds."""
+        return await self._try_chain(
+            "score",
+            lambda p: p.score(job_description, profile_data, tier=tier, **kwargs),
+        )
+
+    async def _try_chain(self, method: str, call):
+        """Execute call against each provider in the chain.
+
+        Catches ProviderQuotaError and TimeoutException, logs the fallback,
+        and tries the next provider. Re-raises if all providers fail.
+        """
+        last_error: Exception | None = None
+
+        for i, provider in enumerate(self._chain):
+            try:
+                return await call(provider)
+            except (ProviderQuotaError, httpx.TimeoutException) as exc:
+                last_error = exc
+                remaining = len(self._chain) - i - 1
+                if remaining > 0:
+                    next_provider = self._chain[i + 1]
+                    logger.warning(
+                        "Fallback: %s.%s() failed (%s: %s), trying %s (%d remaining)",
+                        provider.name,
+                        method,
+                        type(exc).__name__,
+                        str(exc)[:100],
+                        next_provider.name,
+                        remaining,
+                    )
+                else:
+                    logger.error(
+                        "Fallback: all %d providers exhausted for %s(). Last error from %s: %s",
+                        len(self._chain),
+                        method,
+                        provider.name,
+                        str(exc)[:200],
+                    )
+
+        # All providers failed — re-raise the last error
+        raise last_error  # type: ignore[misc]

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1,0 +1,194 @@
+"""Tests for provider fallback chain (G-405).
+
+Covers:
+- FallbackProvider tries providers in order
+- Falls back on ProviderQuotaError
+- Falls back on httpx.TimeoutException
+- Re-raises when all providers fail
+- Logs fallback events
+- Factory builds chain from AI_PROVIDER_FALLBACK env var
+- Factory skips providers with missing keys
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.fallback import FallbackProvider
+from career_os.schemas.ai import AIFeature, AIResponse
+
+
+def _make_provider(name: str, should_fail: str | None = None) -> AIProvider:
+    """Create a mock provider that optionally fails with a specific error."""
+    provider = AsyncMock(spec=AIProvider)
+    provider.name = name
+    provider.privacy_tier = "green"
+
+    success_response = AIResponse(
+        content='{"fit_score": 7}',
+        provider=name,
+        feature=AIFeature.score,
+        structured=None,
+        model="test-model",
+    )
+
+    if should_fail == "quota":
+        provider.complete.side_effect = ProviderQuotaError(name, 429, "rate limited")
+        provider.score.side_effect = ProviderQuotaError(name, 429, "rate limited")
+    elif should_fail == "timeout":
+        provider.complete.side_effect = httpx.TimeoutException("timed out")
+        provider.score.side_effect = httpx.TimeoutException("timed out")
+    else:
+        provider.complete.return_value = success_response
+        provider.score.return_value = success_response
+
+    return provider
+
+
+class TestFallbackProvider:
+    """FallbackProvider tries providers in order."""
+
+    @pytest.mark.asyncio
+    async def test_uses_first_provider_on_success(self) -> None:
+        """First provider succeeds — no fallback needed."""
+        p1 = _make_provider("openrouter")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "openrouter"
+        p1.complete.assert_called_once()
+        p2.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_quota_error(self) -> None:
+        """Quota error triggers fallback to next provider."""
+        p1 = _make_provider("openrouter", should_fail="quota")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "together"
+        p1.complete.assert_called_once()
+        p2.complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_timeout(self) -> None:
+        """Timeout triggers fallback to next provider."""
+        p1 = _make_provider("openrouter", should_fail="timeout")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.score("job desc", {"name": "test"})
+
+        assert result.provider == "together"
+
+    @pytest.mark.asyncio
+    async def test_tries_all_providers_in_order(self) -> None:
+        """Falls through multiple providers until one succeeds."""
+        p1 = _make_provider("openrouter", should_fail="quota")
+        p2 = _make_provider("together", should_fail="timeout")
+        p3 = _make_provider("ollama")
+
+        fb = FallbackProvider([p1, p2, p3])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "ollama"
+        p1.complete.assert_called_once()
+        p2.complete.assert_called_once()
+        p3.complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_all_fail(self) -> None:
+        """Re-raises last error when all providers exhaust."""
+        p1 = _make_provider("openrouter", should_fail="quota")
+        p2 = _make_provider("together", should_fail="timeout")
+
+        fb = FallbackProvider([p1, p2])
+        with pytest.raises(httpx.TimeoutException):
+            await fb.complete("test", feature=AIFeature.complete)
+
+    @pytest.mark.asyncio
+    async def test_does_not_catch_other_errors(self) -> None:
+        """Non-quota/timeout errors are not caught (bubble up immediately)."""
+        p1 = _make_provider("openrouter")
+        p1.complete.side_effect = ValueError("unexpected error")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        with pytest.raises(ValueError, match="unexpected error"):
+            await fb.complete("test", feature=AIFeature.complete)
+        # p2 never called — error wasn't a fallback trigger
+        p2.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_logs_fallback_events(self, caplog) -> None:
+        """Logs a warning on each fallback attempt."""
+        import logging
+
+        p1 = _make_provider("openrouter", should_fail="quota")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.fallback"):
+            await fb.complete("test", feature=AIFeature.complete)
+
+        assert "Fallback: openrouter.complete() failed" in caplog.text
+        assert "trying together" in caplog.text
+
+    def test_requires_at_least_one_provider(self) -> None:
+        """Empty chain raises ValueError."""
+        with pytest.raises(ValueError, match="at least one provider"):
+            FallbackProvider([])
+
+    def test_name_includes_chain(self) -> None:
+        """Name property shows the full chain."""
+        p1 = _make_provider("openrouter")
+        p2 = _make_provider("together")
+        fb = FallbackProvider([p1, p2])
+        assert fb.name == "fallback(openrouter,together)"
+
+
+class TestFactoryFallbackChain:
+    """Factory builds fallback chain from AI_PROVIDER_FALLBACK env var."""
+
+    def test_no_fallback_env_returns_single_provider(self) -> None:
+        """Without AI_PROVIDER_FALLBACK, factory returns single provider."""
+        from career_os.ai.factory import get_ai_provider
+
+        provider = get_ai_provider("mock")
+        assert provider.name == "mock"
+
+    def test_fallback_env_builds_chain(self) -> None:
+        """With AI_PROVIDER_FALLBACK, factory returns FallbackProvider."""
+        from career_os.ai.factory import get_ai_provider
+
+        with patch.dict(
+            "os.environ",
+            {"AI_PROVIDER_FALLBACK": "mock,demo", "AI_PROVIDER": "mock"},
+        ):
+            provider = get_ai_provider()
+
+        assert "fallback" in provider.name
+
+    def test_fallback_skips_unknown_providers(self) -> None:
+        """Unknown providers in chain are silently skipped."""
+        from career_os.ai.factory import _build_fallback_chain
+
+        with patch.dict("os.environ", {"AI_PROVIDER_FALLBACK": "mock,nonexistent,demo"}):
+            chain = _build_fallback_chain()
+
+        # mock + demo = 2 providers (nonexistent skipped)
+        assert chain is not None
+        assert len(chain) == 2
+
+    def test_single_provider_fallback_returns_none(self) -> None:
+        """Single provider in fallback env doesn't create a chain."""
+        from career_os.ai.factory import _build_fallback_chain
+
+        with patch.dict("os.environ", {"AI_PROVIDER_FALLBACK": "mock"}):
+            assert _build_fallback_chain() is None


### PR DESCRIPTION
## Summary

- New `FallbackProvider` class wrapping ordered provider chain
- Auto-retries on `ProviderQuotaError` (402/429) and `httpx.TimeoutException`
- Configured via `AI_PROVIDER_FALLBACK` env var (comma-separated)
- Follows same decorator pattern as CachedProvider/MaskedProvider
- Providers with missing API keys silently skipped in chain
- 13 tests covering all paths

## Usage

```bash
# Enable fallback: try OpenRouter first, then Together, then Ollama
AI_PROVIDER_FALLBACK=openrouter,together,ollama
```

## Test plan

- [x] 13 new tests pass
- [x] 269 existing provider/factory tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)