### PR TITLE
feat(G-442): cost presets system (Free/Budget/Quality/Private/Custom)

### DIFF
--- a/src/career_os/api/presets.py
+++ b/src/career_os/api/presets.py
@@ -1,0 +1,68 @@
+"""Cost preset API routes."""
+
+from fastapi import APIRouter, HTTPException
+
+from career_os.schemas.presets import (
+    ActivePresetResponse,
+    PresetListResponse,
+    PresetResponse,
+    SetActivePresetRequest,
+)
+from career_os.services.presets import (
+    apply_preset,
+    get_active_preset_name,
+    get_preset,
+    list_presets,
+)
+
+router = APIRouter(prefix="/api/presets", tags=["presets"])
+
+
+def _to_response(p) -> PresetResponse:
+    """Convert a CostPreset dataclass to a Pydantic response."""
+    return PresetResponse(
+        name=p.name,
+        display_name=p.display_name,
+        description=p.description,
+        estimated_cost=p.estimated_cost,
+        provider=p.provider,
+        model=p.model,
+        prefilter_strategy=p.prefilter_strategy,
+        batch_size=p.batch_size,
+    )
+
+
+@router.get("")
+async def list_all_presets() -> PresetListResponse:
+    """List all available cost presets with descriptions and estimated costs."""
+    presets = list_presets()
+    return PresetListResponse(
+        presets=[_to_response(p) for p in presets],
+        count=len(presets),
+    )
+
+
+@router.get("/active")
+async def get_active_preset() -> ActivePresetResponse:
+    """Get the currently active cost preset."""
+    name = get_active_preset_name()
+    preset = get_preset(name)
+    # Should never be None since get_active_preset_name validates,
+    # but guard defensively.
+    if preset is None:  # pragma: no cover
+        raise HTTPException(status_code=500, detail="Active preset not found in registry")
+    return ActivePresetResponse(active=name, preset=_to_response(preset))
+
+
+@router.put("/active")
+async def set_active_preset(payload: SetActivePresetRequest) -> ActivePresetResponse:
+    """Switch to a different cost preset.
+
+    Applies provider, model, and pre-filter settings immediately
+    for the running process.
+    """
+    try:
+        preset = apply_preset(payload.name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ActivePresetResponse(active=payload.name, preset=_to_response(preset))

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     # users with too many prompts.
     active_query_enabled: bool = False
 
+    # Cost preset (G-442) — one setting selects provider, model, pre-filter
+    # strategy, and batch size. Valid values: free, budget, quality, private, custom.
+    cost_preset: str = "budget"
+
     # Regex pre-filter (G-439) — lightweight keyword/title/industry filter
     # that runs BEFORE AI scoring to eliminate ~60% of irrelevant jobs.
     # Strategy: "strict" (title OR skills, NOT blacklisted industry),

--- a/src/career_os/main.py
+++ b/src/career_os/main.py
@@ -29,6 +29,7 @@ from career_os.api.market import router as market_router
 from career_os.api.oauth import limiter as oauth_limiter
 from career_os.api.oauth import router as oauth_router
 from career_os.api.onboarding import router as onboarding_router
+from career_os.api.presets import router as presets_router
 from career_os.api.privacy import router as privacy_router
 from career_os.api.profiles import router as profiles_router
 from career_os.api.pushover import router as pushover_router
@@ -208,6 +209,7 @@ app.include_router(learning_router)
 app.include_router(market_router)
 app.include_router(oauth_router)
 app.include_router(onboarding_router)
+app.include_router(presets_router)
 app.include_router(privacy_router)
 app.include_router(profiles_router)
 app.include_router(pushover_router)

--- a/src/career_os/schemas/presets.py
+++ b/src/career_os/schemas/presets.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for the Cost Presets API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PresetResponse(BaseModel):
+    """Single preset returned by the API."""
+
+    name: str
+    display_name: str
+    description: str
+    estimated_cost: str
+    provider: str
+    model: str
+    prefilter_strategy: str
+    batch_size: int
+
+
+class PresetListResponse(BaseModel):
+    """Response for GET /api/presets."""
+
+    presets: list[PresetResponse]
+    count: int
+
+
+class ActivePresetResponse(BaseModel):
+    """Response for GET /api/presets/active."""
+
+    active: str = Field(description="Name of the currently active preset")
+    preset: PresetResponse
+
+
+class SetActivePresetRequest(BaseModel):
+    """Request body for PUT /api/presets/active."""
+
+    name: str = Field(description="Preset name to activate")

--- a/src/career_os/services/presets.py
+++ b/src/career_os/services/presets.py
@@ -1,0 +1,163 @@
+"""Cost preset service — one setting controls provider, model, pre-filter, and batch size.
+
+Five tiers:
+  free    — OpenRouter free models or Groq/Cerebras, $0/mo
+  budget  — GPT-4o-mini via OpenRouter, ~$0.81/mo (DEFAULT)
+  quality — Sonnet scoring + Opus generation, $5-25/mo
+  private — ZDR providers (Together.ai) or Ollama, $0 + hardware
+  custom  — User configures everything manually
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from career_os.config import settings
+
+
+@dataclass(frozen=True)
+class CostPreset:
+    """Immutable definition of a cost preset."""
+
+    name: str
+    display_name: str
+    description: str
+    estimated_cost: str
+    provider: str
+    model: str
+    prefilter_strategy: str  # strict | moderate | off
+    batch_size: int
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+PRESETS: dict[str, CostPreset] = {
+    "free": CostPreset(
+        name="free",
+        display_name="Free",
+        description=(
+            "Zero-cost tier using OpenRouter free models or Groq/Cerebras. "
+            "Rate-limited; suitable for exploration and testing."
+        ),
+        estimated_cost="$0/mo",
+        provider="openrouter",
+        model="meta-llama/llama-3.3-70b-instruct:free",
+        prefilter_strategy="strict",
+        batch_size=5,
+    ),
+    "budget": CostPreset(
+        name="budget",
+        display_name="Budget",
+        description=(
+            "GPT-4o-mini via OpenRouter. Reliable JSON output, "
+            "low cost. Recommended default for active job searches."
+        ),
+        estimated_cost="~$0.81/mo",
+        provider="openrouter",
+        model="openai/gpt-4o-mini",
+        prefilter_strategy="strict",
+        batch_size=10,
+    ),
+    "quality": CostPreset(
+        name="quality",
+        display_name="Quality",
+        description=(
+            "Sonnet for scoring, Opus for generation. Best reasoning and nuance at higher cost."
+        ),
+        estimated_cost="$5-25/mo",
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+        prefilter_strategy="moderate",
+        batch_size=15,
+    ),
+    "private": CostPreset(
+        name="private",
+        display_name="Private",
+        description=(
+            "Zero data retention providers (Together.ai) or local Ollama. "
+            "Your data never leaves your control."
+        ),
+        estimated_cost="$0 + hardware",
+        provider="together",
+        model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        prefilter_strategy="strict",
+        batch_size=5,
+    ),
+    "custom": CostPreset(
+        name="custom",
+        display_name="Custom",
+        description="User-configured provider, model, and settings. Full control.",
+        estimated_cost="varies",
+        provider="",  # user sets via env/config
+        model="",
+        prefilter_strategy="",
+        batch_size=0,
+    ),
+}
+
+DEFAULT_PRESET = "budget"
+
+# Module-level active preset name — persists for the process lifetime.
+_active_preset: str = ""
+
+
+def _resolve_initial_preset() -> str:
+    """Return the preset name from settings, falling back to DEFAULT_PRESET."""
+    raw = getattr(settings, "cost_preset", DEFAULT_PRESET)
+    return raw if raw in PRESETS else DEFAULT_PRESET
+
+
+def get_active_preset_name() -> str:
+    """Return the currently active preset name."""
+    global _active_preset  # noqa: PLW0603
+    if not _active_preset:
+        _active_preset = _resolve_initial_preset()
+    return _active_preset
+
+
+def get_preset(name: str) -> CostPreset | None:
+    """Look up a preset by name.  Returns None if unknown."""
+    return PRESETS.get(name)
+
+
+def list_presets() -> list[CostPreset]:
+    """Return all available presets in display order."""
+    return list(PRESETS.values())
+
+
+def apply_preset(name: str) -> CostPreset:
+    """Activate a preset, updating runtime settings.
+
+    For the 'custom' preset no settings are changed — the user is expected
+    to configure provider/model via environment variables or the API.
+
+    Raises ValueError if *name* is not a recognised preset.
+    """
+    preset = PRESETS.get(name)
+    if preset is None:
+        raise ValueError(f"Unknown preset '{name}'. Valid presets: {', '.join(PRESETS)}")
+
+    global _active_preset  # noqa: PLW0603
+    _active_preset = name
+
+    # Custom preset: user manages settings themselves.
+    if name == "custom":
+        return preset
+
+    # Apply non-custom preset values to the runtime settings object.
+    # These are in-process overrides; they do NOT write to .env.
+    settings.ai_provider = preset.provider
+    settings.prefilter_strategy = preset.prefilter_strategy
+
+    # Model field depends on provider
+    _MODEL_FIELD_MAP: dict[str, str] = {
+        "openrouter": "openrouter_model",
+        "anthropic": "anthropic_model",
+        "together": "together_model",
+        "ollama": "ollama_model",
+    }
+    model_attr = _MODEL_FIELD_MAP.get(preset.provider)
+    if model_attr:
+        setattr(settings, model_attr, preset.model)
+
+    return preset

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,176 @@
+"""Tests for the cost presets system (G-442)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from career_os.main import app
+from career_os.services.presets import (
+    DEFAULT_PRESET,
+    PRESETS,
+    CostPreset,
+    apply_preset,
+    get_active_preset_name,
+    get_preset,
+    list_presets,
+)
+
+# ---------------------------------------------------------------------------
+# Service layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestListPresets:
+    """list_presets() returns all defined presets."""
+
+    def test_returns_all_five_presets(self):
+        result = list_presets()
+        assert len(result) == 5
+        assert all(isinstance(p, CostPreset) for p in result)
+
+    def test_preset_names_match_keys(self):
+        result = list_presets()
+        names = {p.name for p in result}
+        assert names == {"free", "budget", "quality", "private", "custom"}
+
+
+class TestGetPreset:
+    """get_preset() looks up a single preset by name."""
+
+    def test_known_preset_returns_dataclass(self):
+        preset = get_preset("budget")
+        assert preset is not None
+        assert preset.name == "budget"
+        assert preset.provider == "openrouter"
+
+    def test_unknown_preset_returns_none(self):
+        result = get_preset("nonexistent")
+        assert result is None
+
+
+class TestApplyPreset:
+    """apply_preset() activates a preset and mutates runtime settings."""
+
+    def test_apply_budget_sets_provider_and_model(self):
+        preset = apply_preset("budget")
+        assert preset.name == "budget"
+        assert preset.provider == "openrouter"
+        assert preset.model == "openai/gpt-4o-mini"
+
+    def test_apply_quality_sets_moderate_prefilter(self):
+        preset = apply_preset("quality")
+        assert preset.prefilter_strategy == "moderate"
+        assert preset.batch_size == 15
+
+    def test_apply_free_sets_strict_prefilter(self):
+        preset = apply_preset("free")
+        assert preset.prefilter_strategy == "strict"
+        assert preset.batch_size == 5
+
+    def test_apply_private_uses_together(self):
+        preset = apply_preset("private")
+        assert preset.provider == "together"
+        assert "Llama" in preset.model
+
+    def test_apply_custom_does_not_crash(self):
+        preset = apply_preset("custom")
+        assert preset.name == "custom"
+        assert preset.estimated_cost == "varies"
+
+    def test_apply_unknown_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown preset 'bogus'"):
+            apply_preset("bogus")
+
+    def test_apply_changes_active_preset_name(self):
+        apply_preset("quality")
+        assert get_active_preset_name() == "quality"
+        # Reset to default for other tests
+        apply_preset(DEFAULT_PRESET)
+
+
+class TestGetActivePresetName:
+    """get_active_preset_name() resolves from settings or returns default."""
+
+    def test_returns_string(self):
+        name = get_active_preset_name()
+        assert isinstance(name, str)
+        assert name in PRESETS
+
+
+class TestPresetDataIntegrity:
+    """Every preset has required fields populated (except custom)."""
+
+    @pytest.mark.parametrize("name", ["free", "budget", "quality", "private"])
+    def test_non_custom_presets_have_provider_and_model(self, name: str):
+        preset = PRESETS[name]
+        assert preset.provider != ""
+        assert preset.model != ""
+
+    def test_custom_preset_has_empty_provider(self):
+        preset = PRESETS["custom"]
+        assert preset.provider == ""
+        assert preset.model == ""
+
+    def test_all_presets_have_description_and_cost(self):
+        for name, preset in PRESETS.items():
+            assert preset.description, f"{name} missing description"
+            assert preset.estimated_cost, f"{name} missing estimated_cost"
+
+
+# ---------------------------------------------------------------------------
+# API route tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api_client() -> TestClient:
+    return TestClient(app)
+
+
+class TestPresetsAPI:
+    """HTTP tests for /api/presets endpoints."""
+
+    def test_list_presets_returns_200(self, api_client: TestClient):
+        resp = api_client.get("/api/presets")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 5
+        assert len(body["presets"]) == 5
+
+    def test_list_presets_contains_budget(self, api_client: TestClient):
+        resp = api_client.get("/api/presets")
+        names = [p["name"] for p in resp.json()["presets"]]
+        assert "budget" in names
+        assert "free" in names
+
+    def test_get_active_preset_returns_200(self, api_client: TestClient):
+        resp = api_client.get("/api/presets/active")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "active" in body
+        assert "preset" in body
+        assert body["preset"]["name"] == body["active"]
+
+    def test_set_active_preset_budget(self, api_client: TestClient):
+        resp = api_client.put("/api/presets/active", json={"name": "budget"})
+        assert resp.status_code == 200
+        assert resp.json()["active"] == "budget"
+        assert resp.json()["preset"]["provider"] == "openrouter"
+
+    def test_set_active_preset_quality(self, api_client: TestClient):
+        resp = api_client.put("/api/presets/active", json={"name": "quality"})
+        assert resp.status_code == 200
+        assert resp.json()["active"] == "quality"
+        assert resp.json()["preset"]["prefilter_strategy"] == "moderate"
+        # Reset
+        api_client.put("/api/presets/active", json={"name": "budget"})
+
+    def test_set_unknown_preset_returns_400(self, api_client: TestClient):
+        resp = api_client.put("/api/presets/active", json={"name": "nonexistent"})
+        assert resp.status_code == 400
+        assert "Unknown preset" in resp.json()["detail"]
+
+    def test_set_preset_missing_name_returns_422(self, api_client: TestClient):
+        resp = api_client.put("/api/presets/active", json={})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- 5 presets: Free ($0), Budget ($0.81/mo, DEFAULT), Quality ($5-25), Private ($0+hw), Custom
- Each preset maps to: provider, model, prefilter_strategy, batch_size
- API: GET /api/presets, GET /api/presets/active, PUT /api/presets/active
- apply_preset() mutates runtime settings for seamless switching
- COST_PRESET env var (default: "budget")

## Test plan
- [x] 25 tests: service layer + API routes + error cases
- [x] Ruff lint clean, all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)