### PR TITLE
feat(G-430): input validation hardening — INT64 bounds on all API integers

### DIFF
--- a/.planning/phases/03.1-input-validation-hardening-inserted/03.1-02-SUMMARY.md
+++ b/.planning/phases/03.1-input-validation-hardening-inserted/03.1-02-SUMMARY.md
@@ -1,0 +1,99 @@
+---
+phase: 03.1-input-validation-hardening-inserted
+plan: 02
+subsystem: schemas
+tags: [security, validation, pydantic, sqlite, int64]
+dependency_graph:
+  requires: [03.1-01]
+  provides: [constrained-schema-fields]
+  affects: [openapi-spec, schemathesis-fuzzing]
+tech_stack:
+  added: []
+  patterns: [Field-ge-le-constraints, Annotated-list-items]
+key_files:
+  modified:
+    - src/career_os/schemas/ai.py
+    - src/career_os/schemas/ai_health.py
+    - src/career_os/schemas/analytics.py
+    - src/career_os/schemas/applications.py
+    - src/career_os/schemas/calendar.py
+    - src/career_os/schemas/coaching.py
+    - src/career_os/schemas/contacts.py
+    - src/career_os/schemas/discovery.py
+    - src/career_os/schemas/follow_ups.py
+    - src/career_os/schemas/gaps.py
+    - src/career_os/schemas/goals.py
+    - src/career_os/schemas/integrations.py
+    - src/career_os/schemas/interview_prep.py
+    - src/career_os/schemas/jobs.py
+    - src/career_os/schemas/learning.py
+    - src/career_os/schemas/market.py
+    - src/career_os/schemas/privacy.py
+    - src/career_os/schemas/profiles.py
+    - src/career_os/schemas/pushover.py
+    - src/career_os/schemas/research.py
+    - src/career_os/schemas/role_intelligence.py
+    - src/career_os/schemas/scoring.py
+    - src/career_os/schemas/skills.py
+    - src/career_os/schemas/star_stories.py
+    - src/career_os/schemas/ticktick.py
+    - src/career_os/schemas/voice.py
+decisions:
+  - "INT64_MIN/INT64_MAX imported from constraints module (plan 01) across all 26 files"
+  - "ID fields constrained ge=1, le=INT64_MAX; non-ID counters ge=INT64_MIN, le=INT64_MAX"
+  - "list[int] ID fields use Annotated[int, Field(ge=1, le=INT64_MAX)] wrapper"
+  - "Fields with existing ge+le preserved unchanged (gaps.distance, pushover quiet_hours, scoring percentile)"
+  - "Fields with ge= only got le=INT64_MAX added (rank, sample_size, duration_minutes, time_minutes)"
+  - "dict[str, int] fields skipped per plan (response-only, no overflow risk)"
+metrics:
+  duration: "17m 43s"
+  completed: "2026-04-20T23:06:35Z"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 26
+---
+
+# Phase 3.1 Plan 02: Schema INT64 Bounds Summary
+
+INT64 bounds applied to all 26 Pydantic schema files using constraints module from plan 01, preventing SQLite INTEGER overflow via Pydantic validation layer (HTTP 422 before DB access).
+
+## What Was Done
+
+### Task 1: Schema files A-G (11 files)
+- **Commit:** 49bd767
+- Applied INT64 bounds to ai.py, ai_health.py, analytics.py, applications.py, calendar.py, coaching.py, contacts.py, discovery.py, follow_ups.py, gaps.py, goals.py
+- TokenUsage fields (ai.py): 4 counter fields constrained with INT64_MIN/INT64_MAX
+- gaps.py: `distance` field (ge=0, le=3) preserved, `application_ids: list[int]` converted to Annotated
+- calendar.py: `reminder_minutes_before` (ge=0, le=10080) preserved
+
+### Task 2: Schema files I-V (15 files)
+- **Commit:** 4d514cc
+- Applied INT64 bounds to integrations.py, interview_prep.py, jobs.py, learning.py, market.py, privacy.py, profiles.py, pushover.py, research.py, role_intelligence.py, scoring.py, skills.py, star_stories.py, ticktick.py, voice.py
+- scoring.py: `discovered_job_ids: list[int]` converted to `list[Annotated[int, Field(ge=1, le=INT64_MAX)]]`; `rank` and `total_scored` got le=INT64_MAX added; `percentile` (ge=0, le=100) preserved
+- pushover.py: quiet_hours (ge=0, le=23) and interview_lead_time (ge=0, le=10080) preserved
+- market.py: `sample_size` (ge=0) got le=INT64_MAX added
+- role_intelligence.py: `duration_minutes` (ge=0) got le=INT64_MAX added
+
+## Verification Results
+
+- All 26 schema files import successfully
+- 1530 tests passed, 1 pre-existing failure (test_md_to_pdf unrelated to changes)
+- All existing domain constraints (distance, quiet_hours, percentile, etc.) preserved unchanged
+- All ID fields have ge=1, le=INT64_MAX
+- All non-ID integer fields have ge=INT64_MIN, le=INT64_MAX
+- All list[int] ID fields use Annotated wrapper
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- Commit 49bd767: FOUND
+- Commit 4d514cc: FOUND
+- SUMMARY.md: FOUND
+- Schema files with constraints import: 26/26

--- a/.planning/phases/03.1-input-validation-hardening-inserted/03.1-03-SUMMARY.md
+++ b/.planning/phases/03.1-input-validation-hardening-inserted/03.1-03-SUMMARY.md
@@ -1,0 +1,114 @@
+---
+phase: 03.1-input-validation-hardening-inserted
+plan: 03
+subsystem: api-routes
+tags: [security, input-validation, INT64, fastapi]
+dependency_graph:
+  requires: [03.1-01]
+  provides: [constrained-api-params]
+  affects: [src/career_os/api/]
+tech_stack:
+  added: []
+  patterns: [Annotated-int-Path, INT64_MAX-Query-constraint]
+key_files:
+  modified:
+    - src/career_os/api/analytics.py
+    - src/career_os/api/applications.py
+    - src/career_os/api/calendar.py
+    - src/career_os/api/coaching.py
+    - src/career_os/api/contacts.py
+    - src/career_os/api/discovery.py
+    - src/career_os/api/follow_ups.py
+    - src/career_os/api/gaps.py
+    - src/career_os/api/goals.py
+    - src/career_os/api/intelligence.py
+    - src/career_os/api/interview_prep.py
+    - src/career_os/api/jobs.py
+    - src/career_os/api/learning.py
+    - src/career_os/api/market.py
+    - src/career_os/api/profiles.py
+    - src/career_os/api/pushover.py
+    - src/career_os/api/scoring.py
+    - src/career_os/api/skills.py
+    - src/career_os/api/star_stories.py
+    - src/career_os/api/ticktick.py
+    - src/career_os/api/voice.py
+decisions:
+  - "Skipped ai.py, integrations.py, privacy.py, research.py (no int query/path params)"
+  - "Used ge=0 for salary_min/salary_max (monetary values can be zero, unlike IDs)"
+  - "Aliased pathlib.Path as FilePath in skills.py to avoid collision with fastapi.Path"
+metrics:
+  duration: "11m 29s"
+  completed: "2026-04-20T23:00:23Z"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 21
+---
+
+# Phase 03.1 Plan 03: API Route INT64 Constraints Summary
+
+Added ge=1, le=INT64_MAX bounds to all bare integer query and path parameters across 21 API route files, preventing SQLite INT64 overflow via Schemathesis-generated payloads.
+
+## Tasks Completed
+
+| Task | Name | Commit | Key Changes |
+|------|------|--------|-------------|
+| 1 | Constrain API files A-G (12 files) | 2ebb832 | 10 files modified (ai.py, integrations.py skipped - no int params) |
+| 1-fix | Add missing Path import to goals.py | 5d38ee0 | Deviation Rule 3: goals.py missing fastapi.Path import |
+| 2 | Constrain API files I-V (13 files) | 2a01cab | 11 files modified (privacy.py, research.py skipped - no int params) |
+
+## Changes Applied
+
+### Query Parameter Transforms
+- All `profile_id: Annotated[int, Query(description=...)]` now have `ge=1, le=INT64_MAX`
+- All optional int Query params (application_id, etc.) now have `ge=1, le=INT64_MAX`
+- `salary_min`/`salary_max` use `ge=0, le=INT64_MAX` (monetary values can be zero)
+- `page: Query(ge=1)` params got `le=INT64_MAX` added (preserving existing ge=)
+- `offset: Query(ge=0)` params got `le=INT64_MAX` added
+
+### Path Parameter Transforms
+- All bare `param_id: int,` converted to `param_id: Annotated[int, Path(ge=1, le=INT64_MAX)],`
+- Path params converted: application_id, event_id, follow_up_id, contact_id, goal_id, sp_id, skill_id, story_id, session_id, search_id, gap_id, resource_id, scored_job_id, discovered_job_id, item_id, profile_id
+- `Path` added to fastapi imports in all files with path params
+- `Annotated` added to typing imports where not already present
+
+### Preserved Constraints (unchanged)
+- `page_size: Query(ge=1, le=200)` in discovery.py, skills.py
+- `limit: Query(ge=1, le=100)` in discovery.py
+- `limit: Query(ge=1, le=200)` in pushover.py
+- `score: Query(ge=0, le=10)` in pushover.py
+
+### Files Skipped (no int params)
+- `ai.py` - only str/body params
+- `integrations.py` - only str path params (integration name)
+- `privacy.py` - only str path params (provider name)
+- `research.py` - only body params and bool query param
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Missing Path import in goals.py**
+- **Found during:** Task 1 verification (fuzz test collection error)
+- **Issue:** goals.py had `Annotated[int, Path(ge=1, le=INT64_MAX)]` but no `from fastapi import Path`, causing Pydantic ForwardRef error
+- **Fix:** Added Path to fastapi import line
+- **Files modified:** src/career_os/api/goals.py
+- **Commit:** 5d38ee0
+
+**2. [Rule 3 - Blocking] pathlib.Path collision in skills.py**
+- **Found during:** Task 2 execution
+- **Issue:** skills.py already imports `from pathlib import Path` for file path resolution; adding `Path` from fastapi caused shadowing
+- **Fix:** Aliased pathlib import as `from pathlib import Path as FilePath`
+- **Files modified:** src/career_os/api/skills.py
+- **Commit:** 2a01cab (included in Task 2 commit)
+
+## Verification Results
+
+- 144 routes loaded via FastAPI app startup
+- Zero bare `param_id: int,` path params remaining in any API file
+- 1530 tests passed, 1 pre-existing failure (test_md_to_pdf unrelated)
+- All 21 modified files import cleanly
+
+## Known Stubs
+
+None.

--- a/src/career_os/api/analytics.py
+++ b/src/career_os/api/analytics.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.database import get_db
 from career_os.schemas.analytics import AnalyticsResponse
-from career_os.schemas.constraints import INT64_MAX
+from career_os.schemas.constraints import INT32_MAX
 from career_os.services.analytics import get_analytics
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
@@ -15,7 +15,9 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 
 @router.get("")
 async def analytics(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to show analytics for")],
+    profile_id: Annotated[
+        int, Query(ge=1, le=INT32_MAX, description="Profile to show analytics for")
+    ],
     db: Annotated[Session, Depends(get_db)],
 ) -> AnalyticsResponse:
     """Get analytics dashboard data.

--- a/src/career_os/api/analytics.py
+++ b/src/career_os/api/analytics.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.database import get_db
 from career_os.schemas.analytics import AnalyticsResponse
+from career_os.schemas.constraints import INT64_MAX
 from career_os.services.analytics import get_analytics
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 
 @router.get("")
 async def analytics(
-    profile_id: Annotated[int, Query(description="Profile to show analytics for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to show analytics for")],
     db: Annotated[Session, Depends(get_db)],
 ) -> AnalyticsResponse:
     """Get analytics dashboard data.

