### PR TITLE
feat(G-447): add xAI/Grok provider with privacy warning

### DIFF
--- a/src/career_os/ai/__init__.py
+++ b/src/career_os/ai/__init__.py
@@ -10,6 +10,7 @@ from career_os.ai.ollama_provider import OllamaConnectionError, OllamaProvider
 from career_os.ai.openrouter_provider import CreditsExhaustedError, OpenRouterProvider
 from career_os.ai.pii_masking import MaskedProvider, MaskMapping, PIIMasker
 from career_os.ai.together_provider import TogetherProvider
+from career_os.ai.xai_provider import XAIProvider
 
 __all__ = [
     "AIProvider",
@@ -28,5 +29,6 @@ __all__ = [
     "ProviderQuotaError",
     "TogetherProvider",
     "UnsupportedProviderError",
+    "XAIProvider",
     "get_ai_provider",
 ]

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -13,6 +13,7 @@ from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaProvider
 from career_os.ai.openrouter_provider import OpenRouterProvider
 from career_os.ai.together_provider import TogetherProvider
+from career_os.ai.xai_provider import XAIProvider
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,10 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
     "groq": lambda: GroqProvider(
         api_key=_resolve_api_key("GROQ_API_KEY", "groq_api_key"),
         model=os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile"),
+    ),
+    "xai": lambda: XAIProvider(
+        api_key=_resolve_api_key("XAI_API_KEY", "xai_api_key"),
+        model=os.getenv("XAI_MODEL", "grok-3-mini"),
     ),
 }
 

--- a/src/career_os/ai/privacy.py
+++ b/src/career_os/ai/privacy.py
@@ -117,6 +117,23 @@ _HARDCODED_REGISTRY: dict[str, ProviderPrivacyInfo] = {
         recommendation="Fast inference, no data retention",
         last_verified="2026-04-13",
     ),
