### PR TITLE
fix(G-419): fix SonarCloud 0% coverage on new code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b tsconfig.build.json && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "size": "size-limit"
   },
   "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,10 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 timeout = 30
+
+[tool.coverage.run]
+# relative_files = true makes pytest-cov emit project-relative source paths in
+# coverage.xml instead of absolute runner paths (e.g. /home/runner/work/...).
+# SonarCloud matches coverage data against its source index using relative paths,
+# so without this setting it cannot associate any coverage and reports 0%.
+relative_files = true


### PR DESCRIPTION
## Summary

- Added `relative_files = true` to `[tool.coverage.run]` in `pyproject.toml`
- pytest-cov was emitting absolute paths in coverage.xml — SonarCloud couldn't match them to source files
- Aligned frontend test script to include `--coverage` flag

## Test plan

- [ ] Next PR shows actual coverage percentages in SonarCloud (not 0%)
- [ ] Coverage XML contains relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)