### PR TITLE
feat(G-440): batch scoring — multiple jobs per prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,8 @@ PIPELINE_LOCATION=Remote
 # Inject the top feedback corrections into scoring prompts (Epic 11 bridge).
 # Only enable once you have ≥10 explicit user corrections ("too_high"/"too_low").
 FEEDBACK_CALIBRATION_ENABLED=false
+
+# -- Batch Scoring (G-440) ------------------------------------------------
+# Number of jobs per prompt when using multi-job batch scoring.
+# Higher values save tokens but may slightly reduce quality (<2pp at 25-100).
+BATCH_SCORING_SIZE=10

--- a/src/career_os/services/batch_scoring.py
+++ b/src/career_os/services/batch_scoring.py
@@ -22,6 +22,26 @@ from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
 logger = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 10
+MAX_DESCRIPTION_LENGTH = 8000
+
+# Patterns that could be used for prompt injection in job descriptions
+_INJECTION_PATTERNS = re.compile(
+    r"(?:ignore|disregard|forget)\s+(?:all\s+)?(?:previous|above|prior)\s+instructions",
+    re.IGNORECASE,
+)
+
+
+def _sanitize_description(text: str) -> str:
+    """Sanitize a job description before interpolating into an LLM prompt.
+
+    Truncates to MAX_DESCRIPTION_LENGTH and strips known injection patterns.
+    Job descriptions come from scraped external boards (attacker-controlled).
+    """
+    if not text:
+        return "N/A"
+    text = text[:MAX_DESCRIPTION_LENGTH]
+    text = _INJECTION_PATTERNS.sub("[filtered]", text)
+    return text
 
 
 def get_batch_size() -> int:
