### PR TITLE
fix(G-433): datetime RFC 3339 compliance — UTC validators on all response schemas

### DIFF
--- a/src/career_os/schemas/calendar.py
+++ b/src/career_os/schemas/calendar.py
@@ -1,11 +1,20 @@
 """Pydantic schemas for Calendar Integration API."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
 
 
 class CalendarEventType(StrEnum):
@@ -97,6 +106,11 @@ class CalendarEventResponse(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @field_validator("start_time", "end_time", "created_at", "updated_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 class CalendarEventListResponse(BaseModel):

--- a/src/career_os/schemas/integrations.py
+++ b/src/career_os/schemas/integrations.py
@@ -1,10 +1,20 @@
 """Pydantic schemas for Integration Configuration API."""
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
+
 
 # ---- Integration definitions ----
 
@@ -47,6 +57,11 @@ class IntegrationConnectionTestResult(BaseModel):
     message: str
     tested_at: datetime | None = None
 
+    @field_validator("tested_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
+
 
 class IntegrationConfigResponse(BaseModel):
     """Response schema for a single integration config."""
@@ -66,6 +81,11 @@ class IntegrationConfigResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    @field_validator("last_tested_at", "created_at", "updated_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
+
 
 class IntegrationListResponse(BaseModel):
     """Response schema for listing all integrations."""
@@ -81,6 +101,11 @@ class IntegrationTestResponse(BaseModel):
     success: bool
     message: str
     tested_at: datetime
+
+    @field_validator("tested_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 # ---- Registry of known integrations ----

--- a/src/career_os/schemas/interview_prep.py
+++ b/src/career_os/schemas/interview_prep.py
@@ -10,11 +10,21 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
+
 
 # ---------------------------------------------------------------------------
 # Topic schema
@@ -62,6 +72,11 @@ class PrepChecklistItem(BaseModel):
     priority: str = Field(..., description="Priority: high, medium, low")
     completed: bool = Field(default=False, description="Completion state")
     completed_at: datetime | None = Field(default=None, description="When the item was completed")
+
+    @field_validator("completed_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 class PrepItemUpdate(BaseModel):

--- a/src/career_os/schemas/profiles.py
+++ b/src/career_os/schemas/profiles.py
@@ -1,12 +1,20 @@
 """Pydantic schemas for Profile API."""
 
 import json as json_mod
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
 
 
 class ProfileCreate(BaseModel):
@@ -42,6 +50,11 @@ class ProfileResponse(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
     @field_validator("dream_companies", mode="before")
     @classmethod

--- a/src/career_os/schemas/pushover.py
+++ b/src/career_os/schemas/pushover.py
@@ -1,11 +1,21 @@
 """Pydantic schemas for Pushover notification integration."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
+
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -65,6 +75,11 @@ class NotificationPreferenceResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
+
 
 # ---------------------------------------------------------------------------
 # Send notification request
@@ -100,6 +115,11 @@ class NotificationLogResponse(BaseModel):
     sent_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @field_validator("sent_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 class NotificationLogListResponse(BaseModel):

--- a/src/career_os/schemas/star_stories.py
+++ b/src/career_os/schemas/star_stories.py
@@ -8,11 +8,21 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
+
 
 # ---------------------------------------------------------------------------
 # Request schemas
@@ -66,6 +76,13 @@ class StarStoryResponse(BaseModel):
     skill_tags: list[str]
     created_at: datetime
     updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 class StarStoryListResponse(BaseModel):

--- a/src/career_os/schemas/ticktick.py
+++ b/src/career_os/schemas/ticktick.py
@@ -1,10 +1,19 @@
 """Pydantic schemas for TickTick Sync API."""
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from career_os.schemas.constraints import INT64_MAX, INT64_MIN
+
+
+def _ensure_utc(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime) and v.tzinfo is None:
+        return v.replace(tzinfo=UTC)
+    return v
 
 
 class TickTickSyncTaskResponse(BaseModel):
@@ -20,6 +29,11 @@ class TickTickSyncTaskResponse(BaseModel):
     error_message: str | None = None
 
     model_config = {"from_attributes": True}
+
+    @field_validator("last_synced_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)
 
 
 class TickTickSyncStatusResponse(BaseModel):
@@ -65,3 +79,8 @@ class TickTickConnectionTestResponse(BaseModel):
     success: bool
     message: str
     tested_at: datetime
+
+    @field_validator("tested_at", mode="before")
+    @classmethod
+    def _ensure_timestamps_utc(cls, v: Any) -> datetime | None:
+        return _ensure_utc(v)


### PR DESCRIPTION
## Summary

- Add `_ensure_utc` field validators to 7 schema files missing UTC enforcement on datetime fields
- All API datetime responses now include timezone suffix (`+00:00`) per RFC 3339
- 96 total `_ensure_utc` occurrences across all schema files (complete coverage)
- TestAPIWorkflow xfail updated: datetime fixed, but uncovered enum validation issue (separate ticket)

## Test plan

- [x] 1561 non-fuzz tests pass, zero regressions
- [x] 140 fuzz tests pass, 1 xfail (enum issue, not datetime)
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)