### PR TITLE
fix(G-464): simplify Mermaid diagrams for GitHub rendering

### DIFF
--- a/docs/guides/WRITING-GUIDE.md
+++ b/docs/guides/WRITING-GUIDE.md
@@ -37,8 +37,8 @@ Root-level docs (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`) 
 
 [Detailed explanation in warm, teaching tone]
 
-```mermaid
-[At least one diagram per guide]
+```
+mermaid diagram here (at least one per guide)
 ```
 
 ## Examples

--- a/docs/guides/ai-providers-guide.md
+++ b/docs/guides/ai-providers-guide.md
@@ -27,21 +27,13 @@ Think of AI providers like electricity providers:
 Kestrel works the same way. Pick a provider, connect it, and every feature — scoring, coaching, interview prep — works identically regardless of which AI is behind it.
 
 ```mermaid
-graph LR
+flowchart LR
     K[Kestrel] --> F{Provider Factory}
-    F --> D[Demo Mode<br>Free, offline]
-    F --> OR[OpenRouter<br>300+ models]
-    F --> A[Anthropic<br>Best privacy]
-    F --> T[Together AI<br>Budget bulk]
-    F --> O[Ollama<br>100% local]
-
-    style K fill:#1e40af,color:#fff
-    style F fill:#374151,color:#fff
-    style D fill:#059669,color:#fff
-    style OR fill:#7c3aed,color:#fff
-    style A fill:#dc2626,color:#fff
-    style T fill:#d97706,color:#fff
-    style O fill:#059669,color:#fff
+    F --> D[Demo Mode - Free, offline]
+    F --> OR[OpenRouter - 300+ models]
+    F --> A[Anthropic - Best privacy]
+    F --> T[Together AI - Budget bulk]
+    F --> O[Ollama - 100% local]
 ```
 
 ---

--- a/docs/guides/how-cicd-works.md
+++ b/docs/guides/how-cicd-works.md
@@ -20,38 +20,22 @@ You've probably installed software before — download, double-click, done. But 
 
 ```mermaid
 flowchart LR
-    DEV[Developer writes code] --> CP1
-
-    subgraph CP1 ["Checkpoint 1: Does It Work?"]
-        LINT[Lint & Format]
-        TESTS[Test Suite]
-        SEC[Security Scan]
-        PII[PII Leak Check]
-    end
-
-    CP1 -->|All pass| CP2
-
-    subgraph CP2 ["Checkpoint 2: Ready to Ship?"]
-        MERGE[Merge to main]
-        CONV[Conventional commits<br/>categorize changes]
-        DRAFT[Release draft<br/>auto-generated]
-    end
-
-    CP2 -->|Developer approves| CP3
-
-    subgraph CP3 ["Checkpoint 3: Can You Get It?"]
-        DOCKER[Docker Image<br/>Backend + Frontend]
-        PIP[Python Package<br/>PyPI]
-        NPM[npm Package<br/>Node.js wrapper]
-    end
-
-    CP3 --> USER[You run Kestrel]
-
-    style DEV fill:#e8f4fd
-    style USER fill:#d4edda
-    style CP1 fill:#fff3cd
-    style CP2 fill:#e8f4fd
-    style CP3 fill:#d4edda
+    DEV[Developer writes code] --> LINT[Lint]
+    DEV --> TESTS[Test Suite]
+    DEV --> SEC[Security Scan]
+    DEV --> PII[PII Check]
+    LINT --> PASS{All pass?}
+    TESTS --> PASS
+    SEC --> PASS
+    PII --> PASS
+    PASS -->|Yes| MERGE[Merge to main]
+    MERGE --> DRAFT[Release draft auto-generated]
+    DRAFT -->|Approved| DOCKER[Docker Image]
+    DRAFT -->|Approved| PIP[PyPI Package]
+    DRAFT -->|Approved| NPM[npm Package]
+    DOCKER --> USER[You run Kestrel]
+    PIP --> USER
+    NPM --> USER
 ```
 
 **Checkpoint 1: Does It Work?** When new code is submitted for review, automated checks run immediately. A linter checks coding standards (grammar rules for code). The full test suite runs in under 2 minutes. Security scanners check for known vulnerabilities in dependencies. A special scanner checks that no personal information, passwords, or API keys accidentally ended up in the code — like checking that a letter you're mailing doesn't have your credit card number on the envelope. If any check fails, the code can't move forward.

--- a/docs/guides/how-observability-works.md
+++ b/docs/guides/how-observability-works.md
@@ -33,25 +33,18 @@ But a generation doesn't happen in isolation. Before your prompt reaches the AI 
 
 ```mermaid
 flowchart TD
-    A["You click 'Score this job'"] --> B[Route Context]
-    B -->|"Adds: profile ID, session, feature type"| C[PII Masking]
-    C -->|"Strips emails, phones → records detection count"| D{Cache Check}
-    D -->|"HIT (free, instant)"| E[Return cached result]
-    D -->|"MISS"| F[AI Model generates response]
-    F -->|"Records: model, tokens, latency, I/O"| G[Result returned]
-
+    A[Score a job] --> B[Route Context]
+    B --> C[PII Masking]
+    C --> D{Cache Check}
+    D -->|HIT| E[Return cached result]
+    D -->|MISS| F[AI Model responds]
+    F --> G[Result returned]
     G --> H[Langfuse Dashboard]
     E --> H
-
-    H --> I["Filter by feature, provider, date"]
-    H --> J["Debug unexpected scores"]
-    H --> K["Compare provider performance"]
-    H --> L["Track cost per feature"]
-
-    style A fill:#e8f4fd
-    style E fill:#d4edda
-    style F fill:#fff3cd
-    style H fill:#e8f4fd
+    H --> I[Filter by feature]
+    H --> J[Debug scores]
+    H --> K[Compare providers]
+    H --> L[Track costs]
 ```
 
 **Route context** adds metadata about who asked and why — your profile ID, the scoring session, what kind of AI feature was used. This lets you filter traces later ("show me all scoring calls for engineering roles last week").

--- a/docs/guides/how-scoring-works.md
+++ b/docs/guides/how-scoring-works.md
@@ -26,16 +26,10 @@ Most job-matching tools give you a single score. Kestrel gives you two, because 
 
 The real insight comes from looking at both together:
 
-```mermaid
-quadrantChart
-    title Fit vs Desire Decision Matrix
-    x-axis "Low Desire" --> "High Desire"
-    y-axis "Low Fit" --> "High Fit"
-    quadrant-1 "Dream Job: Go all in"
-    quadrant-2 "Safe Bet: You'd do well, but would you be happy?"
-    quadrant-3 "Skip: Move on, no hard feelings"
-    quadrant-4 "Reach: Exciting, but close gaps first"
-```
+| | **Low Desire** | **High Desire** |
+|---|---|---|
+| **High Fit** | Safe Bet — you'd do well, but would you be happy? | Dream Job — go all in |
+| **Low Fit** | Skip — move on, no hard feelings | Reach — exciting, but close gaps first |
 
 A "Safe Bet" isn't a bad outcome — sometimes stability is exactly what you need. And a "Reach" isn't hopeless — it tells you where to invest if you really want that role. The quadrant helps you make intentional decisions instead of applying to everything and hoping for the best.
 
@@ -60,7 +54,7 @@ Neither score is pulled from thin air. Each one is built from six sub-scores tha
 ```mermaid
 flowchart TD
     A[Job Posting] --> B[Red Flag Detection]
-    B -->|Ghost job / stale / vague| C[Flag warnings attached]
+    B -->|Flags found| C[Warnings attached]
     B -->|Clean| D[Dimension Scoring]
     C --> D
     D --> E[Technical Fit]
@@ -69,15 +63,17 @@ flowchart TD
     D --> H[Location Fit]
     D --> I[Career Trajectory]
     D --> J[Company Fit]
-    E & F & G & H & I & J --> K[Weight by Job Family]
+    E --> K[Weight by Job Family]
+    F --> K
+    G --> K
+    H --> K
+    I --> K
+    J --> K
     K --> L[Fit Score 0-10]
     K --> M[Desire Score 0-10]
-    L & M --> N[Quadrant Classification]
+    L --> N[Quadrant Classification]
+    M --> N
     N --> O[Dream / Safe Bet / Reach / Skip]
-
-    style A fill:#e8f4fd
-    style O fill:#d4edda
-    style C fill:#fff3cd
 ```
 
 ### Red Flags

--- a/docs/guides/how-testing-works.md
+++ b/docs/guides/how-testing-works.md
@@ -21,34 +21,17 @@ Every time you open Kestrel, search for jobs, or check your pipeline, over 2,800
 Software testing follows a pyramid shape — many fast, cheap tests at the base, fewer expensive tests at the top. Here's what each layer does for Kestrel.
 
 ```mermaid
-graph TD
-    subgraph pyramid ["Test Pyramid"]
-        direction TB
-        E2E["Smoke & E2E Tests<br/><i>Start server, hit endpoints</i>"]
-        INT["Integration Tests<br/><i>Frontend ↔ Backend chains</i>"]
-        UNIT["Unit Tests (2,800+)<br/><i>Individual functions & components</i>"]
-    end
+flowchart TD
+    UNIT[Unit Tests - 2,800+] --> INT[Integration Tests]
+    INT --> E2E[Smoke and E2E Tests]
 
-    subgraph guards ["Quality Guards (every PR)"]
-        LINT["Lint & Format Check"]
-        PII["PII Leak Scan"]
-        DEP["Dependency Audit"]
-        MIG["Migration Up/Down Check"]
-    end
+    LINT[Lint and Format] -.-> UNIT
+    PII_G[PII Leak Scan] -.-> UNIT
+    DEP[Dependency Audit] -.-> UNIT
+    MIG[Migration Check] -.-> UNIT
 
-    subgraph ongoing ["Ongoing"]
-        GOLDEN["Golden Set Regression<br/><i>Hand-labeled jobs across domains</i>"]
-        SONAR["SonarCloud Static Analysis"]
-    end
-
-    UNIT --> INT --> E2E
-    guards -.->|run in parallel| pyramid
-    ongoing -.->|on merge to main| pyramid
-
-    style UNIT fill:#d4edda
-    style INT fill:#e8f4fd
-    style E2E fill:#fff3cd
-    style GOLDEN fill:#f8d7da
+    GOLDEN[Golden Set Regression] -.-> INT
+    SONAR[SonarCloud Analysis] -.-> INT
 ```
 
 **Unit tests** are like tasting while you cook. Does this function calculate the right score? Does that button render with the correct label? Over 2,800 of these run in about two minutes. They're fast, focused, and form the foundation of everything else.
@@ -91,17 +74,17 @@ flowchart LR
     CI --> PII_SCAN[PII Leak Scan]
     CI --> DEP_AUDIT[Dependency Audit]
 
-    LINT & TEST & MIG & SMOKE & PII_SCAN & DEP_AUDIT --> PASS{All Pass?}
+    LINT --> PASS{All Pass?}
+    TEST --> PASS
+    MIG --> PASS
+    SMOKE --> PASS
+    PII_SCAN --> PASS
+    DEP_AUDIT --> PASS
     PASS -->|Yes| MERGE[Merge to Main]
-    PASS -->|No| FIX[Fix & Retry]
+    PASS -->|No| FIX[Fix and Retry]
 
     MERGE --> SONAR_RUN[SonarCloud Deep Analysis]
     MERGE --> GOLDEN_RUN[Golden Set Re-check]
-
-    style PR fill:#e8f4fd
-    style PASS fill:#fff3cd
-    style MERGE fill:#d4edda
-    style FIX fill:#f8d7da
 ```
 
 **On every code change (~2 minutes):** Lint, 2,800+ tests, migration check, API smoke test, PII scan, and dependency audit — all running in parallel on GitHub Actions.

--- a/docs/guides/how-token-optimization-works.md
+++ b/docs/guides/how-token-optimization-works.md
@@ -20,22 +20,13 @@ Every time Kestrel asks an AI to score a job, it sends text — your profile, th
 
 ```mermaid
 flowchart TD
-    A["Score 50 jobs<br/>Base cost: ~$0.03/job"] --> B["1. Prompt Caching<br/><i>90% off repeat prefixes</i>"]
-    B --> C["2. Compact Serialization<br/><i>30% off profile data</i>"]
-    C --> D["3. Compressed Prompts<br/><i>67% off system instructions</i>"]
-    D --> E["4. Smart Model Routing<br/><i>60-95% on simple tasks</i>"]
-    E --> F["5. Response Caching<br/><i>100% off duplicates</i>"]
-    F --> G["6. Batch Scoring<br/><i>50% off bulk overnight work</i>"]
-    G --> H["Result: ~$1-2/month"]
-
-    style A fill:#f8d7da
-    style H fill:#d4edda
-    style B fill:#e8f4fd
-    style C fill:#e8f4fd
-    style D fill:#e8f4fd
-    style E fill:#e8f4fd
-    style F fill:#e8f4fd
-    style G fill:#e8f4fd
+    A[Score 50 jobs] --> B[1. Prompt Caching - 90% off]
+    B --> C[2. Compact Serialization - 30% off]
+    C --> D[3. Compressed Prompts - 67% off]
+    D --> E[4. Smart Model Routing - 60-95% off]
+    E --> F[5. Response Caching - 100% off duplicates]
+    F --> G[6. Batch Scoring - 50% off bulk]
+    G --> H[Result: ~$1-2/month]
 ```
 
 **Strategy 1: Prompt Caching (90% off repeat prefixes).** When scoring multiple jobs for the same person, your profile doesn't change between calls. Anthropic's prompt caching "remembers" the system prompt and profile for 5 minutes. The first call pays full price; the other 49 get a 90% discount on those tokens. If your profile is 1,500 tokens and you score 50 jobs, you save ~67,500 tokens of processing.


### PR DESCRIPTION
## Summary

- Simplify all 7 Mermaid diagrams across docs/guides/ for GitHub renderer compatibility
- Replace `quadrantChart` (unsupported) with markdown table
- Expand `&` join syntax into individual edges
- Remove subgraph-to-subgraph edges
- Strip HTML tags (`<i>`, `<br/>`) from node labels
- Remove custom style directives with `color:#fff`
- Fix template placeholder in WRITING-GUIDE.md incorrectly fenced as mermaid

## Test plan

- [ ] Visit any how-X-works guide on GitHub and confirm Mermaid diagrams render without "Could not find a suitable point" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)