### PR TITLE
feat(G-446): add OpenAI direct provider

### DIFF
--- a/src/career_os/ai/__init__.py
+++ b/src/career_os/ai/__init__.py
@@ -6,6 +6,7 @@ from career_os.ai.cache import CachedProvider
 from career_os.ai.factory import UnsupportedProviderError, get_ai_provider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaConnectionError, OllamaProvider
+from career_os.ai.openai_provider import OpenAIProvider
 from career_os.ai.openrouter_provider import CreditsExhaustedError, OpenRouterProvider
 from career_os.ai.pii_masking import MaskedProvider, MaskMapping, PIIMasker
 from career_os.ai.together_provider import TogetherProvider
@@ -21,6 +22,7 @@ __all__ = [
     "MockProvider",
     "OllamaConnectionError",
     "OllamaProvider",
+    "OpenAIProvider",
     "OpenRouterProvider",
     "PIIMasker",
     "ProviderQuotaError",

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -10,6 +10,7 @@ from career_os.ai.anthropic_provider import AnthropicProvider
 from career_os.ai.base import AIProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaProvider
+from career_os.ai.openai_provider import OpenAIProvider
 from career_os.ai.openrouter_provider import OpenRouterProvider
 from career_os.ai.together_provider import TogetherProvider
 
@@ -86,6 +87,10 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
     "together": lambda: TogetherProvider(
         api_key=_resolve_api_key("TOGETHER_API_KEY", "together_api_key"),
         model=os.getenv("TOGETHER_MODEL", "meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+    ),
+    "openai": lambda: OpenAIProvider(
+        api_key=_resolve_api_key("OPENAI_API_KEY", "openai_api_key"),
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
     ),
 }
 

--- a/src/career_os/ai/openai_provider.py
+++ b/src/career_os/ai/openai_provider.py
@@ -1,0 +1,163 @@
+"""OpenAI direct AI provider.
+
+Connects to the OpenAI API (https://api.openai.com) via the native
+chat completions endpoint.
+
+Requires OPENAI_API_KEY in environment.
+"""
+
+import json
+import logging
+
+import httpx
+
+from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.observability import observe, update_current_generation
+from career_os.ai.openrouter_provider import (
+    _SCHEMA_MAP,
+    _scoring_user_prompt,
+    _system_prompt_for_feature,
+    _try_parse_structured,
+)
+from career_os.schemas.ai import AIFeature, AIResponse
+
+logger = logging.getLogger(__name__)
+
+# Compact JSON separators — eliminates whitespace tokens (~30% reduction on profile data)
+_COMPACT = (",", ":")
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+class OpenAIProvider(AIProvider):
+    """AI provider backed by the OpenAI API (native)."""
+
+    def __init__(self, api_key: str, model: str = DEFAULT_MODEL) -> None:
+        """Initialize with API key and optional model override.
+
+        Args:
+            api_key: OpenAI API key.
+            model: Model identifier (default: gpt-4o-mini).
+        """
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY is required for OpenAIProvider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    @observe(name="openai-complete", as_type="generation")
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        feature: AIFeature = AIFeature.complete,
+        context: dict | None = None,
+        max_retries: int = 1,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Send a completion request to the OpenAI API."""
+        update_current_generation(
+            model=self._model,
+            metadata={"feature": feature.value},
+        )
+        expects_structured = feature in _SCHEMA_MAP
+
+        for attempt in range(1, max_retries + 2):
+            user_content = prompt
+            if attempt > 1:
+                user_content += (
+                    "\n\nIMPORTANT: Return ONLY valid JSON"
+                    " with no surrounding text or markdown fences."
+                )
+
+            messages: list[dict[str, str]] = [
+                {"role": "user", "content": user_content},
+            ]
+
+            system_msg = _system_prompt_for_feature(feature)
+            if system_msg:
+                messages.insert(0, {"role": "system", "content": system_msg})
+
+            payload = {
+                "model": self._model,
+                "messages": messages,
+            }
+
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    OPENAI_API_URL,
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                if response.status_code in (402, 429):
+                    detail = _extract_error_detail(response)
+                    raise ProviderQuotaError("openai", response.status_code, detail)
+                response.raise_for_status()
+                data = response.json()
+
+            content = data["choices"][0]["message"]["content"]
+            model_used = data.get("model", self._model)
+
+            structured = _try_parse_structured(content, feature)
+
+            if structured is not None or not expects_structured:
+                usage_data = data.get("usage", {})
+                update_current_generation(
+                    usage_details={
+                        "input": usage_data.get("prompt_tokens", 0),
+                        "output": usage_data.get("completion_tokens", 0),
+                    },
+                )
+                return AIResponse(
+                    content=content,
+                    provider="openai",
+                    feature=feature,
+                    structured=structured,
+                    model=model_used,
+                )
+
+            if attempt <= max_retries:
+                logger.warning(
+                    "Structured parse failed for %s, retrying (attempt %d/%d)",
+                    feature,
+                    attempt,
+                    max_retries + 1,
+                )
+
+        # Exhausted retries — return last response without structured data
+        return AIResponse(
+            content=content,
+            provider="openai",
+            feature=feature,
+            structured=None,
+            model=model_used,
+        )
+
+    async def score(
+        self,
+        job_description: str,
+        profile_data: dict,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Score a job against a profile via the OpenAI API."""
+        prompt = _scoring_user_prompt(
+            job_description, json.dumps(profile_data, separators=_COMPACT)
+        )
+        return await self.complete(prompt, feature=AIFeature.score)
+
+
+def _extract_error_detail(response: httpx.Response) -> str:
+    """Best-effort extraction of error message from an OpenAI error response."""
+    try:
+        body = response.json()
+        error = body.get("error", {})
+        return error.get("message", "") if isinstance(error, dict) else str(error)
+    except Exception:
+        return ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ os.environ["AI_PROVIDER"] = "mock"
 os.environ["OPENROUTER_API_KEY"] = ""
 os.environ["ANTHROPIC_API_KEY"] = ""
 os.environ["TOGETHER_API_KEY"] = ""
+os.environ["OPENAI_API_KEY"] = ""
 
 # ---------------------------------------------------------------------------
 # Network guard: block outbound HTTP to AI provider domains.

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,395 @@
+"""Tests for OpenAIProvider — OpenAI direct API.
+
+Covers:
+- Provider contract (AIProvider subclass, name, privacy tier, init validation)
+- Factory registration and resolution
+- OpenAI-compatible request format (Bearer auth, messages array)
+- HTTP 402/429 → ProviderQuotaError
+- Response parsing (choices[0].message.content)
+- System prompt inclusion for structured features
+- score() delegation to complete()
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.factory import _PROVIDER_REGISTRY, get_ai_provider
+from career_os.ai.openai_provider import (
+    OPENAI_API_URL,
+    OpenAIProvider,
+)
+from career_os.schemas.ai import AIFeature, AIResponse
+
+# Fake credentials used across all tests — not real.
+_TEST_CREDENTIAL = "test-fake-openai-key"  # noqa: S105
+_TEST_CREDENTIAL_2 = "test-fake-openai-key-2"  # noqa: S105
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderInit:
+    """Test OpenAIProvider initialization and contract."""
+
+    def test_name(self) -> None:
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider.name == "openai"
+
+    def test_is_ai_provider(self) -> None:
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        assert isinstance(provider, AIProvider)
+
+    def test_privacy_tier_is_yellow(self) -> None:
+        """OpenAI uses API data per org settings — default yellow tier."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider.privacy_tier == "yellow"
+
+    def test_empty_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            OpenAIProvider(api_key="")
+
+    def test_default_model(self) -> None:
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider._model == "gpt-4o-mini"
+
+    def test_custom_model(self) -> None:
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL, model="gpt-4o")
+        assert provider._model == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Factory registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIFactoryRegistration:
+    """Test OpenAI provider is registered in the factory."""
+
+    def test_openai_in_registry(self) -> None:
+        """'openai' key exists in _PROVIDER_REGISTRY."""
+        assert "openai" in _PROVIDER_REGISTRY
+
+    def test_registry_entry_callable(self) -> None:
+        """Registry entry for openai is callable."""
+        assert callable(_PROVIDER_REGISTRY["openai"])
+
+    def test_factory_creates_openai_provider(self) -> None:
+        """get_ai_provider('openai') returns OpenAIProvider."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": _TEST_CREDENTIAL}):
+            provider = get_ai_provider("openai")
+            assert isinstance(provider, OpenAIProvider)
+            assert provider.name == "openai"
+
+    def test_factory_without_key_raises(self) -> None:
+        """get_ai_provider('openai') without API key raises ValueError."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=False):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+                get_ai_provider("openai")
+
+    def test_openai_in_unsupported_error_message(self) -> None:
+        """UnsupportedProviderError lists openai as a supported provider."""
+        from career_os.ai.factory import UnsupportedProviderError
+
+        with pytest.raises(UnsupportedProviderError) as exc_info:
+            get_ai_provider("nonexistent")
+        assert "openai" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# API request format tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIRequestFormat:
+    """Test the OpenAI API request format."""
+
+    @pytest.mark.asyncio
+    async def test_headers_include_bearer_auth(self) -> None:
+        """Request headers include Authorization: Bearer."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL_2)
+        captured_headers = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_headers.update(headers or {})
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test")
+
+        assert captured_headers["Authorization"] == f"Bearer {_TEST_CREDENTIAL_2}"
+        assert captured_headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_request_sent_to_openai_url(self) -> None:
+        """Request is sent to the OpenAI API URL."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_url = None
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            nonlocal captured_url
+            captured_url = url
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test")
+
+        assert captured_url == OPENAI_API_URL
+
+    @pytest.mark.asyncio
+    async def test_payload_uses_openai_chat_format(self) -> None:
+        """Payload uses OpenAI chat completions format."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "result"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("hello world")
+
+        assert captured_payload["model"] == "gpt-4o-mini"
+        assert captured_payload["messages"] == [{"role": "user", "content": "hello world"}]
+
+    @pytest.mark.asyncio
+    async def test_system_message_for_structured_feature(self) -> None:
+        """Structured features include a system message."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "{}"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test", feature=AIFeature.score)
+
+        messages = captured_payload["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_no_system_message_for_generic_complete(self) -> None:
+        """Generic complete (no feature) does not include system message."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("hello", feature=AIFeature.complete)
+
+        messages = captured_payload["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIResponseParsing:
+    """Test response parsing from OpenAI-format responses."""
+
+    @pytest.mark.asyncio
+    async def test_parses_content_from_choices(self) -> None:
+        """Response correctly parses content from choices[0].message.content."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "Hello world"}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("greet me")
+
+        assert isinstance(result, AIResponse)
+        assert result.content == "Hello world"
+        assert result.provider == "openai"
+        assert result.model == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_uses_model_from_response(self) -> None:
+        """Model field uses the model returned in the API response."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}}],
+                    "model": "gpt-4o-mini-2024-07-18",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.model == "gpt-4o-mini-2024-07-18"
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIErrorHandling:
+    """Test HTTP error handling (402, 429, 500)."""
+
+    @pytest.mark.asyncio
+    async def test_402_raises_provider_quota_error(self) -> None:
+        """HTTP 402 raises ProviderQuotaError."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                402,
+                json={"error": {"message": "Insufficient credits"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError) as exc_info:
+                await provider.complete("test")
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_429_raises_provider_quota_error(self) -> None:
+        """HTTP 429 raises ProviderQuotaError."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                429,
+                json={"error": {"message": "Rate limited"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError) as exc_info:
+                await provider.complete("test")
+            assert exc_info.value.status_code == 429
+            assert exc_info.value.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_500_raises_http_error(self) -> None:
+        """HTTP 500 raises httpx.HTTPStatusError (not ProviderQuotaError)."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                500,
+                json={"error": {"message": "Internal error"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(httpx.HTTPStatusError):
+                await provider.complete("test")
+
+
+# ---------------------------------------------------------------------------
+# Score method tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIScore:
+    """Test the score() method delegates to complete() correctly."""
+
+    @pytest.mark.asyncio
+    async def test_score_calls_complete_with_score_feature(self) -> None:
+        """score() calls complete() with AIFeature.score."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        score_json = json.dumps(
+            {
+                "fit_score": 7.5,
+                "reasoning": "x" * 100,
+                "estimated_salary": "120k EUR",
+                "effort_flag": "medium",
+                "prep_level": "moderate",
+                "prep_notes": "Study X.",
+                "readiness_score": 72.0,
+                "career_alignment": 8.0,
+                "score_breakdown": [
+                    {"factor": "Technical", "contribution": 2.0, "description": "Strong match"},
+                    {"factor": "Culture", "contribution": 1.5, "description": "Good alignment"},
+                    {"factor": "Location", "contribution": -0.5, "description": "Remote pref"},
+                ],
+            }
+        )
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": score_json}}],
+                    "model": "gpt-4o-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.score("Software Engineer at Acme", {"name": "Jane"})
+
+        assert result.feature == AIFeature.score
+        assert result.provider == "openai"
+        # System message should be present (score feature has system prompt)
+        messages = captured_payload["messages"]
+        assert messages[0]["role"] == "system"


### PR DESCRIPTION
## Summary
- Add `OpenAIProvider` class following the Together.ai pattern (OpenAI-compatible chat completions)
- Registered in factory with `OPENAI_API_KEY` / `OPENAI_MODEL` env vars, default model `gpt-4o-mini`
- DB credential fallback, 402/429 → ProviderQuotaError, structured JSON retry
- Test safety: `OPENAI_API_KEY` blanked in conftest.py (api.openai.com already in network guard)

## Test plan
- [x] 22 unit tests covering init, factory registration, request format, response parsing, error handling, score delegation
- [x] Full test suite passes (3160 passed, 0 regressions)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)