### PR TITLE
feat(G-443): Batch API integration (Anthropic + OpenAI)

### DIFF
--- a/src/career_os/ai/openai_provider.py
+++ b/src/career_os/ai/openai_provider.py
@@ -6,6 +6,7 @@ chat completions endpoint.
 Requires OPENAI_API_KEY in environment.
 """
 
+import io
 import json
 import logging
 
@@ -27,6 +28,8 @@ logger = logging.getLogger(__name__)
 _COMPACT = (",", ":")
 
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_BATCH_API_URL = "https://api.openai.com/v1/batches"
+OPENAI_FILES_API_URL = "https://api.openai.com/v1/files"
 DEFAULT_MODEL = "gpt-4o-mini"
 
 
@@ -151,6 +154,200 @@ class OpenAIProvider(AIProvider):
             job_description, json.dumps(profile_data, separators=_COMPACT)
         )
         return await self.complete(prompt, feature=AIFeature.score)
+
+    async def batch_score(
+        self,
+        jobs: list[dict],
+        profile_data: dict,
+        **kwargs: object,
+    ) -> str:
+        """Submit a batch of jobs for scoring via OpenAI Batch API.
+
+        Builds a JSONL file of chat completion requests (one per job),
+        uploads it via the Files API, then creates a batch. Each request
+        uses the same system prompt and scoring format as real-time
+        ``score()``.
+
+        Args:
+            jobs: List of dicts, each with at least 'id' and 'description' keys.
+            profile_data: User profile data dict.
+
+        Returns:
+            Batch ID string for polling results.
+        """
+        system_msg = _system_prompt_for_feature(AIFeature.score) or ""
+        profile_json = json.dumps(profile_data, separators=_COMPACT)
+
+        # Build JSONL content — one line per job
+        lines: list[str] = []
+        for job in jobs:
+            scoring_prompt = (
+                "Score this job against the candidate profile. "
+                "Return a JSON object with: fit_score (0-10), reasoning "
+                "(detailed, >=100 chars), "
+                "estimated_salary (string), effort_flag (low/medium/high), "
+                "prep_level, prep_notes, "
+                "readiness_score (0-100), career_alignment (0-10), "
+                "score_breakdown (array of >=3 objects, each with: factor "
+                "(string), contribution (positive or negative float), "
+                "description (string)), "
+                "dimensional_scores (object with 6 floats 0-10: technical_fit, "
+                "seniority_alignment, compensation_fit, location_fit, "
+                "career_trajectory, company_fit), "
+                "ats_keywords (array of 10-15 objects, each with: keyword "
+                "(string), category (one of technical/soft_skill/tool/"
+                "certification/domain), matched (boolean)), "
+                "desire_score (0-10), desire_reasoning (string).\n\n"
+                f"Candidate Profile:\n{profile_json}\n\n"
+                f"Job Description:\n{job['description']}"
+            )
+
+            messages: list[dict[str, str]] = []
+            if system_msg:
+                messages.append({"role": "system", "content": system_msg})
+            messages.append({"role": "user", "content": scoring_prompt})
+
+            request_obj = {
+                "custom_id": str(job["id"]),
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": self._model,
+                    "messages": messages,
+                },
+            }
+            lines.append(json.dumps(request_obj, separators=_COMPACT))
+
+        jsonl_content = "\n".join(lines)
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+        }
+
+        # 1. Upload JSONL file
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            file_resp = await client.post(
+                OPENAI_FILES_API_URL,
+                headers=headers,
+                data={"purpose": "batch"},
+                files={"file": ("batch_scoring.jsonl", io.BytesIO(jsonl_content.encode()))},
+            )
+            if file_resp.status_code in (402, 429):
+                detail = _extract_error_detail(file_resp)
+                raise ProviderQuotaError("openai", file_resp.status_code, detail)
+            file_resp.raise_for_status()
+            file_id = file_resp.json()["id"]
+
+        # 2. Create batch
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            batch_resp = await client.post(
+                OPENAI_BATCH_API_URL,
+                headers={**headers, "Content-Type": "application/json"},
+                json={
+                    "input_file_id": file_id,
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h",
+                },
+            )
+            if batch_resp.status_code in (402, 429):
+                detail = _extract_error_detail(batch_resp)
+                raise ProviderQuotaError("openai", batch_resp.status_code, detail)
+            batch_resp.raise_for_status()
+            batch_data = batch_resp.json()
+
+        batch_id = batch_data["id"]
+        logger.info("OpenAI batch %s submitted with %d requests", batch_id, len(jobs))
+        return batch_id
+
+    async def get_batch_results(self, batch_id: str) -> dict:
+        """Poll batch status and retrieve results when complete.
+
+        GETs the batch status from the OpenAI API. When the batch has
+        completed, fetches the output file and parses each JSONL line
+        into an :class:`AIResponse`.
+
+        Returns:
+            Dict with 'status' key and 'results' dict (keyed by custom_id)
+            when status is 'ended'.
+        """
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.get(
+                f"{OPENAI_BATCH_API_URL}/{batch_id}",
+                headers=headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        # Map OpenAI statuses to our convention
+        openai_status = data.get("status", "unknown")
+        status_map = {
+            "completed": "ended",
+            "in_progress": "in_progress",
+            "validating": "in_progress",
+            "finalizing": "in_progress",
+            "cancelling": "canceling",
+            "cancelled": "canceled",
+            "expired": "expired",
+            "failed": "failed",
+        }
+        status = status_map.get(openai_status, "unknown")
+
+        if status != "ended":
+            return {"status": status, "results": {}}
+
+        output_file_id = data.get("output_file_id")
+        if not output_file_id:
+            return {"status": status, "results": {}}
+
+        # Fetch JSONL output file content
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            file_resp = await client.get(
+                f"{OPENAI_FILES_API_URL}/{output_file_id}/content",
+                headers=headers,
+            )
+            file_resp.raise_for_status()
+
+        parsed_results: dict[str, AIResponse] = {}
+        for line in file_resp.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            custom_id = entry.get("custom_id", "")
+            response_body = entry.get("response", {}).get("body", {})
+
+            if entry.get("error"):
+                logger.warning(
+                    "OpenAI batch result for %s had error: %s",
+                    custom_id,
+                    entry["error"],
+                )
+                continue
+
+            choices = response_body.get("choices", [])
+            if not choices:
+                logger.warning("OpenAI batch result for %s had no choices", custom_id)
+                continue
+
+            content = choices[0].get("message", {}).get("content", "")
+            model_used = response_body.get("model", self._model)
+            structured = _try_parse_structured(content, AIFeature.score)
+
+            parsed_results[custom_id] = AIResponse(
+                content=content,
+                provider="openai",
+                feature=AIFeature.score,
+                structured=structured,
+                model=model_used,
+            )
+
+        logger.info(
+            "OpenAI batch %s completed: %d results parsed",
+            batch_id,
+            len(parsed_results),
+        )
+        return {"status": status, "results": parsed_results}
 
 
 def _extract_error_detail(response: httpx.Response) -> str:

--- a/src/career_os/api/batch.py
+++ b/src/career_os/api/batch.py
@@ -1,0 +1,220 @@
+"""Async batch scoring API routes.
+
+Exposes endpoints for submitting async batch scoring jobs, checking their
+status, and retrieving results. Uses provider Batch APIs (Anthropic Message
+Batches, OpenAI Batch) for 50% cost savings on non-urgent scoring.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from career_os.ai.factory import get_ai_provider
+from career_os.database import get_db
+from career_os.services.async_batch import (
+    BatchNotReadyError,
+    BatchResultError,
+    BatchSubmissionError,
+    check_batch_status,
+    retrieve_batch_results,
+    submit_batch,
+)
+from career_os.services.scoring import (
+    ProfileIncompleteError,
+    ProfileNotFoundError,
+    build_profile_data,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["batch-scoring"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class BatchJobItem(BaseModel):
+    """A single job to include in the batch."""
+
+    id: str = Field(..., description="Unique job identifier")
+    description: str = Field(..., min_length=1, description="Job posting text")
+
+
+class BatchSubmitRequest(BaseModel):
+    """Request body for POST /api/score/batch/submit."""
+
+    profile_id: int = Field(..., description="Profile ID to score against")
+    jobs: list[BatchJobItem] = Field(
+        ..., min_length=1, max_length=10000, description="Jobs to score"
+    )
+    provider: str | None = Field(
+        default=None,
+        description="AI provider override (default: configured AI_PROVIDER)",
+    )
+
+
+class BatchSubmitResponse(BaseModel):
+    """Response from POST /api/score/batch/submit."""
+
+    batch_id: str = Field(..., description="Batch ID for polling status/results")
+    provider: str = Field(..., description="Provider that accepted the batch")
+    job_count: int = Field(..., description="Number of jobs submitted")
+
+
+class BatchStatusResponse(BaseModel):
+    """Response from GET /api/score/batch/{batch_id}/status."""
+
+    batch_id: str
+    status: str
+    provider: str
+
+
+class BatchResultItem(BaseModel):
+    """A single result from a completed batch."""
+
+    job_id: str
+    score_result: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class BatchResultsResponse(BaseModel):
+    """Response from GET /api/score/batch/{batch_id}/results."""
+
+    batch_id: str
+    results: list[BatchResultItem]
+    total: int
+    successful: int
+    failed: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/score/batch/submit",
+    status_code=202,
+    responses={
+        400: {"description": "Bad request (empty batch, invalid jobs)"},
+        404: {"description": "Profile not found"},
+        422: {"description": "Profile incomplete for scoring"},
+        502: {"description": "Provider batch submission failed"},
+    },
+)
+async def batch_submit_endpoint(
+    payload: BatchSubmitRequest,
+    db: Annotated[Session, Depends(get_db)],
+) -> BatchSubmitResponse:
+    """Submit an async batch of jobs for scoring.
+
+    Jobs are sent to the provider's Batch API (Anthropic or OpenAI) for
+    processing at 50% cost discount. Results are typically available
+    within 24 hours.
+
+    Returns a ``batch_id`` for polling status and retrieving results.
+    """
+    try:
+        profile_data = build_profile_data(db, payload.profile_id)
+    except ProfileNotFoundError:
+        raise HTTPException(status_code=404, detail="Profile not found") from None
+    except ProfileIncompleteError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    provider = get_ai_provider(payload.provider)
+
+    jobs = [{"id": j.id, "description": j.description} for j in payload.jobs]
+
+    try:
+        batch_id = await submit_batch(provider, jobs, profile_data)
+    except BatchSubmissionError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return BatchSubmitResponse(
+        batch_id=batch_id,
+        provider=provider.name,
+        job_count=len(jobs),
+    )
+
+
+@router.get(
+    "/api/score/batch/{batch_id}/status",
+    responses={
+        502: {"description": "Provider status check failed"},
+    },
+)
+async def batch_status_endpoint(
+    batch_id: str,
+    provider: Annotated[str | None, Query(description="AI provider name")] = None,
+) -> BatchStatusResponse:
+    """Check the status of an async batch scoring job."""
+    ai_provider = get_ai_provider(provider)
+
+    try:
+        status = await check_batch_status(ai_provider, batch_id)
+    except BatchResultError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return BatchStatusResponse(
+        batch_id=status["batch_id"],
+        status=status["status"],
+        provider=status["provider"],
+    )
+
+
+@router.get(
+    "/api/score/batch/{batch_id}/results",
+    responses={
+        202: {"description": "Batch not yet complete"},
+        502: {"description": "Provider result retrieval failed"},
+    },
+)
+async def batch_results_endpoint(
+    batch_id: str,
+    provider: Annotated[str | None, Query(description="AI provider name")] = None,
+) -> BatchResultsResponse:
+    """Retrieve results of a completed async batch scoring job.
+
+    Returns 202 if the batch is still processing. Returns results only
+    when all jobs have been scored.
+    """
+    ai_provider = get_ai_provider(provider)
+
+    try:
+        results = await retrieve_batch_results(ai_provider, batch_id)
+    except BatchNotReadyError:
+        raise HTTPException(
+            status_code=202,
+            detail=f"Batch {batch_id} is still processing. Poll status endpoint.",
+        ) from None
+    except BatchResultError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    items = []
+    for r in results:
+        score_dict = None
+        if r["score_result"] is not None:
+            score_dict = r["score_result"].model_dump()
+        items.append(
+            BatchResultItem(
+                job_id=r["job_id"],
+                score_result=score_dict,
+                error=r["error"],
+            )
+        )
+
+    successful = sum(1 for i in items if i.score_result is not None)
+    failed = sum(1 for i in items if i.error is not None)
+
+    return BatchResultsResponse(
+        batch_id=batch_id,
+        results=items,
+        total=len(items),
+        successful=successful,
+        failed=failed,
+    )

--- a/src/career_os/main.py
+++ b/src/career_os/main.py
@@ -13,6 +13,7 @@ from career_os import __version__
 from career_os.api.ai import router as ai_router
 from career_os.api.analytics import router as analytics_router
 from career_os.api.applications import router as applications_router
+from career_os.api.batch import router as batch_router
 from career_os.api.calendar import router as calendar_router
 from career_os.api.coaching import router as coaching_router
 from career_os.api.contacts import router as contacts_router
@@ -192,6 +193,7 @@ app.add_middleware(
 # Include routers
 app.include_router(ai_router)
 app.include_router(analytics_router)
+app.include_router(batch_router)
 app.include_router(calendar_router)
 app.include_router(applications_router)
 app.include_router(coaching_router)

--- a/src/career_os/services/async_batch.py
+++ b/src/career_os/services/async_batch.py
@@ -1,0 +1,207 @@
+"""Async batch scoring service.
+
+Orchestrates async Batch API submission and result retrieval for providers
+that support it (Anthropic Message Batches, OpenAI Batch API). These APIs
+accept a set of requests and return results within 24 hours at 50% cost
+discount compared to real-time API calls.
+
+This is distinct from the synchronous multi-job-per-prompt batching in
+scoring.py (G-440). That sends multiple jobs in one prompt; this submits
+individual requests to a provider's async batch queue.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+
+from career_os.ai.base import AIProvider
+from career_os.schemas.ai import ScoreResult
+
+logger = logging.getLogger(__name__)
+
+
+class BatchStatus(StrEnum):
+    """Possible states of an async batch job."""
+
+    in_progress = "in_progress"
+    ended = "ended"
+    canceling = "canceling"
+    canceled = "canceled"
+    expired = "expired"
+    failed = "failed"
+    unknown = "unknown"
+
+
+class BatchSubmissionError(Exception):
+    """Raised when batch submission fails."""
+
+
+class BatchNotReadyError(Exception):
+    """Raised when batch results are requested before the batch has completed."""
+
+
+class BatchResultError(Exception):
+    """Raised when batch result retrieval fails."""
+
+
+async def submit_batch(
+    provider: AIProvider,
+    jobs: list[dict],
+    profile_data: dict,
+) -> str:
+    """Submit a batch of jobs for async scoring.
+
+    Each job dict must contain at least ``id`` (unique identifier) and
+    ``description`` (job posting text). The provider's ``batch_score()``
+    method builds the per-job requests and POSTs them to the async batch
+    endpoint.
+
+    Args:
+        provider: AI provider that supports batch scoring.
+        jobs: List of dicts with at least 'id' and 'description' keys.
+        profile_data: User profile data dict used for scoring context.
+
+    Returns:
+        Batch ID string for polling status/results.
+
+    Raises:
+        BatchSubmissionError: If the provider rejects the batch or an
+            unexpected error occurs during submission.
+    """
+    if not jobs:
+        raise BatchSubmissionError("Cannot submit an empty batch")
+
+    for job in jobs:
+        if "id" not in job or "description" not in job:
+            raise BatchSubmissionError("Each job must have 'id' and 'description' keys")
+
+    try:
+        batch_id = await provider.batch_score(jobs, profile_data)
+    except NotImplementedError as exc:
+        raise BatchSubmissionError(
+            f"Provider '{provider.name}' does not support batch scoring"
+        ) from exc
+    except Exception as exc:
+        raise BatchSubmissionError(f"Batch submission failed: {exc}") from exc
+
+    logger.info(
+        "Batch %s submitted via %s with %d jobs",
+        batch_id,
+        provider.name,
+        len(jobs),
+    )
+    return batch_id
+
+
+async def check_batch_status(
+    provider: AIProvider,
+    batch_id: str,
+) -> dict:
+    """Check the status of an async batch job.
+
+    Args:
+        provider: AI provider that submitted the batch.
+        batch_id: The batch ID returned by :func:`submit_batch`.
+
+    Returns:
+        Dict with at least a ``status`` key (one of :class:`BatchStatus`
+        values) and optionally ``counts`` with request processing stats.
+
+    Raises:
+        BatchResultError: If the status check fails.
+    """
+    try:
+        result = await provider.get_batch_results(batch_id)
+    except NotImplementedError as exc:
+        raise BatchResultError(
+            f"Provider '{provider.name}' does not support batch results"
+        ) from exc
+    except Exception as exc:
+        raise BatchResultError(f"Batch status check failed: {exc}") from exc
+
+    status_raw = result.get("status", "unknown")
+    # Normalize to our enum
+    try:
+        status = BatchStatus(status_raw)
+    except ValueError:
+        status = BatchStatus.unknown
+
+    return {"status": status, "batch_id": batch_id, "provider": provider.name}
+
+
+async def retrieve_batch_results(
+    provider: AIProvider,
+    batch_id: str,
+) -> list[dict]:
+    """Retrieve completed batch results as a list of ScoreResult dicts.
+
+    Calls the provider's ``get_batch_results()`` which fetches status and,
+    when the batch has ended, parses the JSONL result stream into
+    ``AIResponse`` objects keyed by custom_id (job ID).
+
+    Args:
+        provider: AI provider that submitted the batch.
+        batch_id: The batch ID returned by :func:`submit_batch`.
+
+    Returns:
+        List of dicts, each with ``job_id`` (str), ``score_result``
+        (:class:`ScoreResult` or None), and ``error`` (str or None).
+
+    Raises:
+        BatchNotReadyError: If the batch has not finished processing.
+        BatchResultError: If result retrieval fails.
+    """
+    try:
+        result = await provider.get_batch_results(batch_id)
+    except NotImplementedError as exc:
+        raise BatchResultError(
+            f"Provider '{provider.name}' does not support batch results"
+        ) from exc
+    except Exception as exc:
+        raise BatchResultError(f"Batch result retrieval failed: {exc}") from exc
+
+    status_raw = result.get("status", "unknown")
+
+    if status_raw != "ended":
+        raise BatchNotReadyError(
+            f"Batch {batch_id} is not ready (status: {status_raw}). "
+            "Results are only available when status is 'ended'."
+        )
+
+    raw_results: dict = result.get("results", {})
+    parsed: list[dict] = []
+
+    for job_id, ai_response in raw_results.items():
+        entry: dict = {"job_id": job_id, "score_result": None, "error": None}
+
+        if ai_response is None:
+            entry["error"] = "No response from provider"
+            parsed.append(entry)
+            continue
+
+        structured = ai_response.structured
+        if structured is None:
+            entry["error"] = "Provider returned unstructured response"
+            parsed.append(entry)
+            continue
+
+        # structured is already a ScoreResult (parsed by the provider)
+        if isinstance(structured, ScoreResult):
+            entry["score_result"] = structured
+        else:
+            # Try to coerce dict → ScoreResult
+            try:
+                entry["score_result"] = ScoreResult(**structured)
+            except Exception as exc:
+                entry["error"] = f"Failed to parse score result: {exc}"
+
+        parsed.append(entry)
+
+    logger.info(
+        "Batch %s: %d results retrieved, %d successful",
+        batch_id,
+        len(parsed),
+        sum(1 for r in parsed if r["score_result"] is not None),
+    )
+    return parsed

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -2987,6 +2987,34 @@ def _gather_scoring_context(db: Session, profile: Profile, profile_id: int) -> d
     return profile_data
 
 
+def build_profile_data(db: Session, profile_id: int) -> dict:
+    """Public entry point to gather profile data for batch scoring.
+
+    Validates the profile exists and is complete enough for scoring,
+    then returns the full scoring context (profile + weights).
+
+    Args:
+        db: Database session.
+        profile_id: Profile ID to gather data for.
+
+    Returns:
+        Profile data dict suitable for AI provider scoring calls.
+
+    Raises:
+        ProfileNotFoundError: If the profile does not exist.
+        ProfileIncompleteError: If required profile fields are missing.
+    """
+    profile = db.query(Profile).filter(Profile.id == profile_id).first()
+    if not profile:
+        raise ProfileNotFoundError(f"Profile {profile_id} not found")
+
+    # Basic completeness check — name is the minimum bar
+    if not profile.name:
+        raise ProfileIncompleteError("Profile is missing required fields for scoring (name).")
+
+    return _gather_scoring_context(db, profile, profile_id)
+
+
 def _gather_red_flag_metadata(
     db: Session,
     discovered_job_id: int | None,

--- a/tests/test_async_batch.py
+++ b/tests/test_async_batch.py
@@ -1,0 +1,518 @@
+"""Tests for async batch scoring service and API routes.
+
+Covers batch submission, status checking, result retrieval, and error
+handling for both the service layer and the FastAPI endpoints.
+All HTTP calls to AI providers are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from career_os.ai.base import AIProvider
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+from career_os.services.async_batch import (
+    BatchNotReadyError,
+    BatchResultError,
+    BatchStatus,
+    BatchSubmissionError,
+    check_batch_status,
+    retrieve_batch_results,
+    submit_batch,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_JOBS = [
+    {"id": "job-1", "description": "Senior Python engineer at Acme Corp"},
+    {"id": "job-2", "description": "Staff ML engineer at BigCo"},
+]
+
+SAMPLE_PROFILE_DATA = {
+    "name": "Test User",
+    "location": "Berlin",
+    "job_family": "Software Engineering",
+    "skills": [{"name": "Python", "category": "technical", "proficiency": 8}],
+    "goals": [{"title": "Senior IC", "type": "career", "description": "Grow to senior"}],
+}
+
+
+def _make_score_result() -> ScoreResult:
+    """Create a minimal valid ScoreResult for testing."""
+    return ScoreResult(
+        fit_score=7.5,
+        reasoning="Good fit because the candidate has strong Python skills " * 3,
+        estimated_salary="$150k-180k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Review system design",
+        readiness_score=75.0,
+        career_alignment=8.0,
+        score_breakdown=[
+            {"factor": "skills", "contribution": 2.0, "description": "Strong Python match"},
+            {"factor": "seniority", "contribution": 1.5, "description": "Right level"},
+            {"factor": "location", "contribution": -0.5, "description": "Remote OK"},
+        ],
+        dimensional_scores={
+            "technical_fit": 8.0,
+            "seniority_alignment": 7.5,
+            "compensation_fit": 7.0,
+            "location_fit": 6.5,
+            "career_trajectory": 8.5,
+            "company_fit": 7.0,
+        },
+        ats_keywords=[],
+        desire_score=7.0,
+        desire_reasoning="Good company culture signals",
+    )
+
+
+def _make_ai_response(structured: ScoreResult | None = None) -> AIResponse:
+    """Create an AIResponse with optional structured ScoreResult."""
+    return AIResponse(
+        content='{"fit_score": 7.5}',
+        provider="anthropic",
+        feature=AIFeature.score,
+        structured=structured,
+        model="claude-sonnet-4-20250514",
+    )
+
+
+class FakeProvider(AIProvider):
+    """Fake AI provider for testing batch operations."""
+
+    def __init__(
+        self,
+        *,
+        batch_id: str = "batch_abc123",
+        batch_status: str = "ended",
+        batch_results: dict | None = None,
+        raise_on_batch_score: Exception | None = None,
+        raise_on_get_results: Exception | None = None,
+    ) -> None:
+        self._batch_id = batch_id
+        self._batch_status = batch_status
+        self._batch_results = batch_results or {}
+        self._raise_on_batch_score = raise_on_batch_score
+        self._raise_on_get_results = raise_on_get_results
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    async def complete(self, prompt, **kwargs):
+        return _make_ai_response()
+
+    async def score(self, job_description, profile_data, **kwargs):
+        return _make_ai_response(_make_score_result())
+
+    async def batch_score(self, jobs, profile_data, **kwargs):
+        if self._raise_on_batch_score:
+            raise self._raise_on_batch_score
+        return self._batch_id
+
+    async def get_batch_results(self, batch_id):
+        if self._raise_on_get_results:
+            raise self._raise_on_get_results
+        return {"status": self._batch_status, "results": self._batch_results}
+
+
+class NoSupportProvider(AIProvider):
+    """Provider that does not support batch operations."""
+
+    @property
+    def name(self) -> str:
+        return "nosupport"
+
+    async def complete(self, prompt, **kwargs):
+        return _make_ai_response()
+
+    async def score(self, job_description, profile_data, **kwargs):
+        return _make_ai_response()
+
+    # Deliberately does NOT override batch_score / get_batch_results
+    # so the base class NotImplementedError fires.
+
+
+# ---------------------------------------------------------------------------
+# Service layer tests: submit_batch
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitBatch:
+    """Tests for the submit_batch service function."""
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_returns_batch_id(self):
+        provider = FakeProvider(batch_id="batch_xyz789")
+        batch_id = await submit_batch(provider, SAMPLE_JOBS, SAMPLE_PROFILE_DATA)
+        assert batch_id == "batch_xyz789"
+        assert isinstance(batch_id, str)
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_empty_jobs_raises(self):
+        provider = FakeProvider()
+        with pytest.raises(BatchSubmissionError, match="empty batch"):
+            await submit_batch(provider, [], SAMPLE_PROFILE_DATA)
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_missing_id_raises(self):
+        provider = FakeProvider()
+        bad_jobs = [{"description": "no id here"}]
+        with pytest.raises(BatchSubmissionError, match="'id' and 'description'"):
+            await submit_batch(provider, bad_jobs, SAMPLE_PROFILE_DATA)
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_missing_description_raises(self):
+        provider = FakeProvider()
+        bad_jobs = [{"id": "1"}]
+        with pytest.raises(BatchSubmissionError, match="'id' and 'description'"):
+            await submit_batch(provider, bad_jobs, SAMPLE_PROFILE_DATA)
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_unsupported_provider(self):
+        provider = NoSupportProvider()
+        with pytest.raises(BatchSubmissionError, match="does not support"):
+            await submit_batch(provider, SAMPLE_JOBS, SAMPLE_PROFILE_DATA)
+
+    @pytest.mark.asyncio
+    async def test_submit_batch_provider_error(self):
+        provider = FakeProvider(raise_on_batch_score=RuntimeError("API down"))
+        with pytest.raises(BatchSubmissionError, match="Batch submission failed"):
+            await submit_batch(provider, SAMPLE_JOBS, SAMPLE_PROFILE_DATA)
+
+
+# ---------------------------------------------------------------------------
+# Service layer tests: check_batch_status
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBatchStatus:
+    """Tests for the check_batch_status service function."""
+
+    @pytest.mark.asyncio
+    async def test_check_status_in_progress(self):
+        provider = FakeProvider(batch_status="in_progress")
+        result = await check_batch_status(provider, "batch_123")
+        assert result["status"] == BatchStatus.in_progress
+        assert result["batch_id"] == "batch_123"
+        assert result["provider"] == "fake"
+
+    @pytest.mark.asyncio
+    async def test_check_status_ended(self):
+        provider = FakeProvider(batch_status="ended")
+        result = await check_batch_status(provider, "batch_456")
+        assert result["status"] == BatchStatus.ended
+        assert result["batch_id"] == "batch_456"
+
+    @pytest.mark.asyncio
+    async def test_check_status_unknown_maps_correctly(self):
+        provider = FakeProvider(batch_status="some_weird_status")
+        result = await check_batch_status(provider, "batch_789")
+        assert result["status"] == BatchStatus.unknown
+        assert result["provider"] == "fake"
+
+    @pytest.mark.asyncio
+    async def test_check_status_unsupported_provider(self):
+        provider = NoSupportProvider()
+        with pytest.raises(BatchResultError, match="does not support"):
+            await check_batch_status(provider, "batch_123")
+
+    @pytest.mark.asyncio
+    async def test_check_status_provider_error(self):
+        provider = FakeProvider(raise_on_get_results=RuntimeError("Network error"))
+        with pytest.raises(BatchResultError, match="Batch status check failed"):
+            await check_batch_status(provider, "batch_123")
+
+
+# ---------------------------------------------------------------------------
+# Service layer tests: retrieve_batch_results
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveBatchResults:
+    """Tests for the retrieve_batch_results service function."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_success(self):
+        score = _make_score_result()
+        ai_resp = _make_ai_response(structured=score)
+        provider = FakeProvider(
+            batch_status="ended",
+            batch_results={"job-1": ai_resp, "job-2": ai_resp},
+        )
+        results = await retrieve_batch_results(provider, "batch_done")
+        assert len(results) == 2
+        assert results[0]["job_id"] in ("job-1", "job-2")
+        assert results[0]["score_result"].fit_score == 7.5
+        assert results[0]["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_not_ready(self):
+        provider = FakeProvider(batch_status="in_progress")
+        with pytest.raises(BatchNotReadyError, match="not ready"):
+            await retrieve_batch_results(provider, "batch_pending")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_with_none_response(self):
+        provider = FakeProvider(
+            batch_status="ended",
+            batch_results={"job-1": None},
+        )
+        results = await retrieve_batch_results(provider, "batch_partial")
+        assert len(results) == 1
+        assert results[0]["score_result"] is None
+        assert results[0]["error"] == "No response from provider"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_unstructured_response(self):
+        ai_resp = _make_ai_response(structured=None)
+        provider = FakeProvider(
+            batch_status="ended",
+            batch_results={"job-1": ai_resp},
+        )
+        results = await retrieve_batch_results(provider, "batch_unstructured")
+        assert len(results) == 1
+        assert results[0]["score_result"] is None
+        assert results[0]["error"] == "Provider returned unstructured response"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_unsupported_provider(self):
+        provider = NoSupportProvider()
+        with pytest.raises(BatchResultError, match="does not support"):
+            await retrieve_batch_results(provider, "batch_123")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_provider_error(self):
+        provider = FakeProvider(raise_on_get_results=RuntimeError("Fetch failed"))
+        with pytest.raises(BatchResultError, match="retrieval failed"):
+            await retrieve_batch_results(provider, "batch_123")
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+from career_os.main import app  # noqa: E402
+
+
+class TestBatchSubmitEndpoint:
+    """Tests for POST /api/score/batch/submit."""
+
+    def test_submit_success(self, db_session, profile):
+        """Successful batch submission returns 202 with batch_id."""
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(batch_id="batch_api_123"),
+        ):
+            resp = client.post(
+                "/api/score/batch/submit",
+                json={
+                    "profile_id": profile.id,
+                    "jobs": [
+                        {"id": "j1", "description": "Python dev at StartupCo"},
+                        {"id": "j2", "description": "Backend eng at BigCorp"},
+                    ],
+                },
+            )
+
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["batch_id"] == "batch_api_123"
+        assert data["provider"] == "fake"
+        assert data["job_count"] == 2
+
+    def test_submit_profile_not_found(self, db_session):
+        """Non-existent profile returns 404."""
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(),
+        ):
+            resp = client.post(
+                "/api/score/batch/submit",
+                json={
+                    "profile_id": 99999,
+                    "jobs": [{"id": "j1", "description": "Some job"}],
+                },
+            )
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_submit_empty_jobs_rejected(self, db_session, profile):
+        """Empty jobs list is rejected by Pydantic validation (422)."""
+        client = TestClient(app)
+        resp = client.post(
+            "/api/score/batch/submit",
+            json={"profile_id": profile.id, "jobs": []},
+        )
+        assert resp.status_code == 422
+
+    def test_submit_provider_failure(self, db_session, profile):
+        """Provider batch submission failure returns 502."""
+        client = TestClient(app)
+
+        failing_provider = FakeProvider(
+            raise_on_batch_score=RuntimeError("Provider exploded"),
+        )
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=failing_provider,
+        ):
+            resp = client.post(
+                "/api/score/batch/submit",
+                json={
+                    "profile_id": profile.id,
+                    "jobs": [{"id": "j1", "description": "Some job"}],
+                },
+            )
+
+        assert resp.status_code == 502
+        assert "failed" in resp.json()["detail"].lower()
+
+
+class TestBatchStatusEndpoint:
+    """Tests for GET /api/score/batch/{batch_id}/status."""
+
+    def test_status_in_progress(self):
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(batch_status="in_progress"),
+        ):
+            resp = client.get(
+                "/api/score/batch/batch_123/status",
+                params={"provider": "anthropic"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["batch_id"] == "batch_123"
+        assert data["status"] == "in_progress"
+
+    def test_status_ended(self):
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(batch_status="ended"),
+        ):
+            resp = client.get("/api/score/batch/batch_456/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ended"
+
+    def test_status_provider_error(self):
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(raise_on_get_results=RuntimeError("boom")),
+        ):
+            resp = client.get("/api/score/batch/batch_789/status")
+
+        assert resp.status_code == 502
+        assert "failed" in resp.json()["detail"].lower()
+
+
+class TestBatchResultsEndpoint:
+    """Tests for GET /api/score/batch/{batch_id}/results."""
+
+    def test_results_success(self):
+        client = TestClient(app)
+        score = _make_score_result()
+        ai_resp = _make_ai_response(structured=score)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(
+                batch_status="ended",
+                batch_results={"job-1": ai_resp},
+            ),
+        ):
+            resp = client.get("/api/score/batch/batch_done/results")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["batch_id"] == "batch_done"
+        assert data["total"] == 1
+        assert data["successful"] == 1
+        assert data["failed"] == 0
+        assert data["results"][0]["job_id"] == "job-1"
+        assert data["results"][0]["score_result"]["fit_score"] == 7.5
+
+    def test_results_not_ready_returns_202(self):
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(batch_status="in_progress"),
+        ):
+            resp = client.get("/api/score/batch/batch_pending/results")
+
+        assert resp.status_code == 202
+        assert "still processing" in resp.json()["detail"].lower()
+
+    def test_results_with_errors(self):
+        client = TestClient(app)
+        ai_resp_no_structured = _make_ai_response(structured=None)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(
+                batch_status="ended",
+                batch_results={"job-1": ai_resp_no_structured},
+            ),
+        ):
+            resp = client.get("/api/score/batch/batch_errors/results")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["successful"] == 0
+        assert data["failed"] == 1
+        assert data["results"][0]["error"] is not None
+
+    def test_results_provider_error(self):
+        client = TestClient(app)
+
+        with patch(
+            "career_os.api.batch.get_ai_provider",
+            return_value=FakeProvider(raise_on_get_results=RuntimeError("boom")),
+        ):
+            resp = client.get("/api/score/batch/batch_err/results")
+
+        assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# BatchStatus enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchStatusEnum:
+    """Tests for BatchStatus enum values."""
+
+    def test_batch_status_values(self):
+        assert BatchStatus.in_progress == "in_progress"
+        assert BatchStatus.ended == "ended"
+        assert BatchStatus.canceled == "canceled"
+        assert BatchStatus.failed == "failed"
+        assert BatchStatus.expired == "expired"
+        assert BatchStatus.unknown == "unknown"
+
+    def test_batch_status_from_string(self):
+        status = BatchStatus("ended")
+        assert status == BatchStatus.ended
+        assert status.value == "ended"


### PR DESCRIPTION
## Summary
- Async batch scoring via Anthropic Message Batches API and OpenAI Batch API
- 50% cost reduction, results within 24 hours
- Service layer: submit_batch(), check_batch_status(), retrieve_batch_results()
- API: POST /api/score/batch/submit, GET .../status, GET .../results
- OpenAI provider: batch_score() and get_batch_results() added
- Provider-agnostic service layer with unified BatchStatus enum

## Test plan
- [x] 30 tests: service layer + API endpoints + error paths
- [x] Ruff lint clean, all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)