--- a/src/career_os/api/applications.py
+++ b/src/career_os/api/applications.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
-from career_os.schemas.constraints import INT64_MAX
 from career_os.schemas.applications import (
     ActivityLogResponse,
     ApplicationCreate,
@@ -18,6 +17,7 @@ from career_os.schemas.applications import (
     ApplicationUpdate,
     FollowUpSummaryResponse,
 )
+from career_os.schemas.constraints import INT32_MAX
 from career_os.services.applications import (
     ApplicationNotFoundError,
     InvalidStatusTransitionError,
@@ -85,16 +85,20 @@ async def create(
 
 @router.get("")
 async def list_apps(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list applications for")],
+    profile_id: Annotated[
+        int, Query(ge=1, le=INT32_MAX, description="Profile to list applications for")
+    ],
     db: Annotated[Session, Depends(get_db)],
     status: Annotated[str | None, Query(description="Filter by status")] = None,
     search: Annotated[str | None, Query(description="Search by company name")] = None,
     sort: Annotated[str | None, Query(description="Sort field: 'score' or 'date'")] = None,
     order: Annotated[str, Query(description="Sort order: 'asc' or 'desc'")] = "desc",
     ghost_alert: Annotated[bool, Query(description="Filter to ghost candidates only")] = False,
-    applied_threshold: Annotated[int, Query(ge=1, le=INT64_MAX, description="Applied ghost threshold (days)")] = 14,
+    applied_threshold: Annotated[
+        int, Query(ge=1, le=3650, description="Applied ghost threshold (days)")
+    ] = 14,
     interviewing_threshold: Annotated[
-        int, Query(ge=1, le=INT64_MAX, description="Interviewing ghost threshold (days)")
+        int, Query(ge=1, le=3650, description="Interviewing ghost threshold (days)")
     ] = 7,
 ) -> ApplicationListResponse:
     """List applications with optional filters and sorting.
@@ -153,8 +157,8 @@ async def list_apps(
 
 @router.get("/{application_id}", responses=RESP_404)
 async def get_detail(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationDetailResponse:
     """Get application detail including activity log and follow-ups.
@@ -194,9 +198,9 @@ async def get_detail(
     responses=RESP_404_422,
 )
 async def update(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: ApplicationUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationResponse:
     """Update an application.
@@ -220,8 +224,8 @@ async def update(
 
 @router.delete("/{application_id}", responses=RESP_404)
 async def delete(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationResponse:
     """Soft-delete (archive) an application.

--- a/src/career_os/api/applications.py
+++ b/src/career_os/api/applications.py
@@ -2,11 +2,12 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
+from career_os.schemas.constraints import INT64_MAX
 from career_os.schemas.applications import (
     ActivityLogResponse,
     ApplicationCreate,
@@ -84,16 +85,16 @@ async def create(
 
 @router.get("")
 async def list_apps(
-    profile_id: Annotated[int, Query(description="Profile to list applications for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list applications for")],
     db: Annotated[Session, Depends(get_db)],
     status: Annotated[str | None, Query(description="Filter by status")] = None,
     search: Annotated[str | None, Query(description="Search by company name")] = None,
     sort: Annotated[str | None, Query(description="Sort field: 'score' or 'date'")] = None,
     order: Annotated[str, Query(description="Sort order: 'asc' or 'desc'")] = "desc",
     ghost_alert: Annotated[bool, Query(description="Filter to ghost candidates only")] = False,
-    applied_threshold: Annotated[int, Query(description="Applied ghost threshold (days)")] = 14,
+    applied_threshold: Annotated[int, Query(ge=1, le=INT64_MAX, description="Applied ghost threshold (days)")] = 14,
     interviewing_threshold: Annotated[
-        int, Query(description="Interviewing ghost threshold (days)")
+        int, Query(ge=1, le=INT64_MAX, description="Interviewing ghost threshold (days)")
     ] = 7,
 ) -> ApplicationListResponse:
     """List applications with optional filters and sorting.
@@ -152,8 +153,8 @@ async def list_apps(
 
 @router.get("/{application_id}", responses=RESP_404)
 async def get_detail(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationDetailResponse:
     """Get application detail including activity log and follow-ups.
@@ -193,9 +194,9 @@ async def get_detail(
     responses=RESP_404_422,
 )
 async def update(
-    application_id: int,
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: ApplicationUpdate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationResponse:
     """Update an application.
@@ -219,8 +220,8 @@ async def update(
 
 @router.delete("/{application_id}", responses=RESP_404)
 async def delete(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ApplicationResponse:
     """Soft-delete (archive) an application.

--- a/src/career_os/api/calendar.py
+++ b/src/career_os/api/calendar.py
@@ -9,7 +9,7 @@ Covers:
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
@@ -41,6 +41,7 @@ from career_os.services.calendar import (
     list_calendar_events,
     update_calendar_event,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
@@ -65,10 +66,10 @@ async def create_event(
 
 @router.get("/events")
 async def list_events(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     event_type: Annotated[str | None, Query(description="Filter by event type")] = None,
-    application_id: Annotated[int | None, Query(description="Filter by application")] = None,
+    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, description="Filter by application")] = None,
 ) -> CalendarEventListResponse:
     """List calendar events for a profile with optional filters."""
     events, total = list_calendar_events(
@@ -85,8 +86,8 @@ async def list_events(
 
 @router.get("/events/{event_id}", responses=RESP_404)
 async def get_event(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Get a single calendar event by ID."""
@@ -99,9 +100,9 @@ async def get_event(
 
 @router.patch("/events/{event_id}", responses=RESP_404)
 async def update_event(
-    event_id: int,
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: CalendarEventUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Update a calendar event.
@@ -121,8 +122,8 @@ async def update_event(
     responses=RESP_404,
 )
 async def delete_event(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a calendar event."""
@@ -143,8 +144,8 @@ async def delete_event(
     responses=RESP_404,
 )
 async def create_from_follow_up(
-    follow_up_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    follow_up_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Create a calendar event from a follow-up."""
@@ -169,8 +170,8 @@ async def create_from_follow_up(
 
 @router.get("/events/{event_id}/ical", responses=RESP_404)
 async def export_ical(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> Response:
     """Export a single calendar event as .ics file.
@@ -191,10 +192,10 @@ async def export_ical(
 
 @router.get("/export/ical")
 async def export_all_ical(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     event_type: Annotated[str | None, Query(description="Filter by event type")] = None,
-    application_id: Annotated[int | None, Query(description="Filter by application")] = None,
+    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, description="Filter by application")] = None,
 ) -> Response:
     """Export calendar events as .ics file.
 
@@ -220,8 +221,8 @@ async def export_all_ical(
 
 @router.get("/events/{event_id}/google", responses=RESP_404)
 async def google_calendar_url(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoogleCalendarUrlResponse:
     """Get a Google Calendar 'Add Event' URL for an event."""
@@ -239,8 +240,8 @@ async def google_calendar_url(
 
 @router.get("/events/{event_id}/fantastical", responses=RESP_404)
 async def fantastical_url(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FantasticalUrlResponse:
     """Get a Fantastical URL scheme for adding an event."""
@@ -258,8 +259,8 @@ async def fantastical_url(
 
 @router.get("/events/{event_id}/providers", responses=RESP_404)
 async def event_providers(
-    event_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarProviderConfigResponse:
     """Get export URLs/data for all supported calendar providers."""

--- a/src/career_os/api/calendar.py
+++ b/src/career_os/api/calendar.py
@@ -25,6 +25,7 @@ from career_os.schemas.calendar import (
     FantasticalUrlResponse,
     GoogleCalendarUrlResponse,
 )
+from career_os.schemas.constraints import INT32_MAX
 from career_os.services.calendar import (
     ApplicationNotFoundError,
     CalendarEventNotFoundError,
@@ -41,7 +42,6 @@ from career_os.services.calendar import (
     list_calendar_events,
     update_calendar_event,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
@@ -66,10 +66,12 @@ async def create_event(
 
 @router.get("/events")
 async def list_events(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     event_type: Annotated[str | None, Query(description="Filter by event type")] = None,
-    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, description="Filter by application")] = None,
+    application_id: Annotated[
+        int | None, Query(ge=1, le=INT32_MAX, description="Filter by application")
+    ] = None,
 ) -> CalendarEventListResponse:
     """List calendar events for a profile with optional filters."""
     events, total = list_calendar_events(
@@ -86,8 +88,8 @@ async def list_events(
 
 @router.get("/events/{event_id}", responses=RESP_404)
 async def get_event(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Get a single calendar event by ID."""
@@ -100,9 +102,9 @@ async def get_event(
 
 @router.patch("/events/{event_id}", responses=RESP_404)
 async def update_event(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: CalendarEventUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Update a calendar event.
@@ -122,8 +124,8 @@ async def update_event(
     responses=RESP_404,
 )
 async def delete_event(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a calendar event."""
@@ -144,8 +146,8 @@ async def delete_event(
     responses=RESP_404,
 )
 async def create_from_follow_up(
-    follow_up_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    follow_up_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarEventResponse:
     """Create a calendar event from a follow-up."""
@@ -170,8 +172,8 @@ async def create_from_follow_up(
 
 @router.get("/events/{event_id}/ical", responses=RESP_404)
 async def export_ical(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> Response:
     """Export a single calendar event as .ics file.
@@ -192,10 +194,12 @@ async def export_ical(
 
 @router.get("/export/ical")
 async def export_all_ical(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     event_type: Annotated[str | None, Query(description="Filter by event type")] = None,
-    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, description="Filter by application")] = None,
+    application_id: Annotated[
+        int | None, Query(ge=1, le=INT32_MAX, description="Filter by application")
+    ] = None,
 ) -> Response:
     """Export calendar events as .ics file.
 
@@ -221,8 +225,8 @@ async def export_all_ical(
 
 @router.get("/events/{event_id}/google", responses=RESP_404)
 async def google_calendar_url(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoogleCalendarUrlResponse:
     """Get a Google Calendar 'Add Event' URL for an event."""
@@ -240,8 +244,8 @@ async def google_calendar_url(
 
 @router.get("/events/{event_id}/fantastical", responses=RESP_404)
 async def fantastical_url(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FantasticalUrlResponse:
     """Get a Fantastical URL scheme for adding an event."""
@@ -259,8 +263,8 @@ async def fantastical_url(
 
 @router.get("/events/{event_id}/providers", responses=RESP_404)
 async def event_providers(
-    event_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    event_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CalendarProviderConfigResponse:
     """Get export URLs/data for all supported calendar providers."""

--- a/src/career_os/api/coaching.py
+++ b/src/career_os/api/coaching.py
@@ -12,18 +12,18 @@ from career_os.schemas.coaching import (
     CoachingSuggestionsResponse,
     EffortEstimate,
 )
+from career_os.schemas.constraints import INT32_MAX
 from career_os.services.coaching import (
     ProfileNotFoundError,
     get_coaching_suggestions,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/coaching", tags=["coaching"])
 
 
 @router.get("/suggestions", responses=RESP_404)
 async def get_suggestions(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CoachingSuggestionsResponse:
     """Get prioritized coaching suggestions.

--- a/src/career_os/api/coaching.py
+++ b/src/career_os/api/coaching.py
@@ -16,13 +16,14 @@ from career_os.services.coaching import (
     ProfileNotFoundError,
     get_coaching_suggestions,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/coaching", tags=["coaching"])
 
 
 @router.get("/suggestions", responses=RESP_404)
 async def get_suggestions(
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CoachingSuggestionsResponse:
     """Get prioritized coaching suggestions.

--- a/src/career_os/api/contacts.py
+++ b/src/career_os/api/contacts.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
@@ -36,6 +36,7 @@ from career_os.services.contacts import (
     unlink_contact_from_application,
     update_contact,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api", tags=["contacts"])
 
@@ -60,7 +61,7 @@ async def create(
 
 @router.get("/contacts")
 async def list_all(
-    profile_id: Annotated[int, Query(description="Profile to list contacts for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list contacts for")],
     db: Annotated[Session, Depends(get_db)],
     company: Annotated[str | None, Query(description="Filter by company")] = None,
     relationship_type: Annotated[str | None, Query(description="Filter by type")] = None,
@@ -87,7 +88,7 @@ async def list_all(
 @router.get("/contacts/by-company/{company}")
 async def contacts_at_company(
     company: str,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactListResponse:
     """Get all contacts at a company."""
@@ -100,8 +101,8 @@ async def contacts_at_company(
 
 @router.get("/contacts/{contact_id}", responses=RESP_404)
 async def get_detail(
-    contact_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactDetailResponse:
     """Get contact detail with interactions and linked applications."""
@@ -124,9 +125,9 @@ async def get_detail(
 
 @router.patch("/contacts/{contact_id}", responses=RESP_404)
 async def update(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: ContactUpdate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactResponse:
     """Update a contact."""
@@ -143,8 +144,8 @@ async def update(
     responses=RESP_404,
 )
 async def delete(
-    contact_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Soft-delete a contact."""
@@ -165,9 +166,9 @@ async def delete(
     responses=RESP_404,
 )
 async def log_interaction(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: InteractionCreate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InteractionResponse:
     """Log an interaction with a contact."""
@@ -183,8 +184,8 @@ async def log_interaction(
     responses=RESP_404,
 )
 async def get_interactions(
-    contact_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InteractionListResponse:
     """List interactions for a contact."""
@@ -209,9 +210,9 @@ async def get_interactions(
     responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def link_application(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: ContactApplicationCreate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactApplicationResponse:
     """Link a contact to an application."""
@@ -228,8 +229,8 @@ async def link_application(
 
 @router.get("/contacts/{contact_id}/applications", responses=RESP_404)
 async def get_linked_applications(
-    contact_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """List applications linked to a contact."""
@@ -250,9 +251,9 @@ async def get_linked_applications(
     responses=RESP_404,
 )
 async def unlink_application(
-    contact_id: int,
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Unlink a contact from an application."""
@@ -269,8 +270,8 @@ async def unlink_application(
 
 @router.get("/applications/{application_id}/contacts")
 async def get_application_contacts(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """Get contacts linked to an application (reverse lookup)."""

--- a/src/career_os/api/contacts.py
+++ b/src/career_os/api/contacts.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.contacts import (
     ContactApplicationCreate,
     ContactApplicationResponse,
@@ -36,7 +37,6 @@ from career_os.services.contacts import (
     unlink_contact_from_application,
     update_contact,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api", tags=["contacts"])
 
@@ -61,7 +61,9 @@ async def create(
 
 @router.get("/contacts")
 async def list_all(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list contacts for")],
+    profile_id: Annotated[
+        int, Query(ge=1, le=INT32_MAX, description="Profile to list contacts for")
+    ],
     db: Annotated[Session, Depends(get_db)],
     company: Annotated[str | None, Query(description="Filter by company")] = None,
     relationship_type: Annotated[str | None, Query(description="Filter by type")] = None,
@@ -88,7 +90,7 @@ async def list_all(
 @router.get("/contacts/by-company/{company}")
 async def contacts_at_company(
     company: str,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactListResponse:
     """Get all contacts at a company."""
@@ -101,8 +103,8 @@ async def contacts_at_company(
 
 @router.get("/contacts/{contact_id}", responses=RESP_404)
 async def get_detail(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactDetailResponse:
     """Get contact detail with interactions and linked applications."""
@@ -125,9 +127,9 @@ async def get_detail(
 
 @router.patch("/contacts/{contact_id}", responses=RESP_404)
 async def update(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: ContactUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactResponse:
     """Update a contact."""
@@ -144,8 +146,8 @@ async def update(
     responses=RESP_404,
 )
 async def delete(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Soft-delete a contact."""
@@ -166,9 +168,9 @@ async def delete(
     responses=RESP_404,
 )
 async def log_interaction(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: InteractionCreate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InteractionResponse:
     """Log an interaction with a contact."""
@@ -184,8 +186,8 @@ async def log_interaction(
     responses=RESP_404,
 )
 async def get_interactions(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InteractionListResponse:
     """List interactions for a contact."""
@@ -210,9 +212,9 @@ async def get_interactions(
     responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def link_application(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: ContactApplicationCreate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ContactApplicationResponse:
     """Link a contact to an application."""
@@ -229,8 +231,8 @@ async def link_application(
 
 @router.get("/contacts/{contact_id}/applications", responses=RESP_404)
 async def get_linked_applications(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """List applications linked to a contact."""
@@ -251,9 +253,9 @@ async def get_linked_applications(
     responses=RESP_404,
 )
 async def unlink_application(
-    contact_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    contact_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Unlink a contact from an application."""
@@ -270,8 +272,8 @@ async def unlink_application(
 
 @router.get("/applications/{application_id}/contacts")
 async def get_application_contacts(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """Get contacts linked to an application (reverse lookup)."""

--- a/src/career_os/api/discovery.py
+++ b/src/career_os/api/discovery.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
@@ -30,6 +30,7 @@ from career_os.services.discovery import (
     run_discovery,
     update_search_profile,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["discovery"])
 
@@ -107,7 +108,7 @@ async def create_search_profile_endpoint(
     "/api/search-profiles",
 )
 async def list_search_profiles_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     active_only: Annotated[bool, Query(description="Only active profiles")] = False,
 ) -> SearchProfileListResponse:
@@ -124,8 +125,8 @@ async def list_search_profiles_endpoint(
     responses=RESP_404,
 )
 async def get_search_profile_endpoint(
-    sp_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SearchProfileResponse:
     """Get a single search profile."""
@@ -141,9 +142,9 @@ async def get_search_profile_endpoint(
     responses=RESP_404,
 )
 async def update_search_profile_endpoint(
-    sp_id: int,
+    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: SearchProfileUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SearchProfileResponse:
     """Update a search profile."""
@@ -165,8 +166,8 @@ async def update_search_profile_endpoint(
     responses=RESP_404,
 )
 async def delete_search_profile_endpoint(
-    sp_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a search profile."""
@@ -185,7 +186,7 @@ async def delete_search_profile_endpoint(
     "/api/discovery-runs",
 )
 async def list_discovery_runs_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,
 ) -> list[DiscoveryRunResponse]:
@@ -196,7 +197,7 @@ async def list_discovery_runs_endpoint(
 
 @router.get("/api/discovery-runs/latest")
 async def get_latest_discovery_run_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> DiscoveryRunResponse | None:
     """Get the most recent completed discovery run for a profile."""

--- a/src/career_os/api/discovery.py
+++ b/src/career_os/api/discovery.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.discovery import (
     DiscoveredJobResponse,
     DiscoverRequest,
@@ -30,7 +31,6 @@ from career_os.services.discovery import (
     run_discovery,
     update_search_profile,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["discovery"])
 
@@ -108,7 +108,7 @@ async def create_search_profile_endpoint(
     "/api/search-profiles",
 )
 async def list_search_profiles_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     active_only: Annotated[bool, Query(description="Only active profiles")] = False,
 ) -> SearchProfileListResponse:
@@ -125,8 +125,8 @@ async def list_search_profiles_endpoint(
     responses=RESP_404,
 )
 async def get_search_profile_endpoint(
-    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    sp_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SearchProfileResponse:
     """Get a single search profile."""
@@ -142,9 +142,9 @@ async def get_search_profile_endpoint(
     responses=RESP_404,
 )
 async def update_search_profile_endpoint(
-    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    sp_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: SearchProfileUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SearchProfileResponse:
     """Update a search profile."""
@@ -166,8 +166,8 @@ async def update_search_profile_endpoint(
     responses=RESP_404,
 )
 async def delete_search_profile_endpoint(
-    sp_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    sp_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a search profile."""
@@ -186,7 +186,7 @@ async def delete_search_profile_endpoint(
     "/api/discovery-runs",
 )
 async def list_discovery_runs_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,
 ) -> list[DiscoveryRunResponse]:
@@ -197,7 +197,7 @@ async def list_discovery_runs_endpoint(
 
 @router.get("/api/discovery-runs/latest")
 async def get_latest_discovery_run_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> DiscoveryRunResponse | None:
     """Get the most recent completed discovery run for a profile."""

--- a/src/career_os/api/follow_ups.py
+++ b/src/career_os/api/follow_ups.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
@@ -23,6 +23,7 @@ from career_os.services.follow_ups import (
     get_overdue_count,
     list_follow_ups,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/follow-ups", tags=["follow-ups"])
 
@@ -60,7 +61,7 @@ async def create(
 
 @router.get("/overdue-count")
 async def overdue_count(
-    profile_id: Annotated[int, Query(description="Profile to check overdue count for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to check overdue count for")],
     db: Annotated[Session, Depends(get_db)],
 ) -> OverdueCountResponse:
     """Get the count of overdue, incomplete follow-ups."""
@@ -70,7 +71,7 @@ async def overdue_count(
 
 @router.get("")
 async def list_all(
-    profile_id: Annotated[int, Query(description="Profile to list follow-ups for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list follow-ups for")],
     db: Annotated[Session, Depends(get_db)],
     overdue: Annotated[bool, Query(description="Only show overdue follow-ups")] = False,
 ) -> FollowUpListResponse:
@@ -98,9 +99,9 @@ async def list_all(
 
 @router.patch("/{follow_up_id}", responses=RESP_404)
 async def complete(
-    follow_up_id: int,
+    follow_up_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: FollowUpComplete,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FollowUpResponse:
     """Complete a follow-up (set completed_at).

--- a/src/career_os/api/follow_ups.py
+++ b/src/career_os/api/follow_ups.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.follow_ups import (
     FollowUpComplete,
     FollowUpCreate,
@@ -23,7 +24,6 @@ from career_os.services.follow_ups import (
     get_overdue_count,
     list_follow_ups,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/follow-ups", tags=["follow-ups"])
 
@@ -61,7 +61,9 @@ async def create(
 
 @router.get("/overdue-count")
 async def overdue_count(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to check overdue count for")],
+    profile_id: Annotated[
+        int, Query(ge=1, le=INT32_MAX, description="Profile to check overdue count for")
+    ],
     db: Annotated[Session, Depends(get_db)],
 ) -> OverdueCountResponse:
     """Get the count of overdue, incomplete follow-ups."""
@@ -71,7 +73,9 @@ async def overdue_count(
 
 @router.get("")
 async def list_all(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list follow-ups for")],
+    profile_id: Annotated[
+        int, Query(ge=1, le=INT32_MAX, description="Profile to list follow-ups for")
+    ],
     db: Annotated[Session, Depends(get_db)],
     overdue: Annotated[bool, Query(description="Only show overdue follow-ups")] = False,
 ) -> FollowUpListResponse:
@@ -99,9 +103,9 @@ async def list_all(
 
 @router.patch("/{follow_up_id}", responses=RESP_404)
 async def complete(
-    follow_up_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    follow_up_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: FollowUpComplete,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FollowUpResponse:
     """Complete a follow-up (set completed_at).

--- a/src/career_os/api/gaps.py
+++ b/src/career_os/api/gaps.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
@@ -25,6 +25,7 @@ from career_os.services.gap_analysis import (
     analyze_gaps,
     create_job_requirements,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["gaps"])
 
@@ -34,8 +35,8 @@ router = APIRouter(tags=["gaps"])
     responses={**RESP_404, 400: {"description": "Bad request"}},
 )
 async def get_application_gaps(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GapAnalysisResponse:
     """Perform gap analysis for a specific application.
@@ -70,7 +71,7 @@ async def get_application_gaps(
     responses=RESP_404,
 )
 async def get_aggregate_gaps(
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> AggregateGapResponse:
     """Get aggregate gap analysis across all applications.
@@ -94,8 +95,8 @@ async def get_aggregate_gaps(
     "/api/applications/{application_id}/requirements",
 )
 async def get_requirements(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[JobRequirementResponse]:
     """Get job requirements for an application.
@@ -123,7 +124,7 @@ async def get_requirements(
     responses=RESP_404,
 )
 async def create_requirements(
-    application_id: int,
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: JobRequirementBulkCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> list[JobRequirementResponse]:

--- a/src/career_os/api/gaps.py
+++ b/src/career_os/api/gaps.py
@@ -9,6 +9,7 @@ from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
 from career_os.models.models import Application
 from career_os.models.skills import JobRequirement
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.gaps import (
     AggregateGapItem,
     AggregateGapResponse,
@@ -25,7 +26,6 @@ from career_os.services.gap_analysis import (
     analyze_gaps,
     create_job_requirements,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["gaps"])
 
@@ -35,8 +35,8 @@ router = APIRouter(tags=["gaps"])
     responses={**RESP_404, 400: {"description": "Bad request"}},
 )
 async def get_application_gaps(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GapAnalysisResponse:
     """Perform gap analysis for a specific application.
@@ -71,7 +71,7 @@ async def get_application_gaps(
     responses=RESP_404,
 )
 async def get_aggregate_gaps(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> AggregateGapResponse:
     """Get aggregate gap analysis across all applications.
@@ -95,8 +95,8 @@ async def get_aggregate_gaps(
     "/api/applications/{application_id}/requirements",
 )
 async def get_requirements(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[JobRequirementResponse]:
     """Get job requirements for an application.
@@ -124,7 +124,7 @@ async def get_requirements(
     responses=RESP_404,
 )
 async def create_requirements(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: JobRequirementBulkCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> list[JobRequirementResponse]:

--- a/src/career_os/api/goals.py
+++ b/src/career_os/api/goals.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404

--- a/src/career_os/api/goals.py
+++ b/src/career_os/api/goals.py
@@ -33,13 +33,14 @@ from career_os.services.goals import (
     recalibrate_goal,
     update_goal,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/goals", tags=["goals"])
 
 
 @router.get("")
 async def list_goals_endpoint(
-    profile_id: Annotated[int, Query(description="Profile to list goals for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list goals for")],
     db: Annotated[Session, Depends(get_db)],
     status: Annotated[str | None, Query(description="Filter by status")] = None,
     goal_type: Annotated[str | None, Query(description="Filter by type")] = None,
@@ -54,8 +55,8 @@ async def list_goals_endpoint(
 
 @router.get("/{goal_id}", responses=RESP_404)
 async def get_goal_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoalResponse:
     """Get a single goal by ID."""
@@ -91,9 +92,9 @@ async def create_goal_endpoint(
 
 @router.put("/{goal_id}", responses=RESP_404)
 async def update_goal_endpoint(
-    goal_id: int,
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: GoalUpdate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoalResponse:
     """Update a goal's fields."""
@@ -112,8 +113,8 @@ async def update_goal_endpoint(
 
 @router.delete("/{goal_id}", status_code=204, responses=RESP_404)
 async def delete_goal_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a goal."""
@@ -125,8 +126,8 @@ async def delete_goal_endpoint(
 
 @router.get("/{goal_id}/reality-map", responses=RESP_404)
 async def get_reality_map_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RealityMapResponse:
     """Get goal-to-reality mapping.
@@ -150,8 +151,8 @@ async def get_reality_map_endpoint(
 
 @router.get("/{goal_id}/progress", responses=RESP_404)
 async def get_progress_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ProgressResponse:
     """Get progress tracking across applications, learning, portfolio."""
@@ -170,8 +171,8 @@ async def get_progress_endpoint(
 
 @router.put("/{goal_id}/recalibrate", responses=RESP_404)
 async def recalibrate_goal_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RecalibrationResponse:
     """AI-powered goal recalibration with market-data-backed suggestions."""
@@ -191,8 +192,8 @@ async def recalibrate_goal_endpoint(
 
 @router.get("/{goal_id}/alternatives", responses=RESP_404)
 async def get_alternatives_endpoint(
-    goal_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> AlternativesResponse:
     """Get alternative path analysis (employment, freelance, consulting)."""

--- a/src/career_os/api/goals.py
+++ b/src/career_os/api/goals.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.goals import (
     AlternativePath,
     AlternativesResponse,
@@ -33,14 +34,13 @@ from career_os.services.goals import (
     recalibrate_goal,
     update_goal,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/goals", tags=["goals"])
 
 
 @router.get("")
 async def list_goals_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list goals for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description="Profile to list goals for")],
     db: Annotated[Session, Depends(get_db)],
     status: Annotated[str | None, Query(description="Filter by status")] = None,
     goal_type: Annotated[str | None, Query(description="Filter by type")] = None,
@@ -55,8 +55,8 @@ async def list_goals_endpoint(
 
 @router.get("/{goal_id}", responses=RESP_404)
 async def get_goal_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoalResponse:
     """Get a single goal by ID."""
@@ -92,9 +92,9 @@ async def create_goal_endpoint(
 
 @router.put("/{goal_id}", responses=RESP_404)
 async def update_goal_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: GoalUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GoalResponse:
     """Update a goal's fields."""
@@ -113,8 +113,8 @@ async def update_goal_endpoint(
 
 @router.delete("/{goal_id}", status_code=204, responses=RESP_404)
 async def delete_goal_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a goal."""
@@ -126,8 +126,8 @@ async def delete_goal_endpoint(
 
 @router.get("/{goal_id}/reality-map", responses=RESP_404)
 async def get_reality_map_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RealityMapResponse:
     """Get goal-to-reality mapping.
@@ -151,8 +151,8 @@ async def get_reality_map_endpoint(
 
 @router.get("/{goal_id}/progress", responses=RESP_404)
 async def get_progress_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ProgressResponse:
     """Get progress tracking across applications, learning, portfolio."""
@@ -171,8 +171,8 @@ async def get_progress_endpoint(
 
 @router.put("/{goal_id}/recalibrate", responses=RESP_404)
 async def recalibrate_goal_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RecalibrationResponse:
     """AI-powered goal recalibration with market-data-backed suggestions."""
@@ -192,8 +192,8 @@ async def recalibrate_goal_endpoint(
 
 @router.get("/{goal_id}/alternatives", responses=RESP_404)
 async def get_alternatives_endpoint(
-    goal_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    goal_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> AlternativesResponse:
     """Get alternative path analysis (employment, freelance, consulting)."""

--- a/src/career_os/api/intelligence.py
+++ b/src/career_os/api/intelligence.py
@@ -25,6 +25,7 @@ from career_os.services.role_intelligence import (
     get_interview_patterns,
     get_salary_benchmarks,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ router = APIRouter(prefix="/api/intelligence", tags=["role-intelligence"])
 )
 async def interview_format_endpoint(
     company: Annotated[str, Query(min_length=1, description="Company name")],
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     role: Annotated[
         str | None, Query(description="Optional role context for more specific results")
@@ -81,7 +82,7 @@ async def interview_format_endpoint(
 )
 async def salary_benchmark_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type to benchmark")],
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     location: Annotated[str | None, Query(description="Optional location filter")] = None,
     company_stage: Annotated[
@@ -123,7 +124,7 @@ async def salary_benchmark_endpoint(
 )
 async def interview_patterns_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type")],
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InterviewPatternsResponse:
     """Get common interview patterns for a role type.

--- a/src/career_os/api/intelligence.py
+++ b/src/career_os/api/intelligence.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404_500
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.role_intelligence import (
     InterviewFormatResponse,
     InterviewPatternsResponse,
@@ -25,7 +26,6 @@ from career_os.services.role_intelligence import (
     get_interview_patterns,
     get_salary_benchmarks,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ router = APIRouter(prefix="/api/intelligence", tags=["role-intelligence"])
 )
 async def interview_format_endpoint(
     company: Annotated[str, Query(min_length=1, description="Company name")],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     role: Annotated[
         str | None, Query(description="Optional role context for more specific results")
@@ -82,7 +82,7 @@ async def interview_format_endpoint(
 )
 async def salary_benchmark_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type to benchmark")],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     location: Annotated[str | None, Query(description="Optional location filter")] = None,
     company_stage: Annotated[
@@ -124,7 +124,7 @@ async def salary_benchmark_endpoint(
 )
 async def interview_patterns_endpoint(
     role: Annotated[str, Query(min_length=1, description="Role type")],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InterviewPatternsResponse:
     """Get common interview patterns for a role type.

--- a/src/career_os/api/interview_prep.py
+++ b/src/career_os/api/interview_prep.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404_500
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.interview_prep import (
     InterviewPrepResponse,
     PrepChecklistItem,
@@ -28,7 +29,6 @@ from career_os.services.interview_prep import (
     get_or_create_interview_prep,
     update_prep_item,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ router = APIRouter(prefix="/api/applications", tags=["interview-prep"])
     responses=RESP_404_500,
 )
 async def get_interview_prep_endpoint(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InterviewPrepResponse:
     """Get or generate interview preparation for an application.
@@ -85,9 +85,9 @@ async def get_interview_prep_endpoint(
     responses=RESP_404_500,
 )
 async def update_prep_item_endpoint(
-    item_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    item_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     body: PrepItemUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> PrepChecklistItem:
     """Update a prep checklist item's completion state.

--- a/src/career_os/api/interview_prep.py
+++ b/src/career_os/api/interview_prep.py
@@ -11,7 +11,7 @@ Covers:
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404_500
@@ -28,6 +28,7 @@ from career_os.services.interview_prep import (
     get_or_create_interview_prep,
     update_prep_item,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +45,8 @@ router = APIRouter(prefix="/api/applications", tags=["interview-prep"])
     responses=RESP_404_500,
 )
 async def get_interview_prep_endpoint(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> InterviewPrepResponse:
     """Get or generate interview preparation for an application.
@@ -84,9 +85,9 @@ async def get_interview_prep_endpoint(
     responses=RESP_404_500,
 )
 async def update_prep_item_endpoint(
-    item_id: int,
+    item_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     body: PrepItemUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> PrepChecklistItem:
     """Update a prep checklist item's completion state.

--- a/src/career_os/api/jobs.py
+++ b/src/career_os/api/jobs.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
@@ -25,6 +25,7 @@ from career_os.services.jobs import (
     search_jobs,
     update_saved_search,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["jobs"])
 
@@ -36,13 +37,13 @@ router = APIRouter(tags=["jobs"])
 
 @router.get("/api/jobs", responses=RESP_404)
 async def search_jobs_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     q: Annotated[str | None, Query(description="Full-text search query")] = None,
     source: Annotated[str | None, Query(description="Filter by source name")] = None,
     remote: Annotated[bool | None, Query(description="Filter by remote status")] = None,
-    salary_min: Annotated[int | None, Query(description="Min salary (numeric)")] = None,
-    salary_max: Annotated[int | None, Query(description="Max salary (numeric)")] = None,
+    salary_min: Annotated[int | None, Query(ge=0, le=INT64_MAX, description="Min salary (numeric)")] = None,
+    salary_max: Annotated[int | None, Query(ge=0, le=INT64_MAX, description="Max salary (numeric)")] = None,
     score_min: Annotated[float | None, Query(description="Min fit score")] = None,
     score_max: Annotated[float | None, Query(description="Max fit score")] = None,
     date_from: Annotated[str | None, Query(description="Date from (ISO 8601)")] = None,
@@ -53,7 +54,7 @@ async def search_jobs_endpoint(
         str | None, Query(description="Sort by: score, date, salary, readiness")
     ] = None,
     order: Annotated[str | None, Query(description="Sort order: asc, desc")] = None,
-    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    page: Annotated[int, Query(ge=1, le=INT64_MAX, description="Page number")] = 1,
     page_size: Annotated[int, Query(ge=1, le=100, description="Page size")] = 20,
 ) -> JobSearchResponse:
     """Search, filter, sort, and paginate discovered jobs.
@@ -139,7 +140,7 @@ async def create_saved_search_endpoint(
     "/api/saved-searches",
 )
 async def list_saved_searches_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchListResponse:
     """List all saved searches for a profile."""
@@ -155,8 +156,8 @@ async def list_saved_searches_endpoint(
     responses=RESP_404,
 )
 async def get_saved_search_endpoint(
-    search_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchResponse:
     """Get a single saved search."""
@@ -172,9 +173,9 @@ async def get_saved_search_endpoint(
     responses=RESP_404,
 )
 async def update_saved_search_endpoint(
-    search_id: int,
+    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: SavedSearchUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchResponse:
     """Update a saved search."""
@@ -198,8 +199,8 @@ async def update_saved_search_endpoint(
     responses=RESP_404,
 )
 async def delete_saved_search_endpoint(
-    search_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a saved search."""

--- a/src/career_os/api/jobs.py
+++ b/src/career_os/api/jobs.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.jobs import (
     JobSearchResponse,
     JobSearchResult,
@@ -25,7 +26,6 @@ from career_os.services.jobs import (
     search_jobs,
     update_saved_search,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["jobs"])
 
@@ -37,13 +37,17 @@ router = APIRouter(tags=["jobs"])
 
 @router.get("/api/jobs", responses=RESP_404)
 async def search_jobs_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     q: Annotated[str | None, Query(description="Full-text search query")] = None,
     source: Annotated[str | None, Query(description="Filter by source name")] = None,
     remote: Annotated[bool | None, Query(description="Filter by remote status")] = None,
-    salary_min: Annotated[int | None, Query(ge=0, le=INT64_MAX, description="Min salary (numeric)")] = None,
-    salary_max: Annotated[int | None, Query(ge=0, le=INT64_MAX, description="Max salary (numeric)")] = None,
+    salary_min: Annotated[
+        int | None, Query(ge=0, le=INT32_MAX, description="Min salary (numeric)")
+    ] = None,
+    salary_max: Annotated[
+        int | None, Query(ge=0, le=INT32_MAX, description="Max salary (numeric)")
+    ] = None,
     score_min: Annotated[float | None, Query(description="Min fit score")] = None,
     score_max: Annotated[float | None, Query(description="Max fit score")] = None,
     date_from: Annotated[str | None, Query(description="Date from (ISO 8601)")] = None,
@@ -54,7 +58,7 @@ async def search_jobs_endpoint(
         str | None, Query(description="Sort by: score, date, salary, readiness")
     ] = None,
     order: Annotated[str | None, Query(description="Sort order: asc, desc")] = None,
-    page: Annotated[int, Query(ge=1, le=INT64_MAX, description="Page number")] = 1,
+    page: Annotated[int, Query(ge=1, le=INT32_MAX, description="Page number")] = 1,
     page_size: Annotated[int, Query(ge=1, le=100, description="Page size")] = 20,
 ) -> JobSearchResponse:
     """Search, filter, sort, and paginate discovered jobs.
@@ -140,7 +144,7 @@ async def create_saved_search_endpoint(
     "/api/saved-searches",
 )
 async def list_saved_searches_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchListResponse:
     """List all saved searches for a profile."""
@@ -156,8 +160,8 @@ async def list_saved_searches_endpoint(
     responses=RESP_404,
 )
 async def get_saved_search_endpoint(
-    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    search_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchResponse:
     """Get a single saved search."""
@@ -173,9 +177,9 @@ async def get_saved_search_endpoint(
     responses=RESP_404,
 )
 async def update_saved_search_endpoint(
-    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    search_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: SavedSearchUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SavedSearchResponse:
     """Update a saved search."""
@@ -199,8 +203,8 @@ async def update_saved_search_endpoint(
     responses=RESP_404,
 )
 async def delete_saved_search_endpoint(
-    search_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    search_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a saved search."""

--- a/src/career_os/api/learning.py
+++ b/src/career_os/api/learning.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.learning import (
     GapRecommendationsResponse,
     LearningResourceCreate,
@@ -23,7 +24,6 @@ from career_os.services.learning import (
     get_gap_recommendations,
     update_learning_status,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["learning"])
 
@@ -33,8 +33,8 @@ router = APIRouter(tags=["learning"])
     responses=RESP_404,
 )
 async def get_recommendations(
-    gap_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    gap_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GapRecommendationsResponse:
     """Get learning recommendations for a specific gap.
@@ -77,7 +77,7 @@ async def get_recommendations(
     responses=RESP_404,
 )
 async def add_recommendation(
-    gap_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    gap_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: LearningResourceCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> LearningResourceResponse:
@@ -113,7 +113,7 @@ async def add_recommendation(
     responses=RESP_404_422,
 )
 async def update_status(
-    resource_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    resource_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: LearningStatusUpdate,
     db: Annotated[Session, Depends(get_db)],
 ) -> LearningResourceResponse:

--- a/src/career_os/api/learning.py
+++ b/src/career_os/api/learning.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
@@ -23,6 +23,7 @@ from career_os.services.learning import (
     get_gap_recommendations,
     update_learning_status,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["learning"])
 
@@ -32,8 +33,8 @@ router = APIRouter(tags=["learning"])
     responses=RESP_404,
 )
 async def get_recommendations(
-    gap_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    gap_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> GapRecommendationsResponse:
     """Get learning recommendations for a specific gap.
@@ -76,7 +77,7 @@ async def get_recommendations(
     responses=RESP_404,
 )
 async def add_recommendation(
-    gap_id: int,
+    gap_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: LearningResourceCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> LearningResourceResponse:
@@ -112,7 +113,7 @@ async def add_recommendation(
     responses=RESP_404_422,
 )
 async def update_status(
-    resource_id: int,
+    resource_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: LearningStatusUpdate,
     db: Annotated[Session, Depends(get_db)],
 ) -> LearningResourceResponse:

--- a/src/career_os/api/market.py
+++ b/src/career_os/api/market.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.market import (
     HiringPatternsResponse,
     MarketRefreshRequest,
@@ -26,7 +27,6 @@ from career_os.services.market import (
     get_skill_trends,
     refresh_market_data,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["market-intelligence"])
 
@@ -38,7 +38,7 @@ router = APIRouter(tags=["market-intelligence"])
 
 @router.get("/api/market/salary-trends", responses=RESP_404)
 async def salary_trends_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     role: Annotated[str | None, Query(description="Filter by role substring")] = None,
     location: Annotated[str | None, Query(description="Filter by location substring")] = None,
@@ -63,7 +63,7 @@ async def salary_trends_endpoint(
 
 @router.get("/api/market/skill-trends", responses=RESP_404)
 async def skill_trends_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillTrendsResponse:
     """Get most-demanded skills ranked by mention count.
@@ -86,7 +86,7 @@ async def skill_trends_endpoint(
 
 @router.get("/api/market/hiring-patterns", responses=RESP_404)
 async def hiring_patterns_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> HiringPatternsResponse:
     """Get company hiring patterns.
@@ -109,7 +109,7 @@ async def hiring_patterns_endpoint(
 
 @router.get("/api/market/positioning", responses=RESP_404)
 async def positioning_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> PositioningResponse:
     """Get market positioning - profile match % by role type.
@@ -132,7 +132,7 @@ async def positioning_endpoint(
 
 @router.get("/api/market/opportunity-radar", responses=RESP_404)
 async def opportunity_radar_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     dream_companies: Annotated[
         str | None,

--- a/src/career_os/api/market.py
+++ b/src/career_os/api/market.py
@@ -26,6 +26,7 @@ from career_os.services.market import (
     get_skill_trends,
     refresh_market_data,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(tags=["market-intelligence"])
 
@@ -37,7 +38,7 @@ router = APIRouter(tags=["market-intelligence"])
 
 @router.get("/api/market/salary-trends", responses=RESP_404)
 async def salary_trends_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     role: Annotated[str | None, Query(description="Filter by role substring")] = None,
     location: Annotated[str | None, Query(description="Filter by location substring")] = None,
@@ -62,7 +63,7 @@ async def salary_trends_endpoint(
 
 @router.get("/api/market/skill-trends", responses=RESP_404)
 async def skill_trends_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillTrendsResponse:
     """Get most-demanded skills ranked by mention count.
@@ -85,7 +86,7 @@ async def skill_trends_endpoint(
 
 @router.get("/api/market/hiring-patterns", responses=RESP_404)
 async def hiring_patterns_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> HiringPatternsResponse:
     """Get company hiring patterns.
@@ -108,7 +109,7 @@ async def hiring_patterns_endpoint(
 
 @router.get("/api/market/positioning", responses=RESP_404)
 async def positioning_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> PositioningResponse:
     """Get market positioning - profile match % by role type.
@@ -131,7 +132,7 @@ async def positioning_endpoint(
 
 @router.get("/api/market/opportunity-radar", responses=RESP_404)
 async def opportunity_radar_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     dream_companies: Annotated[
         str | None,

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from career_os.api.constants import PROFILE_NOT_FOUND, RESP_404
 from career_os.database import get_db
 from career_os.models.models import Profile
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.profiles import (
     ProfileCreate,
     ProfileListResponse,
@@ -17,7 +18,6 @@ from career_os.schemas.profiles import (
     ProfileUpdate,
 )
 from career_os.services.scoring import flag_stale_scores, regenerate_weights_for_job_family
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/profiles", tags=["profiles"])
 
@@ -33,7 +33,9 @@ async def list_profiles(db: Annotated[Session, Depends(get_db)]) -> ProfileListR
 
 
 @router.get("/{profile_id}", responses=RESP_404)
-async def get_profile(profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)], db: Annotated[Session, Depends(get_db)]) -> ProfileResponse:
+async def get_profile(
+    profile_id: Annotated[int, Path(ge=1, le=INT32_MAX)], db: Annotated[Session, Depends(get_db)]
+) -> ProfileResponse:
     """Get a specific profile by ID."""
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
     if profile is None:
@@ -65,7 +67,7 @@ async def create_profile(
 
 @router.patch("/{profile_id}", responses=RESP_404)
 async def update_profile(
-    profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: ProfileUpdate,
     db: Annotated[Session, Depends(get_db)],
 ) -> ProfileResponse:
@@ -108,7 +110,7 @@ async def update_profile(
     responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def delete_profile(
-    profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a profile.

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -3,7 +3,7 @@
 import json
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -17,6 +17,7 @@ from career_os.schemas.profiles import (
     ProfileUpdate,
 )
 from career_os.services.scoring import flag_stale_scores, regenerate_weights_for_job_family
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/profiles", tags=["profiles"])
 
@@ -32,7 +33,7 @@ async def list_profiles(db: Annotated[Session, Depends(get_db)]) -> ProfileListR
 
 
 @router.get("/{profile_id}", responses=RESP_404)
-async def get_profile(profile_id: int, db: Annotated[Session, Depends(get_db)]) -> ProfileResponse:
+async def get_profile(profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)], db: Annotated[Session, Depends(get_db)]) -> ProfileResponse:
     """Get a specific profile by ID."""
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
     if profile is None:
@@ -64,7 +65,7 @@ async def create_profile(
 
 @router.patch("/{profile_id}", responses=RESP_404)
 async def update_profile(
-    profile_id: int,
+    profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: ProfileUpdate,
     db: Annotated[Session, Depends(get_db)],
 ) -> ProfileResponse:
@@ -107,7 +108,7 @@ async def update_profile(
     responses={**RESP_404, 409: {"description": "Conflict"}},
 )
 async def delete_profile(
-    profile_id: int,
+    profile_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a profile.

--- a/src/career_os/api/pushover.py
+++ b/src/career_os/api/pushover.py
@@ -27,6 +27,7 @@ from career_os.services.pushover import (
     trigger_interview_reminders,
     update_preferences,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
@@ -38,7 +39,7 @@ router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
 @router.get("/preferences")
 async def get_notification_preferences(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationPreferenceResponse:
     """Get notification preferences for a profile."""
@@ -48,7 +49,7 @@ async def get_notification_preferences(
 
 @router.put("/preferences")
 async def update_notification_preferences(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     payload: NotificationPreferenceUpdate = ...,
 ) -> NotificationPreferenceResponse:
@@ -64,11 +65,11 @@ async def update_notification_preferences(
 
 @router.get("/log")
 async def get_notification_log(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     category: Annotated[str | None, Query(description=DESC_FILTER_BY_CATEGORY)] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
-    offset: Annotated[int, Query(ge=0)] = 0,
+    offset: Annotated[int, Query(ge=0, le=INT64_MAX)] = 0,
 ) -> NotificationLogListResponse:
     """List notification history for a profile."""
     logs, total = list_notification_logs(
@@ -87,7 +88,7 @@ async def get_notification_log(
 
 @router.post("/trigger/follow-ups")
 async def trigger_follow_ups(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for due follow-ups and send Pushover notifications."""
@@ -97,7 +98,7 @@ async def trigger_follow_ups(
 
 @router.post("/trigger/ghosts")
 async def trigger_ghosts(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for ghost applications and send Pushover notifications."""
@@ -107,12 +108,12 @@ async def trigger_ghosts(
 
 @router.post("/trigger/discovery")
 async def trigger_discovery(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     company: Annotated[str, Query(description="Company name")],
     role: Annotated[str, Query(description="Role title")],
     score: Annotated[float, Query(ge=0, le=10, description="Fit score")],
     db: Annotated[Session, Depends(get_db)],
-    application_id: Annotated[int | None, Query()] = None,
+    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, )] = None,
     url: Annotated[str | None, Query()] = None,
 ) -> NotificationTriggerResponse:
     """Send notification for a high-scoring discovery."""
@@ -130,7 +131,7 @@ async def trigger_discovery(
 
 @router.post("/trigger/interviews")
 async def trigger_interviews(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for upcoming interviews and send Pushover reminders."""
@@ -145,7 +146,7 @@ async def trigger_interviews(
 
 @router.post("/deliver-queued")
 async def deliver_queued(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     """Deliver queued notifications that were deferred during quiet hours."""

--- a/src/career_os/api/pushover.py
+++ b/src/career_os/api/pushover.py
@@ -2,11 +2,12 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_FILTER_BY_CATEGORY, DESC_PROFILE_ID
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.pushover import (
     NotificationLogListResponse,
     NotificationLogResponse,
@@ -16,6 +17,7 @@ from career_os.schemas.pushover import (
     SendNotificationRequest,
 )
 from career_os.services.pushover import (
+    ProfileNotFoundError,
     deliver_queued_notifications,
     get_preferences,
     list_notification_logs,
@@ -27,7 +29,6 @@ from career_os.services.pushover import (
     trigger_interview_reminders,
     update_preferences,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
@@ -39,22 +40,28 @@ router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
 @router.get("/preferences")
 async def get_notification_preferences(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationPreferenceResponse:
     """Get notification preferences for a profile."""
-    pref = get_preferences(db, profile_id)
+    try:
+        pref = get_preferences(db, profile_id)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationPreferenceResponse.model_validate(pref)
 
 
 @router.put("/preferences")
 async def update_notification_preferences(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     payload: NotificationPreferenceUpdate = ...,
 ) -> NotificationPreferenceResponse:
     """Update notification preferences for a profile."""
-    pref = update_preferences(db, profile_id, payload)
+    try:
+        pref = update_preferences(db, profile_id, payload)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationPreferenceResponse.model_validate(pref)
 
 
@@ -65,11 +72,11 @@ async def update_notification_preferences(
 
 @router.get("/log")
 async def get_notification_log(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     category: Annotated[str | None, Query(description=DESC_FILTER_BY_CATEGORY)] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
-    offset: Annotated[int, Query(ge=0, le=INT64_MAX)] = 0,
+    offset: Annotated[int, Query(ge=0, le=INT32_MAX)] = 0,
 ) -> NotificationLogListResponse:
     """List notification history for a profile."""
     logs, total = list_notification_logs(
@@ -88,54 +95,66 @@ async def get_notification_log(
 
 @router.post("/trigger/follow-ups")
 async def trigger_follow_ups(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for due follow-ups and send Pushover notifications."""
-    result = trigger_follow_up_reminders(db, profile_id)
+    try:
+        result = trigger_follow_up_reminders(db, profile_id)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationTriggerResponse(**result)
 
 
 @router.post("/trigger/ghosts")
 async def trigger_ghosts(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for ghost applications and send Pushover notifications."""
-    result = trigger_ghost_alerts(db, profile_id)
+    try:
+        result = trigger_ghost_alerts(db, profile_id)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationTriggerResponse(**result)
 
 
 @router.post("/trigger/discovery")
 async def trigger_discovery(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     company: Annotated[str, Query(description="Company name")],
     role: Annotated[str, Query(description="Role title")],
     score: Annotated[float, Query(ge=0, le=10, description="Fit score")],
     db: Annotated[Session, Depends(get_db)],
-    application_id: Annotated[int | None, Query(ge=1, le=INT64_MAX, )] = None,
+    application_id: Annotated[int | None, Query(ge=1, le=INT32_MAX)] = None,
     url: Annotated[str | None, Query()] = None,
 ) -> NotificationTriggerResponse:
     """Send notification for a high-scoring discovery."""
-    result = trigger_discovery_alert(
-        db,
-        profile_id,
-        company=company,
-        role=role,
-        score=score,
-        application_id=application_id,
-        url=url,
-    )
+    try:
+        result = trigger_discovery_alert(
+            db,
+            profile_id,
+            company=company,
+            role=role,
+            score=score,
+            application_id=application_id,
+            url=url,
+        )
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationTriggerResponse(**result)
 
 
 @router.post("/trigger/interviews")
 async def trigger_interviews(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> NotificationTriggerResponse:
     """Check for upcoming interviews and send Pushover reminders."""
-    result = trigger_interview_reminders(db, profile_id)
+    try:
+        result = trigger_interview_reminders(db, profile_id)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return NotificationTriggerResponse(**result)
 
 
@@ -146,11 +165,14 @@ async def trigger_interviews(
 
 @router.post("/deliver-queued")
 async def deliver_queued(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     """Deliver queued notifications that were deferred during quiet hours."""
-    return deliver_queued_notifications(db, profile_id)
+    try:
+        return deliver_queued_notifications(db, profile_id)
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/send")
@@ -159,14 +181,17 @@ async def send_notification(
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     """Send a manual notification via Pushover."""
-    return send_test_notification(
-        db,
-        profile_id=payload.profile_id,
-        category=payload.category,
-        title=payload.title,
-        message=payload.message,
-        application_id=payload.application_id,
-    )
+    try:
+        return send_test_notification(
+            db,
+            profile_id=payload.profile_id,
+            category=payload.category,
+            title=payload.title,
+            message=payload.message,
+            application_id=payload.application_id,
+        )
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/test-connection")

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -10,6 +10,7 @@ from career_os.ai.base import ProviderQuotaError
 from career_os.ai.openrouter_provider import CreditsExhaustedError
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.scoring import (
     BatchScoreRequest,
     BatchScoreResponse,
@@ -51,7 +52,6 @@ from career_os.services.scoring import (
     submit_feedback,
     update_weights,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ async def score_endpoint(
 
 @router.get("/api/scoring-weights", responses=RESP_404)
 async def get_weights_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoringWeightsResponse:
     """Get scoring weights for a profile."""
@@ -136,7 +136,7 @@ async def get_weights_endpoint(
 @router.put("/api/scoring-weights", responses=RESP_404)
 async def update_weights_endpoint(
     payload: ScoringWeightsUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoringWeightsResponse:
     """Update scoring weights for a profile.
@@ -267,8 +267,8 @@ def _build_profile_completeness(
 
 @router.get("/api/score/job/{discovered_job_id}", responses=RESP_404)
 async def get_job_score_endpoint(
-    discovered_job_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    discovered_job_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
     """Get the latest score for a discovered job.
@@ -289,8 +289,8 @@ async def get_job_score_endpoint(
     responses=RESP_404,
 )
 async def get_application_score_endpoint(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
     """Get the latest score for an application.
@@ -313,7 +313,7 @@ async def get_application_score_endpoint(
 
 @router.post("/api/scoring/flag-stale")
 async def flag_stale_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> dict[str, int]:
     """Mark all scores for a profile as stale.
@@ -339,9 +339,9 @@ async def flag_stale_endpoint(
     },
 )
 async def submit_feedback_endpoint(
-    scored_job_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    scored_job_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: FeedbackCreate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FeedbackResponse:
     """Submit user feedback on an AI-generated score.
@@ -369,7 +369,7 @@ async def submit_feedback_endpoint(
 
 @router.get("/api/score/feedback")
 async def list_feedback_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[FeedbackResponse]:
     """List all feedback records for a profile, newest first."""
@@ -379,7 +379,7 @@ async def list_feedback_endpoint(
 
 @router.get("/api/score/feedback/stats")
 async def feedback_stats_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FeedbackStats:
     """Return summary statistics for feedback submitted by a profile.
@@ -398,7 +398,7 @@ async def feedback_stats_endpoint(
 
 @router.get("/api/score/suggestions")
 async def suggestions_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SuggestionsResponse:
     """Get weight adjustment suggestions based on accumulated feedback.

--- a/src/career_os/api/scoring.py
+++ b/src/career_os/api/scoring.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.ai.base import ProviderQuotaError
@@ -51,6 +51,7 @@ from career_os.services.scoring import (
     submit_feedback,
     update_weights,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ async def score_endpoint(
 
 @router.get("/api/scoring-weights", responses=RESP_404)
 async def get_weights_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoringWeightsResponse:
     """Get scoring weights for a profile."""
@@ -135,7 +136,7 @@ async def get_weights_endpoint(
 @router.put("/api/scoring-weights", responses=RESP_404)
 async def update_weights_endpoint(
     payload: ScoringWeightsUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoringWeightsResponse:
     """Update scoring weights for a profile.
@@ -266,8 +267,8 @@ def _build_profile_completeness(
 
 @router.get("/api/score/job/{discovered_job_id}", responses=RESP_404)
 async def get_job_score_endpoint(
-    discovered_job_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    discovered_job_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
     """Get the latest score for a discovered job.
@@ -288,8 +289,8 @@ async def get_job_score_endpoint(
     responses=RESP_404,
 )
 async def get_application_score_endpoint(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ScoreResponse | None:
     """Get the latest score for an application.
@@ -312,7 +313,7 @@ async def get_application_score_endpoint(
 
 @router.post("/api/scoring/flag-stale")
 async def flag_stale_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> dict[str, int]:
     """Mark all scores for a profile as stale.
@@ -338,9 +339,9 @@ async def flag_stale_endpoint(
     },
 )
 async def submit_feedback_endpoint(
-    scored_job_id: int,
+    scored_job_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: FeedbackCreate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FeedbackResponse:
     """Submit user feedback on an AI-generated score.
@@ -368,7 +369,7 @@ async def submit_feedback_endpoint(
 
 @router.get("/api/score/feedback")
 async def list_feedback_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[FeedbackResponse]:
     """List all feedback records for a profile, newest first."""
@@ -378,7 +379,7 @@ async def list_feedback_endpoint(
 
 @router.get("/api/score/feedback/stats")
 async def feedback_stats_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> FeedbackStats:
     """Return summary statistics for feedback submitted by a profile.
@@ -397,7 +398,7 @@ async def feedback_stats_endpoint(
 
 @router.get("/api/score/suggestions")
 async def suggestions_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SuggestionsResponse:
     """Get weight adjustment suggestions based on accumulated feedback.

--- a/src/career_os/api/skills.py
+++ b/src/career_os/api/skills.py
@@ -1,9 +1,9 @@
 """Skills Intelligence API routes."""
 
-from pathlib import Path
+from pathlib import Path as FilePath
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import (
@@ -32,24 +32,25 @@ from career_os.services.skills import (
     list_skills,
     update_skill,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
 # Default paths for parsing sources
-_PROJECT_ROOT = Path(__file__).resolve().parents[3]  # src/../../../
+_PROJECT_ROOT = FilePath(__file__).resolve().parents[3]  # src/../../../
 _DEFAULT_CV_PATH = _PROJECT_ROOT / "cv" / "cv.yaml"
 _DEFAULT_PROFILE_DIR = _PROJECT_ROOT / "profile"
 
 
 @router.get("")
 async def list_skills_endpoint(
-    profile_id: Annotated[int, Query(description="Profile to list skills for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list skills for")],
     db: Annotated[Session, Depends(get_db)],
     category: Annotated[str | None, Query(description=DESC_FILTER_BY_CATEGORY)] = None,
     source: Annotated[str | None, Query(description="Filter by evidence source")] = None,
     proficiency: Annotated[str | None, Query(description="Filter by proficiency")] = None,
     q: Annotated[str | None, Query(description="Search by name")] = None,
-    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    page: Annotated[int, Query(ge=1, le=INT64_MAX, description="Page number")] = 1,
     page_size: Annotated[int, Query(ge=1, le=200, description="Results per page")] = 50,
 ) -> SkillListResponse | SkillsEmptyStateResponse:
     """List skills with optional filters.
@@ -79,8 +80,8 @@ async def list_skills_endpoint(
 
 @router.get("/{skill_id}", responses=RESP_404)
 async def get_skill_endpoint(
-    skill_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillResponse:
     """Get a single skill by ID."""
@@ -93,8 +94,8 @@ async def get_skill_endpoint(
 
 @router.get("/{skill_id}/history", responses=RESP_404)
 async def get_skill_history_endpoint(
-    skill_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[SkillHistoryResponse]:
     """Get proficiency change history for a skill."""
@@ -135,9 +136,9 @@ async def create_skill_endpoint(
 
 @router.put("/{skill_id}", responses=RESP_404)
 async def update_skill_endpoint(
-    skill_id: int,
+    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     payload: SkillUpdate,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillResponse:
     """Update a skill. Records history if proficiency changes."""

--- a/src/career_os/api/skills.py
+++ b/src/career_os/api/skills.py
@@ -12,6 +12,7 @@ from career_os.api.constants import (
     RESP_404,
 )
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.skills import (
     IngestRequest,
     IngestResponse,
@@ -32,7 +33,6 @@ from career_os.services.skills import (
     list_skills,
     update_skill,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
@@ -44,13 +44,13 @@ _DEFAULT_PROFILE_DIR = _PROJECT_ROOT / "profile"
 
 @router.get("")
 async def list_skills_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description="Profile to list skills for")],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description="Profile to list skills for")],
     db: Annotated[Session, Depends(get_db)],
     category: Annotated[str | None, Query(description=DESC_FILTER_BY_CATEGORY)] = None,
     source: Annotated[str | None, Query(description="Filter by evidence source")] = None,
     proficiency: Annotated[str | None, Query(description="Filter by proficiency")] = None,
     q: Annotated[str | None, Query(description="Search by name")] = None,
-    page: Annotated[int, Query(ge=1, le=INT64_MAX, description="Page number")] = 1,
+    page: Annotated[int, Query(ge=1, le=INT32_MAX, description="Page number")] = 1,
     page_size: Annotated[int, Query(ge=1, le=200, description="Results per page")] = 50,
 ) -> SkillListResponse | SkillsEmptyStateResponse:
     """List skills with optional filters.
@@ -80,8 +80,8 @@ async def list_skills_endpoint(
 
 @router.get("/{skill_id}", responses=RESP_404)
 async def get_skill_endpoint(
-    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    skill_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillResponse:
     """Get a single skill by ID."""
@@ -94,8 +94,8 @@ async def get_skill_endpoint(
 
 @router.get("/{skill_id}/history", responses=RESP_404)
 async def get_skill_history_endpoint(
-    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    skill_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[SkillHistoryResponse]:
     """Get proficiency change history for a skill."""
@@ -136,9 +136,9 @@ async def create_skill_endpoint(
 
 @router.put("/{skill_id}", responses=RESP_404)
 async def update_skill_endpoint(
-    skill_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    skill_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     payload: SkillUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SkillResponse:
     """Update a skill. Records history if proficiency changes."""

--- a/src/career_os/api/star_stories.py
+++ b/src/career_os/api/star_stories.py
@@ -9,7 +9,7 @@ Covers:
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
@@ -34,6 +34,7 @@ from career_os.services.star_stories import (
     list_star_stories,
     update_star_story,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ router = APIRouter(prefix="/api/star-stories", tags=["star-stories"])
 @router.post("", status_code=201, responses=RESP_404)
 async def create_star_story_endpoint(
     body: StarStoryCreate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Create a new STAR story."""
@@ -60,7 +61,7 @@ async def create_star_story_endpoint(
 
 @router.get("", responses=RESP_404)
 async def list_star_stories_endpoint(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryListResponse:
     """List all STAR stories for a profile."""
@@ -72,8 +73,8 @@ async def list_star_stories_endpoint(
 
 @router.get("/{story_id}", responses=RESP_404)
 async def get_star_story_endpoint(
-    story_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Get a single STAR story by ID."""
@@ -87,9 +88,9 @@ async def get_star_story_endpoint(
 
 @router.put("/{story_id}", responses=RESP_404)
 async def update_star_story_endpoint(
-    story_id: int,
+    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     body: StarStoryUpdate,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Update an existing STAR story."""
@@ -103,8 +104,8 @@ async def update_star_story_endpoint(
 
 @router.delete("/{story_id}", status_code=204, responses=RESP_404)
 async def delete_star_story_endpoint(
-    story_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a STAR story."""
@@ -128,8 +129,8 @@ app_router = APIRouter(prefix="/api/applications", tags=["star-stories"])
     responses=RESP_404,
 )
 async def get_recommended_stories_endpoint(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RecommendedStoriesResponse:
     """Get STAR stories recommended for an application.
@@ -149,8 +150,8 @@ async def get_recommended_stories_endpoint(
     responses=RESP_404,
 )
 async def get_story_gaps_endpoint(
-    application_id: int,
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StoryGapsResponse:
     """Identify skills with no corresponding STAR story.

--- a/src/career_os/api/star_stories.py
+++ b/src/career_os/api/star_stories.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_PROFILE_ID, RESP_404
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.star_stories import (
     RecommendedStoriesResponse,
     StarStoryCreate,
@@ -34,7 +35,6 @@ from career_os.services.star_stories import (
     list_star_stories,
     update_star_story,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ router = APIRouter(prefix="/api/star-stories", tags=["star-stories"])
 @router.post("", status_code=201, responses=RESP_404)
 async def create_star_story_endpoint(
     body: StarStoryCreate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Create a new STAR story."""
@@ -61,7 +61,7 @@ async def create_star_story_endpoint(
 
 @router.get("", responses=RESP_404)
 async def list_star_stories_endpoint(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryListResponse:
     """List all STAR stories for a profile."""
@@ -73,8 +73,8 @@ async def list_star_stories_endpoint(
 
 @router.get("/{story_id}", responses=RESP_404)
 async def get_star_story_endpoint(
-    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    story_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Get a single STAR story by ID."""
@@ -88,9 +88,9 @@ async def get_star_story_endpoint(
 
 @router.put("/{story_id}", responses=RESP_404)
 async def update_star_story_endpoint(
-    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    story_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     body: StarStoryUpdate,
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StarStoryResponse:
     """Update an existing STAR story."""
@@ -104,8 +104,8 @@ async def update_star_story_endpoint(
 
 @router.delete("/{story_id}", status_code=204, responses=RESP_404)
 async def delete_star_story_endpoint(
-    story_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    story_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a STAR story."""
@@ -129,8 +129,8 @@ app_router = APIRouter(prefix="/api/applications", tags=["star-stories"])
     responses=RESP_404,
 )
 async def get_recommended_stories_endpoint(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> RecommendedStoriesResponse:
     """Get STAR stories recommended for an application.
@@ -150,8 +150,8 @@ async def get_recommended_stories_endpoint(
     responses=RESP_404,
 )
 async def get_story_gaps_endpoint(
-    application_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    application_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> StoryGapsResponse:
     """Identify skills with no corresponding STAR story.

--- a/src/career_os/api/ticktick.py
+++ b/src/career_os/api/ticktick.py
@@ -11,6 +11,7 @@ from career_os.database import get_db
 from career_os.models.models import Application, FollowUp
 from career_os.models.skills import Goal
 from career_os.models.ticktick_sync import TickTickSyncTask
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.ticktick import (
     TickTickConnectionTestResponse,
     TickTickPullResponse,
@@ -29,14 +30,13 @@ from career_os.services.ticktick_sync import (
     sync_learning_goal_to_ticktick,
     sync_pipeline_action_to_ticktick,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/ticktick", tags=["ticktick"])
 
 
 @router.get("/status")
 async def ticktick_sync_status(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> TickTickSyncStatusResponse:
     """Get the current TickTick sync status for a profile."""
@@ -135,7 +135,7 @@ def _fetch_entity(db: Session, model, entity_id: int, profile_id: int, label: st
 
 @router.post("/pull", responses={400: {"description": "Bad request"}})
 async def ticktick_pull(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> TickTickPullResponse:
     """Pull completed tasks from TickTick and update Career OS entities."""

--- a/src/career_os/api/ticktick.py
+++ b/src/career_os/api/ticktick.py
@@ -29,13 +29,14 @@ from career_os.services.ticktick_sync import (
     sync_learning_goal_to_ticktick,
     sync_pipeline_action_to_ticktick,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/ticktick", tags=["ticktick"])
 
 
 @router.get("/status")
 async def ticktick_sync_status(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> TickTickSyncStatusResponse:
     """Get the current TickTick sync status for a profile."""
@@ -134,7 +135,7 @@ def _fetch_entity(db: Session, model, entity_id: int, profile_id: int, label: st
 
 @router.post("/pull", responses={400: {"description": "Bad request"}})
 async def ticktick_pull(
-    profile_id: Annotated[int, Query(description=DESC_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> TickTickPullResponse:
     """Pull completed tasks from TickTick and update Career OS entities."""

--- a/src/career_os/api/voice.py
+++ b/src/career_os/api/voice.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
@@ -26,6 +26,7 @@ from career_os.services.voice import (
     list_sessions,
     send_message,
 )
+from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/voice", tags=["voice"])
 
@@ -66,7 +67,7 @@ async def create_voice_session(
 
 @router.get("/sessions")
 async def list_voice_sessions(
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     mode: Annotated[str | None, Query(description="Filter by mode")] = None,
 ) -> VoiceSessionListResponse:
@@ -80,8 +81,8 @@ async def list_voice_sessions(
 
 @router.get("/sessions/{session_id}", responses=RESP_404)
 async def get_voice_session(
-    session_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSessionResponse:
     """Get a voice session with all messages."""
@@ -98,7 +99,7 @@ async def get_voice_session(
     responses=RESP_404,
 )
 async def send_voice_message(
-    session_id: int,
+    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
     data: VoiceMessageCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSendResponse:
@@ -131,8 +132,8 @@ async def send_voice_message(
     responses=RESP_404,
 )
 async def complete_voice_session(
-    session_id: int,
-    profile_id: Annotated[int, Query(description=DESC_ACTIVE_PROFILE_ID)],
+    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSessionResponse:
     """Mark a voice session as completed."""

--- a/src/career_os/api/voice.py
+++ b/src/career_os/api/voice.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from career_os.api.constants import DESC_ACTIVE_PROFILE_ID, RESP_404, RESP_404_422
 from career_os.database import get_db
+from career_os.schemas.constraints import INT32_MAX
 from career_os.schemas.voice import (
     VoiceMessageCreate,
     VoiceMessageResponse,
@@ -26,7 +27,6 @@ from career_os.services.voice import (
     list_sessions,
     send_message,
 )
-from career_os.schemas.constraints import INT64_MAX
 
 router = APIRouter(prefix="/api/voice", tags=["voice"])
 
@@ -67,7 +67,7 @@ async def create_voice_session(
 
 @router.get("/sessions")
 async def list_voice_sessions(
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
     mode: Annotated[str | None, Query(description="Filter by mode")] = None,
 ) -> VoiceSessionListResponse:
@@ -81,8 +81,8 @@ async def list_voice_sessions(
 
 @router.get("/sessions/{session_id}", responses=RESP_404)
 async def get_voice_session(
-    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    session_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSessionResponse:
     """Get a voice session with all messages."""
@@ -99,7 +99,7 @@ async def get_voice_session(
     responses=RESP_404,
 )
 async def send_voice_message(
-    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
+    session_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
     data: VoiceMessageCreate,
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSendResponse:
@@ -132,8 +132,8 @@ async def send_voice_message(
     responses=RESP_404,
 )
 async def complete_voice_session(
-    session_id: Annotated[int, Path(ge=1, le=INT64_MAX)],
-    profile_id: Annotated[int, Query(ge=1, le=INT64_MAX, description=DESC_ACTIVE_PROFILE_ID)],
+    session_id: Annotated[int, Path(ge=1, le=INT32_MAX)],
+    profile_id: Annotated[int, Query(ge=1, le=INT32_MAX, description=DESC_ACTIVE_PROFILE_ID)],
     db: Annotated[Session, Depends(get_db)],
 ) -> VoiceSessionResponse:
     """Mark a voice session as completed."""

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -294,10 +296,10 @@ class InterviewPatternsResult(BaseModel):
 class TokenUsage(BaseModel):
     """Token usage statistics from an AI provider response."""
 
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cache_creation_input_tokens: int = 0
-    cache_read_input_tokens: int = 0
+    input_tokens: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    output_tokens: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    cache_creation_input_tokens: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    cache_read_input_tokens: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/schemas/ai_health.py
+++ b/src/career_os/schemas/ai_health.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class ProviderCredits(BaseModel):
     """Credit/quota information for an AI provider."""
@@ -14,8 +16,8 @@ class ProviderCredits(BaseModel):
 class ProviderRateLimit(BaseModel):
     """Rate limit information for an AI provider."""
 
-    requests_per_minute: int | None = Field(None, description="RPM limit")
-    tokens_per_minute: int | None = Field(None, description="TPM limit")
+    requests_per_minute: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="RPM limit")
+    tokens_per_minute: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="TPM limit")
 
 
 class ProviderHealthStatus(BaseModel):

--- a/src/career_os/schemas/ai_health.py
+++ b/src/career_os/schemas/ai_health.py
@@ -16,7 +16,9 @@ class ProviderCredits(BaseModel):
 class ProviderRateLimit(BaseModel):
     """Rate limit information for an AI provider."""
 
-    requests_per_minute: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="RPM limit")
+    requests_per_minute: int | None = Field(
+        None, ge=INT64_MIN, le=INT64_MAX, description="RPM limit"
+    )
     tokens_per_minute: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="TPM limit")
 
 

--- a/src/career_os/schemas/analytics.py
+++ b/src/career_os/schemas/analytics.py
@@ -2,12 +2,14 @@
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class FunnelStage(BaseModel):
     """A single stage in the conversion funnel."""
 
     stage: str = Field(..., description="Pipeline status name")
-    count: int = Field(..., description="Number of applications in this stage")
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this stage")
     percentage: float = Field(
         ...,
         description=(
@@ -29,36 +31,36 @@ class WeeklyCount(BaseModel):
     """Weekly application count."""
 
     week: str = Field(..., description="ISO week start date (YYYY-MM-DD)")
-    count: int = Field(..., description="Number of applications created that week")
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications created that week")
 
 
 class ScoreBucket(BaseModel):
     """A histogram bucket for score distribution."""
 
     range: str = Field(..., description="Score range label (e.g. '8-9')")
-    count: int = Field(..., description="Number of applications in this range")
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this range")
 
 
 class PrepMetrics(BaseModel):
     """Interview prep completion metrics."""
 
-    total_sessions: int = Field(0, description="Total prep sessions created")
+    total_sessions: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total prep sessions created")
     completed_sessions: int = Field(
-        0, description="Sessions where all checklist items are completed"
+        0, ge=INT64_MIN, le=INT64_MAX, description="Sessions where all checklist items are completed"
     )
     completion_rate: float | None = Field(
         None, description="Percentage of prep sessions fully completed (0-100)"
     )
-    total_items: int = Field(0, description="Total checklist items across all sessions")
-    completed_items: int = Field(0, description="Total completed checklist items")
+    total_items: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total checklist items across all sessions")
+    completed_items: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total completed checklist items")
 
 
 class NotificationMetrics(BaseModel):
     """Notification delivery metrics."""
 
-    total_sent: int = Field(0, description="Total notifications sent")
-    total_failed: int = Field(0, description="Total failed notifications")
-    total_queued: int = Field(0, description="Total queued notifications")
+    total_sent: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total notifications sent")
+    total_failed: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total failed notifications")
+    total_queued: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total queued notifications")
     by_category: dict[str, int] = Field(
         default_factory=dict,
         description="Sent notification count per category (follow_up, ghost, discovery, interview)",

--- a/src/career_os/schemas/analytics.py
+++ b/src/career_os/schemas/analytics.py
@@ -9,7 +9,9 @@ class FunnelStage(BaseModel):
     """A single stage in the conversion funnel."""
 
     stage: str = Field(..., description="Pipeline status name")
-    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this stage")
+    count: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this stage"
+    )
     percentage: float = Field(
         ...,
         description=(
@@ -31,36 +33,53 @@ class WeeklyCount(BaseModel):
     """Weekly application count."""
 
     week: str = Field(..., description="ISO week start date (YYYY-MM-DD)")
-    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications created that week")
+    count: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications created that week"
+    )
 
 
 class ScoreBucket(BaseModel):
     """A histogram bucket for score distribution."""
 
     range: str = Field(..., description="Score range label (e.g. '8-9')")
-    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this range")
+    count: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications in this range"
+    )
 
 
 class PrepMetrics(BaseModel):
     """Interview prep completion metrics."""
 
-    total_sessions: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total prep sessions created")
+    total_sessions: int = Field(
+        0, ge=INT64_MIN, le=INT64_MAX, description="Total prep sessions created"
+    )
     completed_sessions: int = Field(
-        0, ge=INT64_MIN, le=INT64_MAX, description="Sessions where all checklist items are completed"
+        0,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Sessions where all checklist items are completed",
     )
     completion_rate: float | None = Field(
         None, description="Percentage of prep sessions fully completed (0-100)"
     )
-    total_items: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total checklist items across all sessions")
-    completed_items: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total completed checklist items")
+    total_items: int = Field(
+        0, ge=INT64_MIN, le=INT64_MAX, description="Total checklist items across all sessions"
+    )
+    completed_items: int = Field(
+        0, ge=INT64_MIN, le=INT64_MAX, description="Total completed checklist items"
+    )
 
 
 class NotificationMetrics(BaseModel):
     """Notification delivery metrics."""
 
     total_sent: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total notifications sent")
-    total_failed: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total failed notifications")
-    total_queued: int = Field(0, ge=INT64_MIN, le=INT64_MAX, description="Total queued notifications")
+    total_failed: int = Field(
+        0, ge=INT64_MIN, le=INT64_MAX, description="Total failed notifications"
+    )
+    total_queued: int = Field(
+        0, ge=INT64_MIN, le=INT64_MAX, description="Total queued notifications"
+    )
     by_category: dict[str, int] = Field(
         default_factory=dict,
         description="Sent notification count per category (follow_up, ghost, discovery, interview)",

--- a/src/career_os/schemas/applications.py
+++ b/src/career_os/schemas/applications.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -100,7 +102,7 @@ def is_valid_transition(from_status: str, to_status: str) -> bool:
 class ApplicationCreate(BaseModel):
     """Request body for POST /api/applications."""
 
-    profile_id: int = Field(..., description="Profile this application belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this application belongs to")
     company: str = Field(..., min_length=1, description="Company name")
     role: str = Field(..., min_length=1, description="Role / job title")
     url: str | None = Field(default=None, description="Job posting URL")
@@ -162,7 +164,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class ActivityLogResponse(BaseModel):
     """Response schema for an activity log entry."""
 
-    id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
     action: str
     details: str | None = None
     source: str | None = None
@@ -179,8 +181,8 @@ class ActivityLogResponse(BaseModel):
 class ApplicationResponse(BaseModel):
     """Response schema for a single application."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     company: str
     role: str
     url: str | None = None
@@ -217,7 +219,7 @@ class ApplicationResponse(BaseModel):
 class FollowUpSummaryResponse(BaseModel):
     """Minimal follow-up info embedded in application detail."""
 
-    id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
     due_date: datetime
     follow_up_type: str
     notes: str | None = None
@@ -235,7 +237,7 @@ class FollowUpSummaryResponse(BaseModel):
 class ApplicationPackageSummaryResponse(BaseModel):
     """Minimal application-package info embedded in application detail."""
 
-    id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
     package_name: str
     file_path: str
     package_type: str
@@ -255,4 +257,4 @@ class ApplicationListResponse(BaseModel):
     """Response schema for list of applications."""
 
     applications: list[ApplicationResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)

--- a/src/career_os/schemas/applications.py
+++ b/src/career_os/schemas/applications.py
@@ -102,7 +102,9 @@ def is_valid_transition(from_status: str, to_status: str) -> bool:
 class ApplicationCreate(BaseModel):
     """Request body for POST /api/applications."""
 
-    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this application belongs to")
+    profile_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Profile this application belongs to"
+    )
     company: str = Field(..., min_length=1, description="Company name")
     role: str = Field(..., min_length=1, description="Role / job title")
     url: str | None = Field(default=None, description="Job posting URL")
@@ -138,6 +140,8 @@ class ApplicationUpdate(BaseModel):
         """
         if v is None:
             return v
+        if not isinstance(v, str):
+            raise ValueError("status must be a string")
         try:
             return normalize_status(v)
         except ValueError:

--- a/src/career_os/schemas/calendar.py
+++ b/src/career_os/schemas/calendar.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class CalendarEventType(StrEnum):
     """Types of calendar events."""
@@ -25,9 +27,9 @@ class CalendarProvider(StrEnum):
 class CalendarEventCreate(BaseModel):
     """Request body for creating a calendar event."""
 
-    profile_id: int
-    application_id: int | None = None
-    follow_up_id: int | None = None
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    follow_up_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
 
     event_type: CalendarEventType
     title: str = Field(..., min_length=1, max_length=500)
@@ -69,11 +71,11 @@ class CalendarEventUpdate(BaseModel):
 class CalendarEventResponse(BaseModel):
     """Response schema for a calendar event."""
 
-    id: int
-    profile_id: int
-    application_id: int | None = None
-    follow_up_id: int | None = None
-    parent_event_id: int | None = None
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    follow_up_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    parent_event_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
 
     event_type: str
     title: str
@@ -88,7 +90,7 @@ class CalendarEventResponse(BaseModel):
     meeting_link: str | None = None
     prep_notes: str | None = None
 
-    reminder_minutes_before: int | None = None
+    reminder_minutes_before: int | None = Field(default=None, ge=INT64_MIN, le=INT64_MAX)
     uid: str | None = None
 
     created_at: datetime
@@ -101,7 +103,7 @@ class CalendarEventListResponse(BaseModel):
     """Response for listing calendar events."""
 
     events: list[CalendarEventResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class CalendarExportResponse(BaseModel):
@@ -116,18 +118,18 @@ class GoogleCalendarUrlResponse(BaseModel):
     """Response with a Google Calendar URL to add event."""
 
     url: str
-    event_id: int
+    event_id: int = Field(..., ge=1, le=INT64_MAX)
 
 
 class FantasticalUrlResponse(BaseModel):
     """Response with a Fantastical URL scheme to add event."""
 
     url: str
-    event_id: int
+    event_id: int = Field(..., ge=1, le=INT64_MAX)
 
 
 class CalendarProviderConfigResponse(BaseModel):
     """Response with provider-specific export data for an event."""
 
-    event_id: int
+    event_id: int = Field(..., ge=1, le=INT64_MAX)
     providers: dict[str, str]  # provider_name -> url_or_data

--- a/src/career_os/schemas/coaching.py
+++ b/src/career_os/schemas/coaching.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -35,10 +37,10 @@ class EffortEstimate(BaseModel):
 class CoachingSuggestionResponse(BaseModel):
     """A single coaching suggestion."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     action: str = Field(..., description="Actionable recommendation")
-    priority: int = Field(..., description="Priority rank (1 = highest)")
+    priority: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Priority rank (1 = highest)")
     effort_estimate: EffortEstimate = Field(
         ..., description="Effort estimate with hours, weeks, difficulty"
     )
@@ -63,5 +65,5 @@ class CoachingSuggestionsResponse(BaseModel):
     """Response for GET /api/coaching/suggestions."""
 
     suggestions: list[CoachingSuggestionResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     focus_area: str | None = Field(default=None, description="AI-recommended primary focus area")

--- a/src/career_os/schemas/coaching.py
+++ b/src/career_os/schemas/coaching.py
@@ -40,7 +40,9 @@ class CoachingSuggestionResponse(BaseModel):
     id: int = Field(..., ge=1, le=INT64_MAX)
     profile_id: int = Field(..., ge=1, le=INT64_MAX)
     action: str = Field(..., description="Actionable recommendation")
-    priority: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Priority rank (1 = highest)")
+    priority: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Priority rank (1 = highest)"
+    )
     effort_estimate: EffortEstimate = Field(
         ..., description="Effort estimate with hours, weeks, difficulty"
     )

--- a/src/career_os/schemas/constraints.py
+++ b/src/career_os/schemas/constraints.py
@@ -1,5 +1,19 @@
-"""Shared integer constraints for SQLite INT64 safety."""
+"""Shared integer constraints for SQLite INT64 safety.
 
-# SQLite INTEGER is signed 64-bit: -2^63 to 2^63-1
+INT32 bounds are used for query/path parameters because ASGI test
+transports (httpx/Schemathesis) serialize large integers through C
+`int` when building URL strings, causing OverflowError at 2^63.
+INT32_MAX (2^31-1 ≈ 2.1 billion) is more than sufficient for any
+practical ID or pagination value in a self-hosted SQLite app.
+
+Body (JSON) fields use the full INT64 range since JSON serialization
+handles arbitrary-precision integers natively.
+"""
+
+# C-int-safe bounds for query/path parameters
+INT32_MIN = -2_147_483_648
+INT32_MAX = 2_147_483_647
+
+# Full SQLite INTEGER range for JSON body fields
 INT64_MIN = -9_223_372_036_854_775_808
 INT64_MAX = 9_223_372_036_854_775_807

--- a/src/career_os/schemas/constraints.py
+++ b/src/career_os/schemas/constraints.py
@@ -1,0 +1,5 @@
+"""Shared integer constraints for SQLite INT64 safety."""
+
+# SQLite INTEGER is signed 64-bit: -2^63 to 2^63-1
+INT64_MIN = -9_223_372_036_854_775_808
+INT64_MAX = 9_223_372_036_854_775_807

--- a/src/career_os/schemas/contacts.py
+++ b/src/career_os/schemas/contacts.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -79,7 +81,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class ContactCreate(BaseModel):
     """Request body for POST /api/contacts."""
 
-    profile_id: int = Field(..., description="Profile this contact belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this contact belongs to")
     name: str = Field(..., min_length=1, max_length=255, description="Contact name")
     company: str | None = Field(default=None, max_length=255, description="Company")
     role: str | None = Field(default=None, max_length=255, description="Their role/title")
@@ -190,8 +192,8 @@ class ContactUpdate(BaseModel):
 class ContactResponse(BaseModel):
     """Response schema for a single contact."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     name: str
     company: str | None = None
     role: str | None = None
@@ -245,7 +247,7 @@ class ContactListResponse(BaseModel):
     """Response schema for list of contacts."""
 
     contacts: list[ContactResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -287,9 +289,9 @@ class InteractionCreate(BaseModel):
 class InteractionResponse(BaseModel):
     """Response schema for a single interaction."""
 
-    id: int
-    contact_id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    contact_id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     interaction_type: str
     direction: str
     subject: str | None = None
@@ -309,7 +311,7 @@ class InteractionListResponse(BaseModel):
     """Response schema for list of interactions."""
 
     interactions: list[InteractionResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +322,7 @@ class InteractionListResponse(BaseModel):
 class ContactApplicationCreate(BaseModel):
     """Request body for POST /api/contacts/{id}/applications."""
 
-    application_id: int = Field(..., description="Application to link")
+    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application to link")
     role: str = Field(..., description="Contact's role for this application")
     notes: str | None = Field(default=None, description="Notes about the link")
 
@@ -338,10 +340,10 @@ class ContactApplicationCreate(BaseModel):
 class ContactApplicationResponse(BaseModel):
     """Response schema for a contact-application link."""
 
-    id: int
-    contact_id: int
-    application_id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    contact_id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     role: str
     notes: str | None = None
     created_at: datetime

--- a/src/career_os/schemas/discovery.py
+++ b/src/career_os/schemas/discovery.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -27,7 +29,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class DiscoverRequest(BaseModel):
     """Request body for POST /api/discover — triggers a discovery sweep."""
 
-    profile_id: int = Field(..., description="Profile to discover jobs for")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile to discover jobs for")
     keywords: list[str] = Field(default_factory=list, description="Search keywords")
     locations: list[str] = Field(default_factory=list, description="Locations to search")
     remote_only: bool = Field(default=False, description="Only remote jobs")
@@ -37,6 +39,8 @@ class DiscoverRequest(BaseModel):
     )
     search_profile_id: int | None = Field(
         default=None,
+        ge=1,
+        le=INT64_MAX,
         description="Use saved search profile parameters instead of inline ones",
     )
     limit_per_source: int = Field(default=25, ge=1, le=100, description="Max per source")
@@ -45,8 +49,8 @@ class DiscoverRequest(BaseModel):
 class DiscoveredJobResponse(BaseModel):
     """Response schema for a single discovered job."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     company: str
     location: str
@@ -58,7 +62,7 @@ class DiscoveredJobResponse(BaseModel):
     sources: list[str] = []
     source_urls: list[str] = []
     fit_score: float | None = None
-    application_id: int | None = None
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     created_at: datetime
     updated_at: datetime
 
@@ -95,10 +99,10 @@ class DiscoveryWarning(BaseModel):
 class DiscoverResponse(BaseModel):
     """Response for POST /api/discover — sweep results."""
 
-    run_id: int
-    total_found: int
-    new_jobs: int
-    duplicates: int
+    run_id: int = Field(..., ge=1, le=INT64_MAX)
+    total_found: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    new_jobs: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    duplicates: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     jobs: list[DiscoveredJobResponse]
     warnings: list[DiscoveryWarning] = []
     sources_queried: list[str] = []
@@ -112,7 +116,7 @@ class DiscoverResponse(BaseModel):
 class SearchProfileCreate(BaseModel):
     """Request body for POST /api/search-profiles."""
 
-    profile_id: int = Field(..., description="Profile this search belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this search belongs to")
     name: str = Field(..., min_length=1, description="Search profile name")
     keywords: list[str] = Field(default_factory=list, description="Keywords")
     locations: list[str] = Field(default_factory=list, description="Locations")
@@ -136,8 +140,8 @@ class SearchProfileUpdate(BaseModel):
 class SearchProfileResponse(BaseModel):
     """Response schema for a saved search profile."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     name: str
     keywords: list[str] = []
     locations: list[str] = []
@@ -196,7 +200,7 @@ class SearchProfileListResponse(BaseModel):
     """Response for listing search profiles."""
 
     profiles: list[SearchProfileResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -207,15 +211,15 @@ class SearchProfileListResponse(BaseModel):
 class DiscoveryRunResponse(BaseModel):
     """Response schema for a discovery run log entry."""
 
-    id: int
-    profile_id: int
-    search_profile_id: int | None = None
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    search_profile_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     trigger: str
     status: str
-    total_found: int
-    new_jobs: int
-    duplicates: int
-    errors: int
+    total_found: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    new_jobs: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    duplicates: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    errors: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     warnings: list[DiscoveryWarning] = []
     started_at: datetime
     completed_at: datetime | None = None

--- a/src/career_os/schemas/follow_ups.py
+++ b/src/career_os/schemas/follow_ups.py
@@ -25,8 +25,12 @@ def _ensure_utc(v: Any) -> datetime | None:
 class FollowUpCreate(BaseModel):
     """Request body for POST /api/follow-ups."""
 
-    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application this follow-up belongs to")
-    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this follow-up belongs to")
+    application_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Application this follow-up belongs to"
+    )
+    profile_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Profile this follow-up belongs to"
+    )
     due_date: datetime = Field(..., description="When the follow-up is due")
     follow_up_type: str = Field(
         ..., min_length=1, description="Type: email, phone, linkedin, other"

--- a/src/career_os/schemas/follow_ups.py
+++ b/src/career_os/schemas/follow_ups.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 def _ensure_utc(v: Any) -> datetime | None:
     """Ensure a datetime value has UTC timezone info."""
@@ -23,8 +25,8 @@ def _ensure_utc(v: Any) -> datetime | None:
 class FollowUpCreate(BaseModel):
     """Request body for POST /api/follow-ups."""
 
-    application_id: int = Field(..., description="Application this follow-up belongs to")
-    profile_id: int = Field(..., description="Profile this follow-up belongs to")
+    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application this follow-up belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this follow-up belongs to")
     due_date: datetime = Field(..., description="When the follow-up is due")
     follow_up_type: str = Field(
         ..., min_length=1, description="Type: email, phone, linkedin, other"
@@ -46,9 +48,9 @@ class FollowUpComplete(BaseModel):
 class FollowUpResponse(BaseModel):
     """Response schema for a single follow-up."""
 
-    id: int
-    application_id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     due_date: datetime
     follow_up_type: str
     notes: str | None = None
@@ -70,10 +72,10 @@ class FollowUpListResponse(BaseModel):
     """Response schema for list of follow-ups."""
 
     follow_ups: list[FollowUpResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class OverdueCountResponse(BaseModel):
     """Response schema for overdue follow-ups count."""
 
-    count: int
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)

--- a/src/career_os/schemas/gaps.py
+++ b/src/career_os/schemas/gaps.py
@@ -2,9 +2,11 @@
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, field_validator
+
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -65,8 +67,8 @@ class JobRequirementCreate(BaseModel):
 class JobRequirementBulkCreate(BaseModel):
     """Request body for bulk-creating job requirements for an application."""
 
-    application_id: int = Field(..., description="Application to add requirements to")
-    profile_id: int = Field(..., description="Profile ID")
+    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application to add requirements to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
     requirements: list[JobRequirementCreate] = Field(
         ..., min_length=1, description="List of job requirements"
     )
@@ -90,21 +92,21 @@ class GapItem(BaseModel):
 class GapAnalysisResponse(BaseModel):
     """Response for GET /api/applications/{id}/gaps."""
 
-    application_id: int
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
     company: str
     role: str
     gaps: list[GapItem]
     readiness_score: float = Field(ge=0, le=100, description="Weighted readiness 0-100")
-    total_requirements: int
-    gaps_count: int
+    total_requirements: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    gaps_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class AggregateGapItem(BaseModel):
     """A skill gap aggregated across multiple applications."""
 
     skill_name: str
-    frequency: int = Field(description="Number of applications with this gap")
-    application_ids: list[int]
+    frequency: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications with this gap")
+    application_ids: list[Annotated[int, Field(ge=1, le=INT64_MAX)]]
     avg_severity: str
     avg_distance: float
 
@@ -113,15 +115,15 @@ class AggregateGapResponse(BaseModel):
     """Response for GET /api/gaps/aggregate."""
 
     gaps: list[AggregateGapItem]
-    total_applications_analyzed: int
+    total_applications_analyzed: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class JobRequirementResponse(BaseModel):
     """Response schema for a job requirement."""
 
-    id: int
-    application_id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     skill_name: str
     required_level: str
     severity: str

--- a/src/career_os/schemas/gaps.py
+++ b/src/career_os/schemas/gaps.py
@@ -67,7 +67,9 @@ class JobRequirementCreate(BaseModel):
 class JobRequirementBulkCreate(BaseModel):
     """Request body for bulk-creating job requirements for an application."""
 
-    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application to add requirements to")
+    application_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Application to add requirements to"
+    )
     profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
     requirements: list[JobRequirementCreate] = Field(
         ..., min_length=1, description="List of job requirements"
@@ -105,7 +107,9 @@ class AggregateGapItem(BaseModel):
     """A skill gap aggregated across multiple applications."""
 
     skill_name: str
-    frequency: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications with this gap")
+    frequency: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of applications with this gap"
+    )
     application_ids: list[Annotated[int, Field(ge=1, le=INT64_MAX)]]
     avg_severity: str
     avg_distance: float

--- a/src/career_os/schemas/goals.py
+++ b/src/career_os/schemas/goals.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator  # noqa: I001
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -49,7 +51,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class GoalCreate(BaseModel):
     """Request body for POST /api/goals."""
 
-    profile_id: int = Field(..., description="Profile this goal belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this goal belongs to")
     title: str = Field(..., min_length=1, description="Goal title")
     goal_type: GoalType = Field(..., description="realistic or aspirational")
     target_date: datetime | None = Field(
@@ -77,8 +79,8 @@ class GoalUpdate(BaseModel):
 class GoalResponse(BaseModel):
     """Response schema for a single goal."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     goal_type: str
     target_date: datetime | None = None
@@ -99,7 +101,7 @@ class GoalListResponse(BaseModel):
     """Response schema for list of goals."""
 
     goals: list[GoalResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +122,7 @@ class RealityMapDimension(BaseModel):
 class RealityMapResponse(BaseModel):
     """Response for GET /api/goals/{id}/reality-map."""
 
-    goal_id: int
+    goal_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     goal_type: str
     dimensions: list[RealityMapDimension]
@@ -143,7 +145,7 @@ class ProgressDimension(BaseModel):
 class ProgressResponse(BaseModel):
     """Response for GET /api/goals/{id}/progress."""
 
-    goal_id: int
+    goal_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     dimensions: list[ProgressDimension]
     overall_progress: float = Field(ge=0, le=100)
@@ -157,7 +159,7 @@ class ProgressResponse(BaseModel):
 class RecalibrationResponse(BaseModel):
     """Response for PUT /api/goals/{id}/recalibrate."""
 
-    goal_id: int
+    goal_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     recalibration_notes: str
     suggested_adjustments: list[dict]
@@ -184,6 +186,6 @@ class AlternativePath(BaseModel):
 class AlternativesResponse(BaseModel):
     """Response for GET /api/goals/{id}/alternatives."""
 
-    goal_id: int
+    goal_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     paths: list[AlternativePath]

--- a/src/career_os/schemas/integrations.py
+++ b/src/career_os/schemas/integrations.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from career_os.schemas.constraints import INT64_MIN, INT64_MAX
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
 
 # ---- Integration definitions ----
 

--- a/src/career_os/schemas/integrations.py
+++ b/src/career_os/schemas/integrations.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MIN, INT64_MAX
+
 # ---- Integration definitions ----
 
 
@@ -69,7 +71,7 @@ class IntegrationListResponse(BaseModel):
     """Response schema for listing all integrations."""
 
     integrations: list[IntegrationConfigResponse]
-    count: int
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class IntegrationTestResponse(BaseModel):

--- a/src/career_os/schemas/interview_prep.py
+++ b/src/career_os/schemas/interview_prep.py
@@ -2,7 +2,7 @@
 
 Covers:
 - VAL-PREP-001: Personalized topic list per application
-- VAL-PREP-002: Practice question generation (≥5 tailored)
+- VAL-PREP-002: Practice question generation (>=5 tailored)
 - VAL-PREP-003: Prep checklist with time estimates and total
 - VAL-PREP-004: Prep progress tracking (persists on revisit)
 - VAL-PREP-005: No-research prompt for un-researched companies
@@ -13,6 +13,8 @@ from __future__ import annotations
 from datetime import datetime
 
 from pydantic import BaseModel, Field
+
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
 
 # ---------------------------------------------------------------------------
 # Topic schema
@@ -54,9 +56,9 @@ class PrepQuestion(BaseModel):
 class PrepChecklistItem(BaseModel):
     """A checklist item with time estimate and progress tracking (VAL-PREP-003/004)."""
 
-    id: int = Field(..., description="Item ID for progress updates")
+    id: int = Field(..., ge=1, le=INT64_MAX, description="Item ID for progress updates")
     item: str = Field(..., description="Checklist item description")
-    time_minutes: int = Field(..., ge=0, description="Estimated time in minutes")
+    time_minutes: int = Field(..., ge=0, le=INT64_MAX, description="Estimated time in minutes")
     priority: str = Field(..., description="Priority: high, medium, low")
     completed: bool = Field(default=False, description="Completion state")
     completed_at: datetime | None = Field(default=None, description="When the item was completed")
@@ -80,7 +82,7 @@ class InterviewPrepResponse(BaseModel):
     persisted progress state.
     """
 
-    application_id: int = Field(..., description="Application this prep is for")
+    application_id: int = Field(..., ge=1, le=INT64_MAX, description="Application this prep is for")
     company: str = Field(..., description="Company name")
     role: str = Field(..., description="Role title")
     company_researched: bool = Field(..., description="Whether the company has been researched")
@@ -94,14 +96,14 @@ class InterviewPrepResponse(BaseModel):
     )
     questions: list[PrepQuestion] = Field(
         default_factory=list,
-        description="Practice questions (≥5 tailored) (VAL-PREP-002)",
+        description="Practice questions (>=5 tailored) (VAL-PREP-002)",
     )
     checklist: list[PrepChecklistItem] = Field(
         default_factory=list,
         description="Prep checklist with time estimates (VAL-PREP-003)",
     )
     total_prep_minutes: int = Field(
-        default=0, description="Total estimated preparation time in minutes"
+        default=0, ge=INT64_MIN, le=INT64_MAX, description="Total estimated preparation time in minutes"
     )
     total_prep_hours: float = Field(default=0.0, description="Total estimated preparation hours")
     progress_percentage: float = Field(
@@ -110,5 +112,5 @@ class InterviewPrepResponse(BaseModel):
         le=100.0,
         description="Percentage of checklist items completed (VAL-PREP-004)",
     )
-    completed_items: int = Field(default=0, description="Number of completed checklist items")
-    total_items: int = Field(default=0, description="Total number of checklist items")
+    completed_items: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Number of completed checklist items")
+    total_items: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Total number of checklist items")

--- a/src/career_os/schemas/interview_prep.py
+++ b/src/career_os/schemas/interview_prep.py
@@ -103,7 +103,10 @@ class InterviewPrepResponse(BaseModel):
         description="Prep checklist with time estimates (VAL-PREP-003)",
     )
     total_prep_minutes: int = Field(
-        default=0, ge=INT64_MIN, le=INT64_MAX, description="Total estimated preparation time in minutes"
+        default=0,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Total estimated preparation time in minutes",
     )
     total_prep_hours: float = Field(default=0.0, description="Total estimated preparation hours")
     progress_percentage: float = Field(
@@ -112,5 +115,9 @@ class InterviewPrepResponse(BaseModel):
         le=100.0,
         description="Percentage of checklist items completed (VAL-PREP-004)",
     )
-    completed_items: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Number of completed checklist items")
-    total_items: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Total number of checklist items")
+    completed_items: int = Field(
+        default=0, ge=INT64_MIN, le=INT64_MAX, description="Number of completed checklist items"
+    )
+    total_items: int = Field(
+        default=0, ge=INT64_MIN, le=INT64_MAX, description="Total number of checklist items"
+    )

--- a/src/career_os/schemas/jobs.py
+++ b/src/career_os/schemas/jobs.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 def _ensure_utc(v: Any) -> datetime | None:
     """Ensure a datetime value has UTC timezone info."""
@@ -23,8 +25,8 @@ def _ensure_utc(v: Any) -> datetime | None:
 class JobSearchResult(BaseModel):
     """A single discovered job result with optional score data."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     company: str
     location: str
@@ -37,7 +39,7 @@ class JobSearchResult(BaseModel):
     source_urls: list[str] = []
     fit_score: float | None = None
     readiness_score: float | None = None
-    application_id: int | None = None
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     created_at: datetime
     updated_at: datetime
 
@@ -67,10 +69,10 @@ class JobSearchResponse(BaseModel):
     """Paginated search results response."""
 
     jobs: list[JobSearchResult]
-    total: int
-    page: int
-    page_size: int
-    total_pages: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    page: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    page_size: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    total_pages: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -84,8 +86,8 @@ class SavedSearchConfig(BaseModel):
     q: str | None = None
     source: str | None = None
     remote: bool | None = None
-    salary_min: int | None = None
-    salary_max: int | None = None
+    salary_min: int | None = Field(default=None, ge=INT64_MIN, le=INT64_MAX)
+    salary_max: int | None = Field(default=None, ge=INT64_MIN, le=INT64_MAX)
     score_min: float | None = None
     score_max: float | None = None
     date_from: str | None = None
@@ -99,7 +101,7 @@ class SavedSearchConfig(BaseModel):
 class SavedSearchCreate(BaseModel):
     """Request body for creating a saved search."""
 
-    profile_id: int = Field(..., description="Profile ID")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
     name: str = Field(..., min_length=1, max_length=255, description="Saved search name")
     config: SavedSearchConfig = Field(
         default_factory=SavedSearchConfig,
@@ -117,8 +119,8 @@ class SavedSearchUpdate(BaseModel):
 class SavedSearchResponse(BaseModel):
     """Response for a saved search record."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     name: str
     config: SavedSearchConfig
     created_at: datetime
@@ -150,4 +152,4 @@ class SavedSearchListResponse(BaseModel):
     """Response for listing saved searches."""
 
     searches: list[SavedSearchResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)

--- a/src/career_os/schemas/learning.py
+++ b/src/career_os/schemas/learning.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -58,7 +60,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class LearningResourceCreate(BaseModel):
     """Request body for creating a learning resource."""
 
-    profile_id: int = Field(..., description="Profile ID")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
     title: str = Field(..., min_length=1, description="Resource title")
     url: str | None = Field(default=None, description="Resource URL")
     resource_type: ResourceType = Field(
@@ -74,7 +76,7 @@ class LearningResourceCreate(BaseModel):
 class LearningStatusUpdate(BaseModel):
     """Request body for updating learning resource status."""
 
-    profile_id: int = Field(..., description="Profile ID")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
     status: LearningStatus = Field(..., description="New status")
 
 
@@ -86,10 +88,10 @@ class LearningStatusUpdate(BaseModel):
 class LearningResourceResponse(BaseModel):
     """Response schema for a learning resource."""
 
-    id: int
-    profile_id: int
-    gap_id: int | None = None
-    skill_id: int | None = None
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    gap_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    skill_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     title: str
     url: str | None = None
     provider: str | None = None
@@ -131,7 +133,7 @@ class RecommendationsCTA(BaseModel):
 class GapRecommendationsResponse(BaseModel):
     """Response for GET /api/gaps/{id}/recommendations."""
 
-    gap_id: int
+    gap_id: int = Field(..., ge=1, le=INT64_MAX)
     skill_name: str
     recommendations: list[LearningResourceResponse]
     template_recommendations: list[TemplateRecommendation] = Field(default_factory=list)

--- a/src/career_os/schemas/market.py
+++ b/src/career_os/schemas/market.py
@@ -33,7 +33,9 @@ class SalaryTrendItem(BaseModel):
     median: float = Field(..., description="Median salary (EUR)")
     p25: float = Field(..., description="25th percentile salary")
     p75: float = Field(..., description="75th percentile salary")
-    sample_size: int = Field(..., ge=0, le=INT64_MAX, description="Number of postings with salary data")
+    sample_size: int = Field(
+        ..., ge=0, le=INT64_MAX, description="Number of postings with salary data"
+    )
 
 
 class SalaryTrendsResponse(BaseModel):
@@ -57,7 +59,9 @@ class SkillTrendItem(BaseModel):
     """A single skill demand trend entry."""
 
     skill_name: str = Field(..., description="Skill name")
-    mention_count: int = Field(..., ge=0, le=INT64_MAX, description="Times mentioned across postings")
+    mention_count: int = Field(
+        ..., ge=0, le=INT64_MAX, description="Times mentioned across postings"
+    )
     trend_direction: str = Field(..., description="Trend: up, down, or stable")
     percentage_of_postings: float = Field(
         ..., ge=0, le=100, description="% of postings mentioning this skill"
@@ -68,7 +72,9 @@ class SkillTrendsResponse(BaseModel):
     """Response for GET /api/market/skill-trends."""
 
     skills: list[SkillTrendItem] = Field(default_factory=list)
-    total_postings_analyzed: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Total postings analyzed")
+    total_postings_analyzed: int = Field(
+        default=0, ge=INT64_MIN, le=INT64_MAX, description="Total postings analyzed"
+    )
     last_refreshed_at: datetime | None = None
 
     @field_validator("last_refreshed_at", mode="before")
@@ -86,7 +92,9 @@ class HiringPatternItem(BaseModel):
     """Hiring pattern for a single company."""
 
     company: str = Field(..., description="Company name")
-    active_postings_count: int = Field(..., ge=0, le=INT64_MAX, description="Number of active postings")
+    active_postings_count: int = Field(
+        ..., ge=0, le=INT64_MAX, description="Number of active postings"
+    )
     posting_velocity: float = Field(..., description="Postings per week (recent velocity)")
     roles_trending: list[str] = Field(
         default_factory=list, description="Role titles being hired for"
@@ -184,7 +192,9 @@ class OpportunityRadarResponse(BaseModel):
 class MarketRefreshRequest(BaseModel):
     """Request body for POST /api/market/refresh."""
 
-    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID to refresh market data for")
+    profile_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Profile ID to refresh market data for"
+    )
 
 
 class MarketRefreshResponse(BaseModel):

--- a/src/career_os/schemas/market.py
+++ b/src/career_os/schemas/market.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 def _ensure_utc(v: Any) -> datetime | None:
     """Ensure a datetime value has UTC timezone info."""
@@ -31,7 +33,7 @@ class SalaryTrendItem(BaseModel):
     median: float = Field(..., description="Median salary (EUR)")
     p25: float = Field(..., description="25th percentile salary")
     p75: float = Field(..., description="75th percentile salary")
-    sample_size: int = Field(..., ge=0, description="Number of postings with salary data")
+    sample_size: int = Field(..., ge=0, le=INT64_MAX, description="Number of postings with salary data")
 
 
 class SalaryTrendsResponse(BaseModel):
@@ -55,7 +57,7 @@ class SkillTrendItem(BaseModel):
     """A single skill demand trend entry."""
 
     skill_name: str = Field(..., description="Skill name")
-    mention_count: int = Field(..., ge=0, description="Times mentioned across postings")
+    mention_count: int = Field(..., ge=0, le=INT64_MAX, description="Times mentioned across postings")
     trend_direction: str = Field(..., description="Trend: up, down, or stable")
     percentage_of_postings: float = Field(
         ..., ge=0, le=100, description="% of postings mentioning this skill"
@@ -66,7 +68,7 @@ class SkillTrendsResponse(BaseModel):
     """Response for GET /api/market/skill-trends."""
 
     skills: list[SkillTrendItem] = Field(default_factory=list)
-    total_postings_analyzed: int = Field(default=0, description="Total postings analyzed")
+    total_postings_analyzed: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX, description="Total postings analyzed")
     last_refreshed_at: datetime | None = None
 
     @field_validator("last_refreshed_at", mode="before")
@@ -84,7 +86,7 @@ class HiringPatternItem(BaseModel):
     """Hiring pattern for a single company."""
 
     company: str = Field(..., description="Company name")
-    active_postings_count: int = Field(..., ge=0, description="Number of active postings")
+    active_postings_count: int = Field(..., ge=0, le=INT64_MAX, description="Number of active postings")
     posting_velocity: float = Field(..., description="Postings per week (recent velocity)")
     roles_trending: list[str] = Field(
         default_factory=list, description="Role titles being hired for"
@@ -116,7 +118,7 @@ class PositionItem(BaseModel):
         ..., ge=0, le=100, description="Profile match % for this role type"
     )
     total_roles_analyzed: int = Field(
-        ..., ge=0, description="Number of roles analyzed for this type"
+        ..., ge=0, le=INT64_MAX, description="Number of roles analyzed for this type"
     )
 
 
@@ -140,7 +142,7 @@ class PositioningResponse(BaseModel):
 class OpportunityItem(BaseModel):
     """A flagged dream company opportunity."""
 
-    id: int = Field(..., description="Discovered job ID")
+    id: int = Field(..., ge=1, le=INT64_MAX, description="Discovered job ID")
     title: str
     company: str
     location: str
@@ -182,16 +184,16 @@ class OpportunityRadarResponse(BaseModel):
 class MarketRefreshRequest(BaseModel):
     """Request body for POST /api/market/refresh."""
 
-    profile_id: int = Field(..., description="Profile ID to refresh market data for")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID to refresh market data for")
 
 
 class MarketRefreshResponse(BaseModel):
     """Response for POST /api/market/refresh."""
 
     last_refreshed_at: datetime
-    salary_trends_count: int = 0
-    skill_trends_count: int = 0
-    companies_analyzed: int = 0
+    salary_trends_count: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    skill_trends_count: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    companies_analyzed: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
 
     @field_validator("last_refreshed_at", mode="before")
     @classmethod

--- a/src/career_os/schemas/privacy.py
+++ b/src/career_os/schemas/privacy.py
@@ -4,6 +4,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class PrivacyTier(StrEnum):
     """Privacy tier classification for AI providers.
@@ -21,7 +23,7 @@ class PrivacyTier(StrEnum):
 class DataRetention(BaseModel):
     """Data retention policy description."""
 
-    days: int | None = Field(None, description="Retention in days, None=indefinite")
+    days: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="Retention in days, None=indefinite")
     description: str = Field(..., description="Human-readable retention policy")
 
 

--- a/src/career_os/schemas/privacy.py
+++ b/src/career_os/schemas/privacy.py
@@ -23,7 +23,9 @@ class PrivacyTier(StrEnum):
 class DataRetention(BaseModel):
     """Data retention policy description."""
 
-    days: int | None = Field(None, ge=INT64_MIN, le=INT64_MAX, description="Retention in days, None=indefinite")
+    days: int | None = Field(
+        None, ge=INT64_MIN, le=INT64_MAX, description="Retention in days, None=indefinite"
+    )
     description: str = Field(..., description="Human-readable retention policy")
 
 

--- a/src/career_os/schemas/profiles.py
+++ b/src/career_os/schemas/profiles.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class ProfileCreate(BaseModel):
     """Request body for POST /api/profiles."""
@@ -30,7 +32,7 @@ class ProfileUpdate(BaseModel):
 class ProfileResponse(BaseModel):
     """Response schema for a profile."""
 
-    id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
     name: str
     email: str | None = None
     location: str | None = None
@@ -60,4 +62,4 @@ class ProfileListResponse(BaseModel):
     """Response schema for list of profiles."""
 
     profiles: list[ProfileResponse]
-    count: int
+    count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)

--- a/src/career_os/schemas/pushover.py
+++ b/src/career_os/schemas/pushover.py
@@ -117,7 +117,11 @@ class NotificationLogListResponse(BaseModel):
 class NotificationTriggerResponse(BaseModel):
     """Response from triggering notifications (e.g., follow-up check)."""
 
-    triggered: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of notifications sent")
-    skipped: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number skipped (disabled, quiet hours, etc.)")
+    triggered: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of notifications sent"
+    )
+    skipped: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number skipped (disabled, quiet hours, etc.)"
+    )
     failed: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number that failed to send")
     details: list[dict] = Field(default_factory=list)

--- a/src/career_os/schemas/pushover.py
+++ b/src/career_os/schemas/pushover.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -48,15 +50,15 @@ class NotificationPreferenceUpdate(BaseModel):
 class NotificationPreferenceResponse(BaseModel):
     """Response schema for notification preferences."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     follow_up_reminders: bool
     ghost_alerts: bool
     discovery_alerts: bool
     interview_reminders: bool
-    quiet_hours_start: int | None = None
-    quiet_hours_end: int | None = None
-    interview_lead_time_minutes: int
+    quiet_hours_start: int | None = Field(default=None, ge=INT64_MIN, le=INT64_MAX)
+    quiet_hours_end: int | None = Field(default=None, ge=INT64_MIN, le=INT64_MAX)
+    interview_lead_time_minutes: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     discovery_score_threshold: float
     created_at: datetime
     updated_at: datetime
@@ -72,11 +74,11 @@ class NotificationPreferenceResponse(BaseModel):
 class SendNotificationRequest(BaseModel):
     """Request body for manually sending a test notification."""
 
-    profile_id: int
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     category: NotificationCategory
     title: str = Field(..., min_length=1, max_length=250)
     message: str = Field(..., min_length=1, max_length=1024)
-    application_id: int | None = None
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -87,12 +89,12 @@ class SendNotificationRequest(BaseModel):
 class NotificationLogResponse(BaseModel):
     """Response schema for a single notification log entry."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     category: str
     title: str
     message: str
-    application_id: int | None = None
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     status: str
     error_message: str | None = None
     sent_at: datetime
@@ -104,7 +106,7 @@ class NotificationLogListResponse(BaseModel):
     """Response schema for listing notification logs."""
 
     notifications: list[NotificationLogResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +117,7 @@ class NotificationLogListResponse(BaseModel):
 class NotificationTriggerResponse(BaseModel):
     """Response from triggering notifications (e.g., follow-up check)."""
 
-    triggered: int = Field(description="Number of notifications sent")
-    skipped: int = Field(description="Number skipped (disabled, quiet hours, etc.)")
-    failed: int = Field(description="Number that failed to send")
+    triggered: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of notifications sent")
+    skipped: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number skipped (disabled, quiet hours, etc.)")
+    failed: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number that failed to send")
     details: list[dict] = Field(default_factory=list)

--- a/src/career_os/schemas/research.py
+++ b/src/career_os/schemas/research.py
@@ -26,7 +26,9 @@ class CompanyResearchRequest(BaseModel):
     """Request body for POST /api/research/company."""
 
     company_name: str = Field(..., min_length=1, description="Company name to research")
-    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID for values alignment scoring")
+    profile_id: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Profile ID for values alignment scoring"
+    )
     company_url: str | None = Field(
         default=None, description="Optional company website URL for enrichment"
     )
@@ -91,7 +93,10 @@ class HiringPatternsReport(BaseModel):
     """Hiring patterns (VAL-RESEARCH-007)."""
 
     active_postings: int | None = Field(
-        default=None, ge=INT64_MIN, le=INT64_MAX, description="Number of currently active job postings"
+        default=None,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Number of currently active job postings",
     )
     posting_velocity: str | None = Field(
         default=None, description="Posting rate (e.g., '12/month')"

--- a/src/career_os/schemas/research.py
+++ b/src/career_os/schemas/research.py
@@ -4,7 +4,7 @@ Covers:
 - VAL-RESEARCH-001: One-click company deep-dive with all report sections
 - VAL-RESEARCH-002: Tech stack categorized by frontend/backend/infra/analytics
 - VAL-RESEARCH-003: Funding data (stage, amount, investors)
-- VAL-RESEARCH-004: Glassdoor rating + culture signals (≥3 keywords)
+- VAL-RESEARCH-004: Glassdoor rating + culture signals (>=3 keywords)
 - VAL-RESEARCH-005: Values alignment score (1-10 with rationale)
 - VAL-RESEARCH-006: ATS platform detection
 - VAL-RESEARCH-007: Hiring patterns (velocity, departments)
@@ -15,6 +15,8 @@ Covers:
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Request schemas
 # ---------------------------------------------------------------------------
@@ -24,7 +26,7 @@ class CompanyResearchRequest(BaseModel):
     """Request body for POST /api/research/company."""
 
     company_name: str = Field(..., min_length=1, description="Company name to research")
-    profile_id: int = Field(..., description="Profile ID for values alignment scoring")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID for values alignment scoring")
     company_url: str | None = Field(
         default=None, description="Optional company website URL for enrichment"
     )
@@ -68,7 +70,7 @@ class GlassdoorReport(BaseModel):
     )
     culture_keywords: list[str] = Field(
         default_factory=list,
-        description="Culture signal keywords from review sentiment (≥3)",
+        description="Culture signal keywords from review sentiment (>=3)",
     )
     work_life_balance: float | None = Field(
         default=None, ge=0, le=5, description="Work-life balance rating (0-5)"
@@ -89,7 +91,7 @@ class HiringPatternsReport(BaseModel):
     """Hiring patterns (VAL-RESEARCH-007)."""
 
     active_postings: int | None = Field(
-        default=None, description="Number of currently active job postings"
+        default=None, ge=INT64_MIN, le=INT64_MAX, description="Number of currently active job postings"
     )
     posting_velocity: str | None = Field(
         default=None, description="Posting rate (e.g., '12/month')"

--- a/src/career_os/schemas/role_intelligence.py
+++ b/src/career_os/schemas/role_intelligence.py
@@ -20,12 +20,16 @@ from career_os.schemas.constraints import INT64_MAX, INT64_MIN
 class InterviewRound(BaseModel):
     """A single interview round."""
 
-    round_number: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Round sequence number (1-based)")
+    round_number: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Round sequence number (1-based)"
+    )
     type: str = Field(
         ..., description="Round type (e.g., 'Phone Screen', 'Technical', 'Behavioral')"
     )
     description: str = Field(..., description="Description of what this round covers")
-    duration_minutes: int = Field(..., ge=0, le=INT64_MAX, description="Expected duration in minutes")
+    duration_minutes: int = Field(
+        ..., ge=0, le=INT64_MAX, description="Expected duration in minutes"
+    )
 
 
 class SourceWarning(BaseModel):

--- a/src/career_os/schemas/role_intelligence.py
+++ b/src/career_os/schemas/role_intelligence.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # VAL-ROLE-INTEL-001: Interview Format
 # ---------------------------------------------------------------------------
@@ -18,12 +20,12 @@ from pydantic import BaseModel, Field
 class InterviewRound(BaseModel):
     """A single interview round."""
 
-    round_number: int = Field(..., description="Round sequence number (1-based)")
+    round_number: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Round sequence number (1-based)")
     type: str = Field(
         ..., description="Round type (e.g., 'Phone Screen', 'Technical', 'Behavioral')"
     )
     description: str = Field(..., description="Description of what this round covers")
-    duration_minutes: int = Field(..., ge=0, description="Expected duration in minutes")
+    duration_minutes: int = Field(..., ge=0, le=INT64_MAX, description="Expected duration in minutes")
 
 
 class SourceWarning(BaseModel):
@@ -64,7 +66,7 @@ class SalaryBenchmark(BaseModel):
     low: float = Field(default=0.0, description="Low end salary (25th percentile)")
     median: float = Field(default=0.0, description="Median salary")
     high: float = Field(default=0.0, description="High end salary (75th percentile)")
-    sample_size: int = Field(default=0, ge=0, description="Number of data points")
+    sample_size: int = Field(default=0, ge=0, le=INT64_MAX, description="Number of data points")
 
 
 class SalaryBenchmarkResponse(BaseModel):

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -67,8 +67,12 @@ class ScoreRequest(BaseModel):
     job_title: str | None = Field(default=None, description="Job title")
     job_company: str | None = Field(default=None, description="Company name")
     job_description: str = Field(..., min_length=1, description="Job description text to score")
-    discovered_job_id: int | None = Field(default=None, ge=1, le=INT64_MAX, description="Link to discovered job record")
-    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX, description="Link to application record")
+    discovered_job_id: int | None = Field(
+        default=None, ge=1, le=INT64_MAX, description="Link to discovered job record"
+    )
+    application_id: int | None = Field(
+        default=None, ge=1, le=INT64_MAX, description="Link to application record"
+    )
 
 
 class RedFlag(BaseModel):
@@ -113,8 +117,12 @@ class ScoreContextResponse(BaseModel):
         le=100,
         description="Percentage of scored jobs this score is higher than",
     )
-    rank: int = Field(..., ge=1, le=INT64_MAX, description="Rank among all scored jobs (1 = highest)")
-    total_scored: int = Field(..., ge=1, le=INT64_MAX, description="Total number of non-stale scored jobs")
+    rank: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Rank among all scored jobs (1 = highest)"
+    )
+    total_scored: int = Field(
+        ..., ge=1, le=INT64_MAX, description="Total number of non-stale scored jobs"
+    )
     avg_score: float = Field(
         ..., ge=0, le=10, description="Average fit_score across all scored jobs"
     )
@@ -500,9 +508,21 @@ class FeedbackResponse(BaseModel):
 class FeedbackStats(BaseModel):
     """Summary statistics for feedback submitted by a profile."""
 
-    total_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Total number of feedback records")
-    explicit_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Explicit corrections (too_high/too_low/correct)")
-    implicit_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Implicit signals (promoted/dismissed/interview)")
+    total_count: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Total number of feedback records"
+    )
+    explicit_count: int = Field(
+        ...,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Explicit corrections (too_high/too_low/correct)",
+    )
+    implicit_count: int = Field(
+        ...,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Implicit signals (promoted/dismissed/interview)",
+    )
     avg_deviation: float | None = Field(
         default=None,
         description="Average |user_score - original_fit_score| for records with user_score",
@@ -547,10 +567,16 @@ class SuggestionsResponse(BaseModel):
         description="Weight adjustment suggestions based on feedback patterns",
     )
     feedback_count: int = Field(
-        ..., ge=INT64_MIN, le=INT64_MAX, description="Total feedback records used to generate suggestions"
+        ...,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Total feedback records used to generate suggestions",
     )
     min_feedback_required: int = Field(
-        ..., ge=INT64_MIN, le=INT64_MAX, description="Minimum feedback records needed before suggestions appear"
+        ...,
+        ge=INT64_MIN,
+        le=INT64_MAX,
+        description="Minimum feedback records needed before suggestions appear",
     )
     ready: bool = Field(..., description="True when enough feedback exists to generate suggestions")
 

--- a/src/career_os/schemas/scoring.py
+++ b/src/career_os/schemas/scoring.py
@@ -3,11 +3,12 @@
 import json as json_mod
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from career_os.schemas.ai import ATSKeywordCategory, ScoreBreakdownFactor
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
 
 
 def _ensure_utc(v: Any) -> datetime | None:
@@ -61,13 +62,13 @@ def score_to_letter_grade(score: float | None) -> str | None:
 class ScoreRequest(BaseModel):
     """Request body for POST /api/score — score a job against a profile."""
 
-    profile_id: int = Field(..., description="Profile to score against")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile to score against")
     job_url: str | None = Field(default=None, description="Job posting URL (for reference)")
     job_title: str | None = Field(default=None, description="Job title")
     job_company: str | None = Field(default=None, description="Company name")
     job_description: str = Field(..., min_length=1, description="Job description text to score")
-    discovered_job_id: int | None = Field(default=None, description="Link to discovered job record")
-    application_id: int | None = Field(default=None, description="Link to application record")
+    discovered_job_id: int | None = Field(default=None, ge=1, le=INT64_MAX, description="Link to discovered job record")
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX, description="Link to application record")
 
 
 class RedFlag(BaseModel):
@@ -112,14 +113,15 @@ class ScoreContextResponse(BaseModel):
         le=100,
         description="Percentage of scored jobs this score is higher than",
     )
-    rank: int = Field(..., ge=1, description="Rank among all scored jobs (1 = highest)")
-    total_scored: int = Field(..., ge=1, description="Total number of non-stale scored jobs")
+    rank: int = Field(..., ge=1, le=INT64_MAX, description="Rank among all scored jobs (1 = highest)")
+    total_scored: int = Field(..., ge=1, le=INT64_MAX, description="Total number of non-stale scored jobs")
     avg_score: float = Field(
         ..., ge=0, le=10, description="Average fit_score across all scored jobs"
     )
     score_band_count: int = Field(
         ...,
         ge=0,
+        le=INT64_MAX,
         description="Number of jobs in the same letter grade band as this score",
     )
 
@@ -135,7 +137,7 @@ class ProfileCompletenessResponse(BaseModel):
         ...,
         ge=0,
         le=100,
-        description="Profile richness 0-100% (higher = more data → tighter range)",
+        description="Profile richness 0-100% (higher = more data -> tighter range)",
     )
     confidence_range: tuple[float, float] = Field(
         ...,
@@ -160,10 +162,10 @@ class ProfileCompletenessResponse(BaseModel):
 class ScoreResponse(BaseModel):
     """Full scoring breakdown response."""
 
-    id: int | None = None
-    profile_id: int
-    discovered_job_id: int | None = None
-    application_id: int | None = None
+    id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    discovered_job_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
 
     # Core scores
     fit_score: float = Field(..., ge=0, le=10, description="Overall fit 1-10")
@@ -190,7 +192,7 @@ class ScoreResponse(BaseModel):
     # Detailed breakdown
     score_breakdown: list[ScoreBreakdownFactor] = Field(
         default_factory=list,
-        description="Breakdown of scoring factors with +/- contributions (≥3 factors)",
+        description="Breakdown of scoring factors with +/- contributions (>=3 factors)",
     )
     red_flags: list[RedFlag] = Field(
         default_factory=list,
@@ -216,7 +218,7 @@ class ScoreResponse(BaseModel):
     dim_career_trajectory: float | None = Field(default=None, exclude=True)
     dim_company_fit: float | None = Field(default=None, exclude=True)
     reasoning: str = Field(
-        ..., min_length=100, description="Scoring explanation (≥100 chars, ≥3 factors)"
+        ..., min_length=100, description="Scoring explanation (>=100 chars, >=3 factors)"
     )
     estimated_salary: str = Field(..., description="Estimated salary range")
     effort_flag: str = Field(..., description="Effort level: low / medium / high")
@@ -341,10 +343,10 @@ def classify_quadrant(fit_score: float | None, desire_score: float | None) -> st
     """Classify a job into a 2D quadrant based on fit and desire scores.
 
     Quadrants (threshold = 5.0):
-        - "dream_job"   — high fit, high desire
-        - "stretch_goal" — low fit, high desire
-        - "safe_bet"    — high fit, low desire
-        - "skip"        — low fit, low desire
+        - "dream_job"   -- high fit, high desire
+        - "stretch_goal" -- low fit, high desire
+        - "safe_bet"    -- high fit, low desire
+        - "skip"        -- low fit, low desire
 
     Returns None if either score is None.
     """
@@ -377,8 +379,8 @@ class DesireScoreResponse(BaseModel):
 class ScoringWeightsResponse(BaseModel):
     """Response schema for scoring weight configuration."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     skills_match: float = Field(default=0.25, ge=0, le=1)
     career_alignment: float = Field(default=0.20, ge=0, le=1)
     culture_fit: float = Field(default=0.15, ge=0, le=1)
@@ -417,8 +419,8 @@ class ScoringWeightsUpdate(BaseModel):
 class BatchScoreRequest(BaseModel):
     """Request body for POST /api/score/batch."""
 
-    profile_id: int = Field(..., description="Profile to score against")
-    discovered_job_ids: list[int] = Field(
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile to score against")
+    discovered_job_ids: list[Annotated[int, Field(ge=1, le=INT64_MAX)]] = Field(
         default_factory=list,
         description="Specific discovered job IDs to score (empty = all unscored)",
     )
@@ -428,7 +430,7 @@ class BatchScoreRequest(BaseModel):
 class BatchScoreResponse(BaseModel):
     """Response for batch scoring operation."""
 
-    scored_count: int = Field(..., description="Number of jobs scored")
+    scored_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of jobs scored")
     total_time_seconds: float = Field(..., description="Total time taken in seconds")
     scores: list[ScoreResponse] = Field(
         default_factory=list, description="Individual score results"
@@ -466,7 +468,7 @@ class FeedbackCreate(BaseModel):
         default=None,
         ge=0,
         le=10,
-        description="Optional: what the user thinks the score should be (0–10)",
+        description="Optional: what the user thinks the score should be (0-10)",
     )
     reason: str | None = Field(
         default=None,
@@ -478,9 +480,9 @@ class FeedbackCreate(BaseModel):
 class FeedbackResponse(BaseModel):
     """Response schema for a single feedback record."""
 
-    id: int
-    scored_job_id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    scored_job_id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     direction: str
     user_score: float | None = None
     reason: str | None = None
@@ -498,9 +500,9 @@ class FeedbackResponse(BaseModel):
 class FeedbackStats(BaseModel):
     """Summary statistics for feedback submitted by a profile."""
 
-    total_count: int = Field(..., description="Total number of feedback records")
-    explicit_count: int = Field(..., description="Explicit corrections (too_high/too_low/correct)")
-    implicit_count: int = Field(..., description="Implicit signals (promoted/dismissed/interview)")
+    total_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Total number of feedback records")
+    explicit_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Explicit corrections (too_high/too_low/correct)")
+    implicit_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Implicit signals (promoted/dismissed/interview)")
     avg_deviation: float | None = Field(
         default=None,
         description="Average |user_score - original_fit_score| for records with user_score",
@@ -545,10 +547,10 @@ class SuggestionsResponse(BaseModel):
         description="Weight adjustment suggestions based on feedback patterns",
     )
     feedback_count: int = Field(
-        ..., description="Total feedback records used to generate suggestions"
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Total feedback records used to generate suggestions"
     )
     min_feedback_required: int = Field(
-        ..., description="Minimum feedback records needed before suggestions appear"
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Minimum feedback records needed before suggestions appear"
     )
     ready: bool = Field(..., description="True when enough feedback exists to generate suggestions")
 

--- a/src/career_os/schemas/skills.py
+++ b/src/career_os/schemas/skills.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -51,7 +53,7 @@ def _ensure_utc(v: Any) -> datetime | None:
 class SkillCreate(BaseModel):
     """Request body for POST /api/skills."""
 
-    profile_id: int = Field(..., description="Profile this skill belongs to")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile this skill belongs to")
     name: str = Field(..., min_length=1, description="Skill name")
     category: SkillCategory = Field(..., description="Skill category")
     proficiency: SkillProficiency = Field(
@@ -77,7 +79,7 @@ class SkillUpdate(BaseModel):
 class IngestRequest(BaseModel):
     """Request body for POST /api/skills/ingest."""
 
-    profile_id: int = Field(..., description="Profile to ingest skills for")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile to ingest skills for")
     sources: list[str] = Field(
         default_factory=lambda: ["cv", "assessments", "profile"],
         description="Sources to ingest: cv, assessments, profile",
@@ -92,8 +94,8 @@ class IngestRequest(BaseModel):
 class SkillResponse(BaseModel):
     """Response schema for a single skill."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     name: str
     category: str
     proficiency: str
@@ -113,8 +115,8 @@ class SkillResponse(BaseModel):
 class SkillHistoryResponse(BaseModel):
     """Response schema for a skill history entry."""
 
-    id: int
-    skill_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    skill_id: int = Field(..., ge=1, le=INT64_MAX)
     previous_proficiency: str | None = None
     new_proficiency: str
     reason: str | None = None
@@ -132,14 +134,14 @@ class SkillListResponse(BaseModel):
     """Response schema for list of skills."""
 
     skills: list[SkillResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class IngestResponse(BaseModel):
     """Response schema for ingestion results."""
 
-    skills_created: int
-    skills_updated: int
+    skills_created: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    skills_updated: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     sources_processed: list[str]
     errors: list[str] = []
 
@@ -148,7 +150,7 @@ class SkillsEmptyStateResponse(BaseModel):
     """Response when no skills exist — includes CTAs."""
 
     skills: list[SkillResponse] = []
-    total: int = 0
+    total: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
     ctas: list[dict] = Field(
         default_factory=lambda: [
             {"label": "Import from CV", "action": "ingest_cv"},

--- a/src/career_os/schemas/star_stories.py
+++ b/src/career_os/schemas/star_stories.py
@@ -12,6 +12,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 # ---------------------------------------------------------------------------
 # Request schemas
 # ---------------------------------------------------------------------------
@@ -54,8 +56,8 @@ class StarStoryUpdate(BaseModel):
 class StarStoryResponse(BaseModel):
     """A STAR story response."""
 
-    id: int
-    profile_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
     title: str
     situation: str
     task: str
@@ -70,7 +72,7 @@ class StarStoryListResponse(BaseModel):
     """List of STAR stories."""
 
     stories: list[StarStoryResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -85,17 +87,17 @@ class RecommendedStory(BaseModel):
     matching_skills: list[str] = Field(
         description="Skill tags that match the application requirements"
     )
-    match_count: int = Field(description="Number of matching skill tags")
+    match_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of matching skill tags")
 
 
 class RecommendedStoriesResponse(BaseModel):
     """Recommended stories for an application."""
 
-    application_id: int
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
     company: str
     role: str
     recommended_stories: list[RecommendedStory]
-    total_requirements: int
+    total_requirements: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     covered_skills: list[str] = Field(description="Skills covered by at least one story")
 
 
@@ -119,10 +121,10 @@ class StoryGap(BaseModel):
 class StoryGapsResponse(BaseModel):
     """Story gaps for an application."""
 
-    application_id: int
+    application_id: int = Field(..., ge=1, le=INT64_MAX)
     company: str
     role: str
     story_gaps: list[StoryGap]
-    total_requirements: int
-    covered_count: int
-    gap_count: int
+    total_requirements: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    covered_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    gap_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX)

--- a/src/career_os/schemas/star_stories.py
+++ b/src/career_os/schemas/star_stories.py
@@ -87,7 +87,9 @@ class RecommendedStory(BaseModel):
     matching_skills: list[str] = Field(
         description="Skill tags that match the application requirements"
     )
-    match_count: int = Field(..., ge=INT64_MIN, le=INT64_MAX, description="Number of matching skill tags")
+    match_count: int = Field(
+        ..., ge=INT64_MIN, le=INT64_MAX, description="Number of matching skill tags"
+    )
 
 
 class RecommendedStoriesResponse(BaseModel):

--- a/src/career_os/schemas/ticktick.py
+++ b/src/career_os/schemas/ticktick.py
@@ -4,13 +4,15 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 class TickTickSyncTaskResponse(BaseModel):
     """Response schema for a single sync task mapping."""
 
-    id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
     entity_type: str
-    entity_id: int
+    entity_id: int = Field(..., ge=1, le=INT64_MAX)
     ticktick_task_id: str
     title: str
     status: str
@@ -23,10 +25,10 @@ class TickTickSyncTaskResponse(BaseModel):
 class TickTickSyncStatusResponse(BaseModel):
     """Response schema for overall TickTick sync status."""
 
-    total_tasks: int
-    synced: int
-    completed: int
-    errors: int
+    total_tasks: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    synced: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    completed: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
+    errors: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
     last_sync_at: str | None = None
     tasks: list[TickTickSyncTaskResponse]
 
@@ -35,8 +37,8 @@ class TickTickPushRequest(BaseModel):
     """Request to push a specific entity to TickTick."""
 
     entity_type: str = Field(..., description="Type: follow_up | learning_goal | pipeline_action")
-    entity_id: int = Field(..., description="ID of the entity to sync")
-    profile_id: int = Field(..., description="Profile ID")
+    entity_id: int = Field(..., ge=1, le=INT64_MAX, description="ID of the entity to sync")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Profile ID")
 
 
 class TickTickPushResponse(BaseModel):
@@ -52,9 +54,9 @@ class TickTickPullResponse(BaseModel):
 
     success: bool
     message: str
-    synced: int = 0
-    errors: int = 0
-    skipped: int = 0
+    synced: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    errors: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
+    skipped: int = Field(default=0, ge=INT64_MIN, le=INT64_MAX)
 
 
 class TickTickConnectionTestResponse(BaseModel):

--- a/src/career_os/schemas/voice.py
+++ b/src/career_os/schemas/voice.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
 
 def _ensure_utc(v: Any) -> datetime | None:
     if v is None:
@@ -22,13 +24,15 @@ def _ensure_utc(v: Any) -> datetime | None:
 class VoiceSessionCreate(BaseModel):
     """Create a new voice discussion session."""
 
-    profile_id: int = Field(..., description="Active profile ID")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Active profile ID")
     mode: str = Field(
         ...,
         description="Session mode: cover_letter, coaching, or job_evaluation",
     )
     application_id: int | None = Field(
         default=None,
+        ge=1,
+        le=INT64_MAX,
         description="Application ID (required for cover_letter and job_evaluation)",
     )
     title: str | None = Field(default=None, description="Optional session title")
@@ -37,7 +41,7 @@ class VoiceSessionCreate(BaseModel):
 class VoiceMessageCreate(BaseModel):
     """Send a message in a voice discussion session."""
 
-    profile_id: int = Field(..., description="Active profile ID")
+    profile_id: int = Field(..., ge=1, le=INT64_MAX, description="Active profile ID")
     content: str = Field(..., min_length=1, description="User message text (from STT or typed)")
 
 
@@ -49,8 +53,8 @@ class VoiceMessageCreate(BaseModel):
 class VoiceMessageResponse(BaseModel):
     """A single message in a voice session."""
 
-    id: int
-    session_id: int
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    session_id: int = Field(..., ge=1, le=INT64_MAX)
     role: str = Field(..., description="Message sender: user or assistant")
     content: str
     created_at: datetime
@@ -66,9 +70,9 @@ class VoiceMessageResponse(BaseModel):
 class VoiceSessionResponse(BaseModel):
     """Voice discussion session summary."""
 
-    id: int
-    profile_id: int
-    application_id: int | None = None
+    id: int = Field(..., ge=1, le=INT64_MAX)
+    profile_id: int = Field(..., ge=1, le=INT64_MAX)
+    application_id: int | None = Field(default=None, ge=1, le=INT64_MAX)
     mode: str
     title: str | None = None
     status: str
@@ -88,7 +92,7 @@ class VoiceSessionListResponse(BaseModel):
     """List of voice sessions."""
 
     sessions: list[VoiceSessionResponse]
-    total: int
+    total: int = Field(..., ge=INT64_MIN, le=INT64_MAX)
 
 
 class VoiceSendResponse(BaseModel):

--- a/src/career_os/services/pushover.py
+++ b/src/career_os/services/pushover.py
@@ -12,10 +12,11 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from career_os.models.integrations import IntegrationConfig
-from career_os.models.models import Application, FollowUp
+from career_os.models.models import Application, FollowUp, Profile
 
 if TYPE_CHECKING:
     from career_os.models.calendar import CalendarEvent
@@ -40,6 +41,10 @@ _URL_TITLE_VIEW_APPLICATION = "View Application"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+class ProfileNotFoundError(Exception):
+    """Raised when the requested profile does not exist."""
 
 
 class PushoverNotConfiguredError(Exception):
@@ -73,6 +78,12 @@ def _get_pushover_client(db: Session) -> PushoverClient:
     return PushoverClient(user_key=user_key, app_token=app_token)
 
 
+def _validate_profile(db: Session, profile_id: int) -> None:
+    """Raise ProfileNotFoundError if the profile does not exist."""
+    if db.query(Profile).filter(Profile.id == profile_id).first() is None:
+        raise ProfileNotFoundError(f"Profile {profile_id} not found")
+
+
 def _get_or_create_preferences(db: Session, profile_id: int) -> NotificationPreference:
     """Get or create notification preferences for a profile."""
     pref = (
@@ -81,9 +92,14 @@ def _get_or_create_preferences(db: Session, profile_id: int) -> NotificationPref
         .first()
     )
     if pref is None:
+        _validate_profile(db, profile_id)
         pref = NotificationPreference(profile_id=profile_id)
         db.add(pref)
-        db.commit()
+        try:
+            db.commit()
+        except IntegrityError as exc:
+            db.rollback()
+            raise ProfileNotFoundError(f"Profile {profile_id} not found") from exc
         db.refresh(pref)
     return pref
 
@@ -874,6 +890,7 @@ def send_test_notification(
 
     VAL-PUSH-005: Auth failure logged and surfaced in UI, no crash.
     """
+    _validate_profile(db, profile_id)
     try:
         client = _get_pushover_client(db)
     except PushoverNotConfiguredError as exc:

--- a/tests/fuzz/conftest.py
+++ b/tests/fuzz/conftest.py
@@ -1,0 +1,61 @@
+"""Fuzz test fixtures -- auth disabled, clean DB state for Schemathesis."""
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, event, pool
+from sqlalchemy.orm import sessionmaker
+
+import career_os.models as _models  # noqa: F401 — register all ORM tables on Base
+from career_os.database import Base, get_db
+from career_os.main import app
+
+
+@pytest.fixture(autouse=True, scope="session")
+def disable_auth():
+    """Disable API-key auth for the entire fuzz session (D-06).
+
+    AUTH_ENABLED must be ``"false"`` *before* any request so the
+    ``APIKeyAuthMiddleware`` skips verification.  We restore the
+    original value (if any) after the session.
+    """
+    original = os.environ.get("AUTH_ENABLED")
+    os.environ["AUTH_ENABLED"] = "false"
+    yield
+    if original is None:
+        os.environ.pop("AUTH_ENABLED", None)
+    else:
+        os.environ["AUTH_ENABLED"] = original
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    """Provide an isolated in-memory database for each fuzz test.
+
+    Overrides the FastAPI ``get_db`` dependency so every generated
+    request hits a fresh SQLite instance with all tables created.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=pool.StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    session_cls = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = session_cls()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    engine.dispose()
+    app.dependency_overrides.clear()

--- a/tests/fuzz/test_api_fuzz.py
+++ b/tests/fuzz/test_api_fuzz.py
@@ -1,0 +1,163 @@
+"""Schemathesis API contract fuzzing tests (ADV-03).
+
+Parametrized endpoint fuzzing verifies no endpoint returns HTTP 500 on
+valid-schema inputs.  The manual lifecycle chain test exercises the most
+common user journey: create profile -> create application -> update status
+-> create contact.
+
+Auth is disabled via the ``disable_auth`` session fixture in conftest.py
+(D-06).  These tests are excluded from the default pytest run via the
+``fuzz`` marker (D-11) and intended for nightly CI (D-10).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import schemathesis
+from hypothesis import HealthCheck, settings
+
+# Ensure auth is off at module level so the schema object (created at
+# import time) already sees AUTH_ENABLED=false.
+os.environ["AUTH_ENABLED"] = "false"
+
+from career_os.main import app  # noqa: E402
+
+schema = schemathesis.openapi.from_asgi("/openapi.json", app)
+
+
+# ---------------------------------------------------------------------------
+# Parametrized endpoint fuzz: every operation from the OpenAPI spec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fuzz
+@schema.parametrize()
+@settings(
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_api_no_500(case):
+    """No endpoint returns 500 on valid-schema inputs (ADV-03).
+
+    Schemathesis generates random payloads conforming to the OpenAPI
+    schema for each operation and asserts the response status is < 500.
+    """
+    response = case.call()
+    assert response.status_code < 500, (
+        f"FUZZ-500: {case.method} {case.path} returned {response.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manual lifecycle chain: profile -> application -> status -> contact
+# ---------------------------------------------------------------------------
+# Schemathesis stateful mode *does* discover transitions from the OpenAPI
+# spec (verified during development).  However the auto-generated state
+# machine is unreliable for validating a *specific* user journey because
+# transition selection is random.  We therefore write a deterministic manual
+# chain that mirrors the canonical lifecycle (D-07).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fuzz
+class TestLifecycleChain:
+    """Chain: create profile -> create application -> update status -> add contact (D-07)."""
+
+    def test_lifecycle_no_500(self, clean_db):
+        """Walk the primary user journey and verify no 500 at any step.
+
+        Uses the ASGI test client from schemathesis to stay in-process.
+        """
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+
+        # Step 1 -- create a profile
+        resp = client.post(
+            "/api/profiles",
+            json={"name": "Fuzz User", "email": "fuzz@example.com"},
+        )
+        assert resp.status_code == 201, f"POST /api/profiles: {resp.status_code} {resp.text}"
+        profile_id = resp.json()["id"]
+
+        # Step 2 -- create an application under that profile
+        resp = client.post(
+            "/api/applications",
+            json={
+                "profile_id": profile_id,
+                "company": "Fuzz Corp",
+                "role": "Fuzz Engineer",
+            },
+        )
+        assert resp.status_code == 201, f"POST /api/applications: {resp.status_code} {resp.text}"
+        app_id = resp.json()["id"]
+        assert resp.json()["status"] == "discovered"
+
+        # Step 3 -- transition status: discovered -> interested -> applied
+        for target_status in ("interested", "applied"):
+            resp = client.patch(
+                f"/api/applications/{app_id}",
+                params={"profile_id": profile_id},
+                json={"status": target_status},
+            )
+            assert resp.status_code == 200, (
+                f"PATCH /api/applications/{app_id} -> {target_status}: "
+                f"{resp.status_code} {resp.text}"
+            )
+            assert resp.json()["status"] == target_status
+
+        # Step 4 -- create a contact linked to the same profile
+        resp = client.post(
+            "/api/contacts",
+            json={
+                "profile_id": profile_id,
+                "name": "Fuzz Contact",
+                "company": "Fuzz Corp",
+            },
+        )
+        assert resp.status_code == 201, f"POST /api/contacts: {resp.status_code} {resp.text}"
+        assert resp.json()["name"] == "Fuzz Contact"
+        assert resp.json()["profile_id"] == profile_id
+
+
+# ---------------------------------------------------------------------------
+# Schemathesis stateful mode (auto-discovered transitions)
+# ---------------------------------------------------------------------------
+# The OpenAPI spec has enough response schemas for schemathesis to infer
+# transitions.  We keep max_examples low because each example walks
+# multiple steps and the in-memory DB starts fresh per test.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fuzz
+class APIWorkflow(schema.as_state_machine()):
+    """Auto-discovered stateful API workflow (ADV-03, D-07).
+
+    Schemathesis chains operations by extracting IDs from responses and
+    injecting them into subsequent requests.
+    """
+
+    def setup(self):  # noqa: D102 — required override
+        pass
+
+
+TestAPIWorkflow = APIWorkflow.TestCase
+TestAPIWorkflow.settings = settings(
+    max_examples=15,
+    stateful_step_count=4,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+# Propagate fuzz marker to the generated TestCase so default pytest run
+# (addopts = -m 'not fuzz') excludes it.
+TestAPIWorkflow = pytest.mark.fuzz(TestAPIWorkflow)
+# Pre-existing schema issue: datetime fields (updated_at, created_at)
+# lack timezone suffixes but OpenAPI schema specifies format: date-time
+# (RFC 3339 requires timezone).  Tracked as deferred item for endpoint fix.
+TestAPIWorkflow = pytest.mark.xfail(
+    reason="Pre-existing: datetime fields missing timezone suffix vs RFC 3339",
+    strict=False,
+)(TestAPIWorkflow)

--- a/tests/fuzz/test_api_fuzz.py
+++ b/tests/fuzz/test_api_fuzz.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 import os
 
 import pytest
-import schemathesis
-from hypothesis import HealthCheck, settings
+
+schemathesis = pytest.importorskip(
+    "schemathesis", reason="schemathesis not installed — fuzz tests skipped"
+)
+pytest.importorskip("hypothesis", reason="hypothesis not installed — fuzz tests skipped")
+from hypothesis import HealthCheck, settings  # noqa: E402
 
 # Ensure auth is off at module level so the schema object (created at
 # import time) already sees AUTH_ENABLED=false.


### PR DESCRIPTION
## Summary

- Add `career_os.schemas.constraints` module with INT64_MIN/INT64_MAX constants
- Constrain all 26 Pydantic schema files: ID fields get `ge=1, le=INT64_MAX`, counters get `ge=INT64_MIN, le=INT64_MAX`, `list[int]` ID fields use `Annotated` wrapper
- Constrain all 21 API route files: query params and path params get `ge=1, le=INT32_MAX` (INT32 due to ASGI transport C int limitation)
- Add Schemathesis fuzz test infrastructure in hard-failure mode (`assert status < 500`, no warnings fallback)
- Fix 4 bugs found during fuzzing: ASGI transport overflow, pushover missing profile check, ghost threshold timedelta overflow, ApplicationUpdate type guard

## Results

- **140 fuzz tests passed**, 1 xfail (datetime RFC 3339 — tracked as G-433/Phase 3.3)
- **Zero FUZZ-500 errors** across 139 API endpoints
- **3077 existing tests pass** with zero regressions
- 53 files changed, 1042 insertions, 441 deletions

## Test plan

- [x] `pytest tests/ -m "not fuzz"` — 3077 passed, zero regressions
- [x] `pytest tests/fuzz/ -m fuzz -v` — 140 passed, 1 xfail, zero 500s
- [x] `ruff check src/career_os/schemas/ src/career_os/api/` — lint clean
- [x] Existing domain constraints preserved (gaps.distance, pushover quiet_hours, scoring percentile, calendar reminder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)