+    "xai": ProviderPrivacyInfo(
+        provider="xai",
+        tier=PrivacyTier.red,
+        trains_on_data=True,
+        human_review=True,
+        retention=DataRetention(days=None, description="Irrevocable data sharing — indefinite"),
+        dpa_available=False,
+        gdpr_compliant=False,
+        eu_banned=False,
+        warnings=[
+            "Irrevocable data sharing program — prompts may be used for training",
+            "Multiple active GDPR investigations by EU data protection authorities",
+            "No opt-out mechanism for data sharing once submitted",
+        ],
+        recommendation="Avoid for sensitive or personal data. Red privacy tier.",
+        last_verified="2026-04-21",
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/ai/xai_provider.py
+++ b/src/career_os/ai/xai_provider.py
@@ -1,0 +1,182 @@
+"""xAI/Grok AI provider.
+
+Connects to the xAI API (https://api.x.ai) via an OpenAI-compatible
+chat completions endpoint.
+
+Requires XAI_API_KEY in environment.
+
+**Privacy warning:** xAI operates an irrevocable data sharing program and
+faces multiple active GDPR investigations.  Privacy tier is **red**.
+See docs/research/provider-privacy-audit.md for details.
+"""
+
+import json
+import logging
+
+import httpx
+
+from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.openrouter_provider import (
+    _SCHEMA_MAP,
+    _system_prompt_for_feature,
+    _try_parse_structured,
+)
+from career_os.schemas.ai import AIFeature, AIResponse
+
+logger = logging.getLogger(__name__)
+
+XAI_API_URL = "https://api.x.ai/v1/chat/completions"
+DEFAULT_MODEL = "grok-3-mini"
+
+
+class XAIProvider(AIProvider):
+    """AI provider backed by the xAI/Grok API (OpenAI-compatible).
+
+    **Privacy tier: red** — xAI has an irrevocable data sharing program
+    and multiple active GDPR investigations.  Use only when the user has
+    explicitly acknowledged the privacy implications.
+    """
+
+    def __init__(self, api_key: str, model: str = DEFAULT_MODEL) -> None:
+        """Initialize with API key and optional model override.
+
+        Args:
+            api_key: xAI API key.
+            model: Model identifier (default: grok-3-mini).
+        """
+        if not api_key:
+            raise ValueError("XAI_API_KEY is required for XAIProvider")
+        self._api_key = api_key
+        self._model = model
+        logger.warning(
+            "xAI/Grok: irrevocable data sharing program. "
+            "See docs/research/provider-privacy-audit.md"
+        )
+
+    @property
+    def name(self) -> str:
+        return "xai"
+
+    @property
+    def privacy_tier(self) -> str:
+        """xAI has an irrevocable data sharing program — red tier."""
+        return "red"
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        feature: AIFeature = AIFeature.complete,
+        context: dict | None = None,
+        max_retries: int = 1,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Send a completion request to the xAI API."""
+        expects_structured = feature in _SCHEMA_MAP
+
+        for attempt in range(1, max_retries + 2):
+            user_content = prompt
+            if attempt > 1:
+                user_content += (
+                    "\n\nIMPORTANT: Return ONLY valid JSON"
+                    " with no surrounding text or markdown fences."
+                )
+
+            messages: list[dict[str, str]] = [
+                {"role": "user", "content": user_content},
+            ]
+
+            system_msg = _system_prompt_for_feature(feature)
+            if system_msg:
+                messages.insert(0, {"role": "system", "content": system_msg})
+
+            payload = {
+                "model": self._model,
+                "messages": messages,
+            }
+
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    XAI_API_URL,
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                if response.status_code in (402, 429):
+                    detail = _extract_error_detail(response)
+                    raise ProviderQuotaError("xai", response.status_code, detail)
+                response.raise_for_status()
+                data = response.json()
+
+            content = data["choices"][0]["message"]["content"]
+            model_used = data.get("model", self._model)
+
+            structured = _try_parse_structured(content, feature)
+
+            if structured is not None or not expects_structured:
+                return AIResponse(
+                    content=content,
+                    provider="xai",
+                    feature=feature,
+                    structured=structured,
+                    model=model_used,
+                )
+
+            if attempt <= max_retries:
+                logger.warning(
+                    "Structured parse failed for %s, retrying (attempt %d/%d)",
+                    feature,
+                    attempt,
+                    max_retries + 1,
+                )
+
+        # Exhausted retries — return last response without structured data
+        return AIResponse(
+            content=content,
+            provider="xai",
+            feature=feature,
+            structured=None,
+            model=model_used,
+        )
+
+    async def score(
+        self,
+        job_description: str,
+        profile_data: dict,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Score a job against a profile via the xAI API."""
+        prompt = (
+            f"Score this job against the candidate profile. "
+            f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
+            f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
+            f"readiness_score (0-100), career_alignment (0-10), "
+            f"score_breakdown (array of >=3 objects, each with: factor (string), "
+            f"contribution (positive or negative float), description (string)), "
+            f"dimensional_scores (object with 6 floats 0-10: technical_fit, "
+            f"seniority_alignment, compensation_fit, location_fit, career_trajectory, "
+            f"company_fit), "
+            f"ats_keywords (array of 10-15 objects, each with: keyword (string), "
+            f"category (one of technical/soft_skill/tool/certification/domain), "
+            f"matched (boolean -- true if the profile demonstrates this keyword)), "
+            f"desire_score (0-10, how much the candidate would WANT this job -- "
+            f"considering company reputation, growth potential, culture signals, "
+            f"role excitement, compensation attractiveness, work-life balance), "
+            f"desire_reasoning (string explaining what makes this job desirable "
+            f"or undesirable from the candidate's perspective).\n\n"
+            f"Job Description:\n{job_description}\n\n"
+            f"Profile:\n{json.dumps(profile_data, indent=2)}"
+        )
+        return await self.complete(prompt, feature=AIFeature.score)
+
+
+def _extract_error_detail(response: httpx.Response) -> str:
+    """Best-effort extraction of error message from an xAI error response."""
+    try:
+        body = response.json()
+        error = body.get("error", {})
+        return error.get("message", "") if isinstance(error, dict) else str(error)
+    except Exception:
+        return ""

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -1,0 +1,426 @@
+"""Tests for XAIProvider — xAI/Grok OpenAI-compatible API.
+
+Covers:
+- Provider contract (AIProvider subclass, name, privacy tier, init validation)
+- Privacy warning logged on init
+- Factory registration and resolution
+- OpenAI-compatible request format (Bearer auth, messages array)
+- HTTP 402/429 → ProviderQuotaError
+- Response parsing (choices[0].message.content)
+- System prompt inclusion for structured features
+- score() delegation to complete()
+"""
+
+import json
+import logging
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.factory import _PROVIDER_REGISTRY, get_ai_provider
+from career_os.ai.xai_provider import (
+    XAI_API_URL,
+    XAIProvider,
+)
+from career_os.schemas.ai import AIFeature, AIResponse
+
+# Fake credentials used across all tests — not real.
+_TEST_CREDENTIAL = "test-fake-xai-key"  # noqa: S105
+_TEST_CREDENTIAL_2 = "test-fake-xai-key-2"  # noqa: S105
+
+
+# ---------------------------------------------------------------------------
+# XAIProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIProviderInit:
+    """Test XAIProvider initialization and contract."""
+
+    def test_name(self) -> None:
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider.name == "xai"
+
+    def test_is_ai_provider(self) -> None:
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        assert isinstance(provider, AIProvider)
+
+    def test_privacy_tier_is_red(self) -> None:
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider.privacy_tier == "red"
+
+    def test_empty_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="XAI_API_KEY"):
+            XAIProvider(api_key="")
+
+    def test_default_model(self) -> None:
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        assert provider._model == "grok-3-mini"
+
+    def test_custom_model(self) -> None:
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL, model="grok-3")
+        assert provider._model == "grok-3"
+
+
+# ---------------------------------------------------------------------------
+# Privacy warning test
+# ---------------------------------------------------------------------------
+
+
+class TestXAIPrivacyWarning:
+    """Test that XAIProvider logs a privacy warning on initialization."""
+
+    def test_init_logs_privacy_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """XAIProvider.__init__ emits a WARNING about irrevocable data sharing."""
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.xai_provider"):
+            XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_messages) >= 1
+        assert "irrevocable data sharing" in warning_messages[0]
+        assert "provider-privacy-audit.md" in warning_messages[0]
+
+    def test_privacy_warning_on_every_init(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Each instantiation emits the warning (not cached/suppressed)."""
+        with caplog.at_level(logging.WARNING, logger="career_os.ai.xai_provider"):
+            XAIProvider(api_key=_TEST_CREDENTIAL)
+            XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        warning_count = sum(
+            1 for r in caplog.records if r.levelno >= logging.WARNING and "irrevocable" in r.message
+        )
+        assert warning_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Factory registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIFactoryRegistration:
+    """Test xAI provider is registered in the factory."""
+
+    def test_xai_in_registry(self) -> None:
+        """'xai' key exists in _PROVIDER_REGISTRY."""
+        assert "xai" in _PROVIDER_REGISTRY
+
+    def test_registry_entry_callable(self) -> None:
+        """Registry entry for xai is callable."""
+        assert callable(_PROVIDER_REGISTRY["xai"])
+
+    def test_factory_creates_xai_provider(self) -> None:
+        """get_ai_provider('xai') returns XAIProvider."""
+        with patch.dict(os.environ, {"XAI_API_KEY": _TEST_CREDENTIAL}):
+            provider = get_ai_provider("xai")
+            assert isinstance(provider, XAIProvider)
+            assert provider.name == "xai"
+
+    def test_factory_without_key_raises(self) -> None:
+        """get_ai_provider('xai') without API key raises ValueError."""
+        with patch.dict(os.environ, {"XAI_API_KEY": ""}, clear=False):
+            with pytest.raises(ValueError, match="XAI_API_KEY"):
+                get_ai_provider("xai")
+
+    def test_xai_in_unsupported_error_message(self) -> None:
+        """UnsupportedProviderError lists xai as a supported provider."""
+        from career_os.ai.factory import UnsupportedProviderError
+
+        with pytest.raises(UnsupportedProviderError) as exc_info:
+            get_ai_provider("nonexistent")
+        assert "xai" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# API request format tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIRequestFormat:
+    """Test the xAI API request format (OpenAI-compatible)."""
+
+    @pytest.mark.asyncio
+    async def test_headers_include_bearer_auth(self) -> None:
+        """Request headers include Authorization: Bearer."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL_2)
+        captured_headers = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_headers.update(headers or {})
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test")
+
+        assert captured_headers["Authorization"] == f"Bearer {_TEST_CREDENTIAL_2}"
+        assert captured_headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_request_sent_to_xai_url(self) -> None:
+        """Request is sent to the xAI API URL."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_url = None
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            nonlocal captured_url
+            captured_url = url
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test")
+
+        assert captured_url == XAI_API_URL
+
+    @pytest.mark.asyncio
+    async def test_payload_uses_openai_chat_format(self) -> None:
+        """Payload uses OpenAI chat completions format."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "result"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("hello world")
+
+        assert captured_payload["model"] == "grok-3-mini"
+        assert captured_payload["messages"] == [{"role": "user", "content": "hello world"}]
+
+    @pytest.mark.asyncio
+    async def test_system_message_for_structured_feature(self) -> None:
+        """Structured features include a system message."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "{}"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("test", feature=AIFeature.score)
+
+        messages = captured_payload["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_no_system_message_for_generic_complete(self) -> None:
+        """Generic complete (no feature) does not include system message."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            await provider.complete("hello", feature=AIFeature.complete)
+
+        messages = captured_payload["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIResponseParsing:
+    """Test response parsing from OpenAI-format responses."""
+
+    @pytest.mark.asyncio
+    async def test_parses_content_from_choices(self) -> None:
+        """Response correctly parses content from choices[0].message.content."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "Hello world"}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("greet me")
+
+        assert isinstance(result, AIResponse)
+        assert result.content == "Hello world"
+        assert result.provider == "xai"
+        assert result.model == "grok-3-mini"
+
+    @pytest.mark.asyncio
+    async def test_uses_model_from_response(self) -> None:
+        """Model field uses the model returned in the API response."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}}],
+                    "model": "grok-3-mini-20260401",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.complete("test")
+
+        assert result.model == "grok-3-mini-20260401"
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIErrorHandling:
+    """Test HTTP error handling (402, 429, 500)."""
+
+    @pytest.mark.asyncio
+    async def test_402_raises_provider_quota_error(self) -> None:
+        """HTTP 402 raises ProviderQuotaError."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                402,
+                json={"error": {"message": "Insufficient credits"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError) as exc_info:
+                await provider.complete("test")
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.provider == "xai"
+
+    @pytest.mark.asyncio
+    async def test_429_raises_provider_quota_error(self) -> None:
+        """HTTP 429 raises ProviderQuotaError."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                429,
+                json={"error": {"message": "Rate limited"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError) as exc_info:
+                await provider.complete("test")
+            assert exc_info.value.status_code == 429
+            assert exc_info.value.provider == "xai"
+
+    @pytest.mark.asyncio
+    async def test_500_raises_http_error(self) -> None:
+        """HTTP 500 raises httpx.HTTPStatusError (not ProviderQuotaError)."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            return httpx.Response(
+                500,
+                json={"error": {"message": "Internal error"}},
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(httpx.HTTPStatusError):
+                await provider.complete("test")
+
+
+# ---------------------------------------------------------------------------
+# Score method tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIScore:
+    """Test the score() method delegates to complete() correctly."""
+
+    @pytest.mark.asyncio
+    async def test_score_calls_complete_with_score_feature(self) -> None:
+        """score() calls complete() with AIFeature.score."""
+        provider = XAIProvider(api_key=_TEST_CREDENTIAL)
+        captured_payload = {}
+
+        score_json = json.dumps(
+            {
+                "fit_score": 7.5,
+                "reasoning": "x" * 100,
+                "estimated_salary": "120k EUR",
+                "effort_flag": "medium",
+                "prep_level": "moderate",
+                "prep_notes": "Study X.",
+                "readiness_score": 72.0,
+                "career_alignment": 8.0,
+                "score_breakdown": [
+                    {"factor": "Technical", "contribution": 2.0, "description": "Strong match"},
+                    {"factor": "Culture", "contribution": 1.5, "description": "Good alignment"},
+                    {"factor": "Location", "contribution": -0.5, "description": "Remote pref"},
+                ],
+            }
+        )
+
+        async def mock_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": score_json}}],
+                    "model": "grok-3-mini",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            result = await provider.score("Software Engineer at Acme", {"name": "Jane"})
+
+        assert result.feature == AIFeature.score
+        assert result.provider == "xai"
+        # System message should be present (score feature has system prompt)
+        messages = captured_payload["messages"]
+        assert messages[0]["role"] == "system"


### PR DESCRIPTION
## Summary
- XAIProvider with OpenAI-compatible API at api.x.ai/v1
- Privacy tier: RED — irrevocable data sharing, active GDPR investigations
- Warning logged on init, privacy registry entry added
- Rebased on main after G-445 merge (conflict in factory.py resolved)

## Test plan
- [x] 24 tests, Ruff clean, hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)