@@ -73,7 +93,8 @@ def build_batch_prompt(
             block_parts.append(f"Company: {job['company']}")
         if job.get("url"):
             block_parts.append(f"URL: {job['url']}")
-        block_parts.append(f"Description:\n{job.get('description', 'N/A')}")
+        desc = _sanitize_description(job.get("description", "N/A"))
+        block_parts.append(f"Description:\n{desc}")
         job_blocks.append("\n".join(block_parts))
 
     jobs_section = "\n\n".join(job_blocks)

--- a/src/career_os/services/batch_scoring.py
+++ b/src/career_os/services/batch_scoring.py
@@ -1,0 +1,335 @@
+"""Batch scoring — multiple jobs per prompt.
+
+Sends N jobs in a single LLM prompt and parses a JSON array of ScoreResult
+objects from the response.  Based on arXiv:2604.03684 which confirms <2pp
+quality loss at batch sizes 25-100.
+
+Position bias is mitigated by randomizing job order within each batch.
+If batch parsing fails, the service falls back to individual scoring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import re
+
+from career_os.ai.base import AIProvider
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 10
+
+
+def get_batch_size() -> int:
+    """Return the configured batch size from env var or default."""
+    raw = os.environ.get("BATCH_SCORING_SIZE", "")
+    if raw.strip():
+        try:
+            size = int(raw)
+            if size < 1:
+                logger.warning(
+                    "BATCH_SCORING_SIZE=%s invalid, using default %d", raw, DEFAULT_BATCH_SIZE
+                )
+                return DEFAULT_BATCH_SIZE
+            return size
+        except ValueError:
+            logger.warning(
+                "BATCH_SCORING_SIZE=%s not an int, using default %d", raw, DEFAULT_BATCH_SIZE
+            )
+            return DEFAULT_BATCH_SIZE
+    return DEFAULT_BATCH_SIZE
+
+
+def build_batch_prompt(
+    jobs: list[dict],
+    profile_data: dict,
+) -> tuple[str, list[str]]:
+    """Build a multi-job scoring prompt.
+
+    Args:
+        jobs: List of dicts, each with at least 'id' and 'description'.
+              May also contain 'title', 'company', 'url'.
+        profile_data: User profile data dict.
+
+    Returns:
+        Tuple of (prompt_text, ordered_job_ids) where ordered_job_ids is
+        the randomized order of job IDs as they appear in the prompt.
+    """
+    # Randomize order within the batch (position bias mitigation)
+    shuffled = list(jobs)
+    random.shuffle(shuffled)
+    ordered_ids = [str(j["id"]) for j in shuffled]
+
+    job_blocks: list[str] = []
+    for idx, job in enumerate(shuffled, 1):
+        block_parts = [f"--- Job {idx} (ID: {job['id']}) ---"]
+        if job.get("title"):
+            block_parts.append(f"Title: {job['title']}")
+        if job.get("company"):
+            block_parts.append(f"Company: {job['company']}")
+        if job.get("url"):
+            block_parts.append(f"URL: {job['url']}")
+        block_parts.append(f"Description:\n{job.get('description', 'N/A')}")
+        job_blocks.append("\n".join(block_parts))
+
+    jobs_section = "\n\n".join(job_blocks)
+
+    prompt = (
+        f"Score each of the following {len(shuffled)} jobs against the candidate profile. "
+        f"Return a JSON ARRAY where each element is an object with:\n"
+        f"- job_id (string matching the ID in the job header)\n"
+        f"- fit_score (0-10)\n"
+        f"- reasoning (detailed, >=100 chars)\n"
+        f"- estimated_salary (string)\n"
+        f"- effort_flag (low/medium/high)\n"
+        f"- prep_level (string)\n"
+        f"- prep_notes (string)\n"
+        f"- readiness_score (0-100)\n"
+        f"- career_alignment (0-10)\n"
+        f"- score_breakdown (array of >=3 objects with factor, contribution, description)\n"
+        f"- dimensional_scores (object with 6 floats 0-10: technical_fit, "
+        f"seniority_alignment, compensation_fit, location_fit, career_trajectory, "
+        f"company_fit)\n"
+        f"- ats_keywords (array of 10-15 objects with keyword, category, matched)\n"
+        f"- desire_score (0-10)\n"
+        f"- desire_reasoning (string)\n\n"
+        f"Return ONLY a JSON array of {len(shuffled)} objects. "
+        f"No surrounding text or markdown.\n\n"
+        f"JOBS:\n\n{jobs_section}\n\n"
+        f"PROFILE:\n{json.dumps(profile_data, indent=2)}"
+    )
+
+    return prompt, ordered_ids
+
+
+def _extract_json_array(text: str) -> list[dict] | None:
+    """Extract a JSON array from LLM output, handling markdown fences.
+
+    Returns the parsed list or None if extraction fails.
+    """
+    cleaned = text.strip()
+    # Strip markdown code fences
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        end = -1 if lines[-1].startswith("```") else len(lines)
+        cleaned = "\n".join(lines[1:end]) if len(lines) > 2 else cleaned
+
+    # Strip trailing commas before ] or }
+    cleaned = re.sub(r",\s*([}\]])", r"\1", cleaned)
+
+    # Try direct parse
+    try:
+        data = json.loads(cleaned)
+        if isinstance(data, list):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    # Try to find array in the text using bracket matching
+    start = cleaned.find("[")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape_next = False
+    for i in range(start, len(cleaned)):
+        ch = cleaned[i]
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\":
+            if in_string:
+                escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                candidate = cleaned[start : i + 1]
+                candidate = re.sub(r",\s*([}\]])", r"\1", candidate)
+                try:
+                    data = json.loads(candidate)
+                    if isinstance(data, list):
+                        return data
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def parse_batch_response(
+    content: str,
+    ordered_ids: list[str],
+) -> dict[str, ScoreResult]:
+    """Parse a batch scoring response into a map of job_id -> ScoreResult.
+
+    Args:
+        content: Raw LLM response text.
+        ordered_ids: The job IDs in the order they were sent.
+
+    Returns:
+        Dict mapping job_id (str) to ScoreResult. Jobs that fail validation
+        are omitted from the result.
+    """
+    items = _extract_json_array(content)
+    if items is None:
+        logger.warning("Batch response did not contain a valid JSON array")
+        return {}
+
+    results: dict[str, ScoreResult] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        job_id = str(item.get("job_id", ""))
+        if not job_id:
+            # Try positional fallback — if the array has the right length
+            # and no job_id fields, map by position
+            continue
+        try:
+            score_result = ScoreResult.model_validate(item)
+            results[job_id] = score_result
+        except Exception as exc:
+            logger.warning(
+                "Failed to validate ScoreResult for job %s in batch: %s",
+                job_id,
+                exc,
+            )
+
+    # Positional fallback: if no job_ids were found but array length matches,
+    # assume results are in prompt order
+    if not results and items and len(items) == len(ordered_ids):
+        logger.info("No job_id fields in batch response, using positional mapping")
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            try:
+                score_result = ScoreResult.model_validate(item)
+                results[ordered_ids[idx]] = score_result
+            except Exception as exc:
+                logger.warning(
+                    "Failed to validate ScoreResult at position %d in batch: %s",
+                    idx,
+                    exc,
+                )
+
+    return results
+
+
+def chunk_jobs(jobs: list[dict], batch_size: int) -> list[list[dict]]:
+    """Split jobs into batches of the given size."""
+    return [jobs[i : i + batch_size] for i in range(0, len(jobs), batch_size)]
+
+
+async def batch_score_jobs(
+    provider: AIProvider,
+    jobs: list[dict],
+    profile_data: dict,
+    *,
+    batch_size: int | None = None,
+) -> dict[str, ScoreResult]:
+    """Score multiple jobs using multi-job-per-prompt batching.
+
+    Splits jobs into chunks of batch_size, sends each chunk as a single
+    prompt, and collects results.  Falls back to individual scoring for
+    any jobs whose batch parsing fails.
+
+    Args:
+        provider: AI provider to use for scoring.
+        jobs: List of dicts with at least 'id' and 'description'.
+        profile_data: User profile data dict.
+        batch_size: Jobs per prompt (default from env/config).
+
+    Returns:
+        Dict mapping job_id (str) to ScoreResult for successfully scored jobs.
+    """
+    if batch_size is None:
+        batch_size = get_batch_size()
+
+    if not jobs:
+        return {}
+
+    all_results: dict[str, ScoreResult] = {}
+    failed_jobs: list[dict] = []
+
+    batches = chunk_jobs(jobs, batch_size)
+    logger.info(
+        "Batch scoring %d jobs in %d batches of up to %d",
+        len(jobs),
+        len(batches),
+        batch_size,
+    )
+
+    for batch_idx, batch in enumerate(batches):
+        prompt, ordered_ids = build_batch_prompt(batch, profile_data)
+
+        try:
+            response: AIResponse = await provider.complete(
+                prompt,
+                feature=AIFeature.score,
+                tier=None,
+            )
+            batch_results = parse_batch_response(response.content, ordered_ids)
+
+            if batch_results:
+                all_results.update(batch_results)
+                logger.info(
+                    "Batch %d/%d: parsed %d/%d scores",
+                    batch_idx + 1,
+                    len(batches),
+                    len(batch_results),
+                    len(batch),
+                )
+
+            # Identify jobs that weren't in the parsed results
+            parsed_ids = set(batch_results.keys())
+            for job in batch:
+                if str(job["id"]) not in parsed_ids:
+                    failed_jobs.append(job)
+
+        except Exception as exc:
+            logger.warning(
+                "Batch %d/%d failed (%s), adding %d jobs to fallback queue",
+                batch_idx + 1,
+                len(batches),
+                exc,
+                len(batch),
+            )
+            failed_jobs.extend(batch)
+
+    # Fallback: score individually any jobs that failed in batch
+    if failed_jobs:
+        logger.info(
+            "Falling back to individual scoring for %d jobs",
+            len(failed_jobs),
+        )
+        for job in failed_jobs:
+            try:
+                response = await provider.score(
+                    job_description=job.get("description", ""),
+                    profile_data=profile_data,
+                )
+                if response.structured and isinstance(response.structured, ScoreResult):
+                    all_results[str(job["id"])] = response.structured
+                else:
+                    logger.warning(
+                        "Individual fallback for job %s did not return ScoreResult",
+                        job["id"],
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Individual fallback for job %s failed: %s",
+                    job["id"],
+                    exc,
+                )
+
+    return all_results

--- a/tests/test_batch_scoring.py
+++ b/tests/test_batch_scoring.py
@@ -1,0 +1,428 @@
+"""Tests for batch scoring — multi-job-per-prompt scoring service."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+from career_os.services.batch_scoring import (
+    DEFAULT_BATCH_SIZE,
+    _extract_json_array,
+    batch_score_jobs,
+    build_batch_prompt,
+    chunk_jobs,
+    get_batch_size,
+    parse_batch_response,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_PROFILE = {
+    "name": "Alice Engineer",
+    "location": "Berlin, Germany",
+    "job_family": "SWE",
+    "skills": [{"name": "Python", "level": 8}],
+    "goals": [],
+    "weights": {"skills_match": 0.3, "career_alignment": 0.2},
+}
+
+SAMPLE_JOBS = [
+    {
+        "id": "101",
+        "title": "Backend Engineer",
+        "company": "Acme Corp",
+        "description": "Build APIs with Python and FastAPI. 3+ years experience required.",
+    },
+    {
+        "id": "102",
+        "title": "Frontend Developer",
+        "company": "Widget Inc",
+        "description": "React and TypeScript SPA development. Remote friendly.",
+    },
+    {
+        "id": "103",
+        "title": "Data Engineer",
+        "company": "DataCo",
+        "description": "ETL pipelines with Spark and Airflow. SQL expertise needed.",
+    },
+]
+
+
+def _make_score_dict(job_id: str, fit_score: float = 7.5) -> dict:
+    """Build a valid ScoreResult dict with the given job_id."""
+    return {
+        "job_id": job_id,
+        "fit_score": fit_score,
+        "reasoning": "A" * 100,
+        "estimated_salary": "$120k-150k",
+        "effort_flag": "medium",
+        "prep_level": "moderate",
+        "prep_notes": "Brush up on system design",
+        "readiness_score": 75.0,
+        "career_alignment": 8.0,
+        "score_breakdown": [
+            {"factor": "skills", "contribution": 2.0, "description": "Strong Python"},
+            {"factor": "experience", "contribution": 1.5, "description": "3+ years"},
+            {"factor": "location", "contribution": -0.5, "description": "Remote ok"},
+        ],
+        "dimensional_scores": {
+            "technical_fit": 8.0,
+            "seniority_alignment": 7.0,
+            "compensation_fit": 7.5,
+            "location_fit": 9.0,
+            "career_trajectory": 7.0,
+            "company_fit": 6.5,
+        },
+        "ats_keywords": [
+            {"keyword": "Python", "category": "technical", "matched": True},
+            {"keyword": "FastAPI", "category": "tool", "matched": True},
+        ],
+        "desire_score": 7.0,
+        "desire_reasoning": "Good growth opportunity at a solid company",
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_batch_size
+# ---------------------------------------------------------------------------
+
+
+class TestGetBatchSize:
+    def test_default_when_env_not_set(self):
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove BATCH_SCORING_SIZE if present
+            import os
+
+            os.environ.pop("BATCH_SCORING_SIZE", None)
+            result = get_batch_size()
+            assert result == DEFAULT_BATCH_SIZE
+            assert result == 10
+
+    def test_reads_from_env(self):
+        with patch.dict("os.environ", {"BATCH_SCORING_SIZE": "25"}):
+            result = get_batch_size()
+            assert result == 25
+
+    def test_invalid_env_returns_default(self):
+        with patch.dict("os.environ", {"BATCH_SCORING_SIZE": "abc"}):
+            result = get_batch_size()
+            assert result == DEFAULT_BATCH_SIZE
+
+    def test_zero_env_returns_default(self):
+        with patch.dict("os.environ", {"BATCH_SCORING_SIZE": "0"}):
+            result = get_batch_size()
+            assert result == DEFAULT_BATCH_SIZE
+
+    def test_negative_env_returns_default(self):
+        with patch.dict("os.environ", {"BATCH_SCORING_SIZE": "-5"}):
+            result = get_batch_size()
+            assert result == DEFAULT_BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# build_batch_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBatchPrompt:
+    def test_prompt_contains_all_jobs(self):
+        prompt, ordered_ids = build_batch_prompt(SAMPLE_JOBS, SAMPLE_PROFILE)
+        assert "101" in prompt
+        assert "102" in prompt
+        assert "103" in prompt
+        assert len(ordered_ids) == 3
+        assert set(ordered_ids) == {"101", "102", "103"}
+
+    def test_prompt_contains_profile(self):
+        prompt, _ = build_batch_prompt(SAMPLE_JOBS, SAMPLE_PROFILE)
+        assert "Alice Engineer" in prompt
+        assert "Berlin" in prompt
+
+    def test_position_randomization(self):
+        """Run multiple times and verify order varies (statistical check)."""
+        orders_seen: set[tuple[str, ...]] = set()
+        for _ in range(50):
+            _, ordered_ids = build_batch_prompt(SAMPLE_JOBS, SAMPLE_PROFILE)
+            orders_seen.add(tuple(ordered_ids))
+        # With 3 jobs and 50 attempts, we should see more than 1 order
+        # (probability of all same is (1/6)^49 ≈ 0)
+        assert len(orders_seen) > 1
+        # All orders should contain the same IDs
+        for order in orders_seen:
+            assert set(order) == {"101", "102", "103"}
+
+    def test_prompt_contains_job_metadata(self):
+        prompt, _ = build_batch_prompt(SAMPLE_JOBS, SAMPLE_PROFILE)
+        assert "Backend Engineer" in prompt
+        assert "Acme Corp" in prompt
+        assert "Build APIs" in prompt
+
+    def test_prompt_requests_json_array(self):
+        prompt, _ = build_batch_prompt(SAMPLE_JOBS, SAMPLE_PROFILE)
+        assert "JSON ARRAY" in prompt
+        assert "job_id" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _extract_json_array
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonArray:
+    def test_plain_array(self):
+        text = '[{"a": 1}, {"a": 2}]'
+        result = _extract_json_array(text)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["a"] == 1
+
+    def test_markdown_fenced_array(self):
+        text = '```json\n[{"a": 1}]\n```'
+        result = _extract_json_array(text)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_array_with_surrounding_text(self):
+        text = 'Here are the results:\n[{"a": 1}]\nDone.'
+        result = _extract_json_array(text)
+        assert result is not None
+        assert result[0]["a"] == 1
+
+    def test_trailing_commas_handled(self):
+        text = '[{"a": 1,}, {"a": 2,},]'
+        result = _extract_json_array(text)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_no_array_returns_none(self):
+        text = "This is not JSON at all"
+        result = _extract_json_array(text)
+        assert result is None
+
+    def test_object_not_array_returns_none(self):
+        text = '{"a": 1}'
+        result = _extract_json_array(text)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# parse_batch_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseBatchResponse:
+    def test_parses_valid_response(self):
+        scores = [_make_score_dict("101", 7.5), _make_score_dict("102", 6.0)]
+        content = json.dumps(scores)
+        results = parse_batch_response(content, ["101", "102"])
+        assert "101" in results
+        assert "102" in results
+        assert results["101"].fit_score == 7.5
+        assert results["102"].fit_score == 6.0
+
+    def test_positional_fallback_when_no_job_ids(self):
+        """When response lacks job_id fields, uses positional mapping."""
+        scores = [_make_score_dict("ignored", 7.5), _make_score_dict("ignored", 6.0)]
+        # Remove job_id from each
+        for s in scores:
+            del s["job_id"]
+        content = json.dumps(scores)
+        results = parse_batch_response(content, ["101", "102"])
+        assert "101" in results
+        assert "102" in results
+        assert results["101"].fit_score == 7.5
+        assert results["102"].fit_score == 6.0
+
+    def test_invalid_json_returns_empty(self):
+        results = parse_batch_response("not json at all", ["101"])
+        assert results == {}
+
+    def test_partial_parse_skips_invalid(self):
+        """Valid scores are kept, invalid ones skipped."""
+        valid = _make_score_dict("101", 8.0)
+        invalid = {"job_id": "102", "fit_score": "not_a_number"}
+        content = json.dumps([valid, invalid])
+        results = parse_batch_response(content, ["101", "102"])
+        assert "101" in results
+        assert "102" not in results
+        assert results["101"].fit_score == 8.0
+
+
+# ---------------------------------------------------------------------------
+# chunk_jobs
+# ---------------------------------------------------------------------------
+
+
+class TestChunkJobs:
+    def test_even_split(self):
+        jobs = [{"id": str(i)} for i in range(10)]
+        chunks = chunk_jobs(jobs, 5)
+        assert len(chunks) == 2
+        assert len(chunks[0]) == 5
+        assert len(chunks[1]) == 5
+
+    def test_remainder_chunk(self):
+        jobs = [{"id": str(i)} for i in range(7)]
+        chunks = chunk_jobs(jobs, 3)
+        assert len(chunks) == 3
+        assert len(chunks[0]) == 3
+        assert len(chunks[1]) == 3
+        assert len(chunks[2]) == 1
+
+    def test_single_item(self):
+        jobs = [{"id": "1"}]
+        chunks = chunk_jobs(jobs, 10)
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 1
+
+    def test_empty_list(self):
+        chunks = chunk_jobs([], 10)
+        assert chunks == []
+
+
+# ---------------------------------------------------------------------------
+# batch_score_jobs (integration with mock provider)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchScoreJobs:
+    @pytest.mark.asyncio
+    async def test_successful_batch_scoring(self):
+        """Full batch scoring with a mocked provider returning valid array."""
+        scores = [_make_score_dict("101", 7.5), _make_score_dict("102", 6.0)]
+        mock_response = AIResponse(
+            content=json.dumps(scores),
+            provider="mock",
+            feature=AIFeature.score,
+            structured=None,
+            model="mock-v1",
+        )
+        provider = AsyncMock()
+        provider.complete = AsyncMock(return_value=mock_response)
+
+        results = await batch_score_jobs(provider, SAMPLE_JOBS[:2], SAMPLE_PROFILE, batch_size=10)
+
+        assert "101" in results
+        assert "102" in results
+        assert results["101"].fit_score == 7.5
+        assert results["102"].fit_score == 6.0
+        # Should have called complete once (all fit in one batch)
+        provider.complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_individual_on_parse_failure(self):
+        """When batch parsing fails, falls back to individual scoring."""
+        # Batch returns garbage
+        batch_response = AIResponse(
+            content="not valid json",
+            provider="mock",
+            feature=AIFeature.score,
+            structured=None,
+            model="mock-v1",
+        )
+        # Individual fallback returns valid score
+        individual_response = AIResponse(
+            content="{}",
+            provider="mock",
+            feature=AIFeature.score,
+            structured=ScoreResult.model_validate(_make_score_dict("101")),
+            model="mock-v1",
+        )
+        provider = AsyncMock()
+        provider.complete = AsyncMock(return_value=batch_response)
+        provider.score = AsyncMock(return_value=individual_response)
+
+        results = await batch_score_jobs(provider, [SAMPLE_JOBS[0]], SAMPLE_PROFILE, batch_size=10)
+
+        assert "101" in results
+        assert results["101"].fit_score == 7.5
+        # complete was called for batch, score for fallback
+        provider.complete.assert_called_once()
+        provider.score.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_batches(self):
+        """Jobs are split across multiple batches."""
+        batch1_scores = [_make_score_dict("101", 7.0)]
+        batch2_scores = [_make_score_dict("102", 8.0)]
+
+        responses = [
+            AIResponse(
+                content=json.dumps(batch1_scores),
+                provider="mock",
+                feature=AIFeature.score,
+                structured=None,
+                model="mock-v1",
+            ),
+            AIResponse(
+                content=json.dumps(batch2_scores),
+                provider="mock",
+                feature=AIFeature.score,
+                structured=None,
+                model="mock-v1",
+            ),
+        ]
+        provider = AsyncMock()
+        provider.complete = AsyncMock(side_effect=responses)
+
+        results = await batch_score_jobs(
+            provider,
+            SAMPLE_JOBS[:2],
+            SAMPLE_PROFILE,
+            batch_size=1,  # Force 1-per-batch
+        )
+
+        assert len(results) == 2
+        assert provider.complete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_jobs_returns_empty(self):
+        provider = AsyncMock()
+        results = await batch_score_jobs(provider, [], SAMPLE_PROFILE)
+        assert results == {}
+        provider.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batch_exception_triggers_fallback(self):
+        """If the batch call raises, jobs go to individual fallback."""
+        individual_response = AIResponse(
+            content="{}",
+            provider="mock",
+            feature=AIFeature.score,
+            structured=ScoreResult.model_validate(_make_score_dict("101")),
+            model="mock-v1",
+        )
+        provider = AsyncMock()
+        provider.complete = AsyncMock(side_effect=Exception("API error"))
+        provider.score = AsyncMock(return_value=individual_response)
+
+        results = await batch_score_jobs(provider, [SAMPLE_JOBS[0]], SAMPLE_PROFILE, batch_size=10)
+
+        assert "101" in results
+        assert results["101"].fit_score == 7.5
+        provider.score.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_configurable_batch_size_from_env(self):
+        """batch_size=None reads from environment."""
+        scores = [_make_score_dict("101")]
+        mock_response = AIResponse(
+            content=json.dumps(scores),
+            provider="mock",
+            feature=AIFeature.score,
+            structured=None,
+            model="mock-v1",
+        )
+        provider = AsyncMock()
+        provider.complete = AsyncMock(return_value=mock_response)
+
+        with patch.dict("os.environ", {"BATCH_SCORING_SIZE": "5"}):
+            results = await batch_score_jobs(provider, [SAMPLE_JOBS[0]], SAMPLE_PROFILE)
+
+        assert "101" in results
+        assert results["101"].fit_score == 7.5


### PR DESCRIPTION
## Summary
- batch_score_jobs() sends 10 jobs per prompt instead of individual calls
- Randomized job order within batches (position bias mitigation per arXiv:2604.03684)
- JSON array parsing with markdown fence handling and positional fallback
- Automatic fallback to individual scoring on parse failure
- Configurable batch size via BATCH_SCORING_SIZE env var (default: 10)
- Works with any provider via provider.complete() interface

## Test plan
- [x] 30 tests: prompt construction, JSON parsing, randomization, fallback, config
- [x] Ruff lint clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)