### PR TITLE
fix(G-491): fix release gate date parsing and qualifying commit detection

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -36,7 +36,9 @@ jobs:
 
           # Check PR age (1-hour cool-down)
           CREATED=$(echo "$PR" | jq -r '.createdAt')
-          AGE_SECONDS=$(( $(date +%s) - $(date -d "$CREATED" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED" +%s 2>/dev/null || echo 0) ))
+          # Parse ISO 8601 date portably (works on both GNU and BSD date)
+          CREATED_EPOCH=$(date -d "$CREATED" +%s 2>/dev/null || python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('$CREATED'.replace('Z','+00:00')).timestamp()))")
+          AGE_SECONDS=$(( $(date +%s) - CREATED_EPOCH ))
           if [ "$AGE_SECONDS" -lt 3600 ]; then
             echo "PR is less than 1 hour old ($AGE_SECONDS seconds) — cool-down period"
             echo "ready=false" >> "$GITHUB_OUTPUT"
@@ -66,11 +68,13 @@ jobs:
         id: commits
         if: steps.find-pr.outputs.found == 'true'
         run: |
-          # Check if there are feat: or fix: commits (not just chore/docs)
+          # Release-please PRs have a single "chore(main): release X" commit,
+          # so we check the PR body (changelog) for feat/fix entries instead.
           PR_NUMBER=${{ steps.find-pr.outputs.number }}
-          COMMITS=$(gh pr view "$PR_NUMBER" --json commits -q '.commits[].messageHeadline' 2>/dev/null || echo "")
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body' 2>/dev/null || echo "")
 
-          HAS_QUALIFYING=$(echo "$COMMITS" | grep -cE '^(feat|fix)' || echo "0")
+          # Release-please groups changes under ### headers (Bug Fixes, Features, etc.)
+          HAS_QUALIFYING=$(echo "$PR_BODY" | grep -cE '### (Bug Fixes|Features)' || echo "0")
 
           if [ "$HAS_QUALIFYING" -gt 0 ]; then
             echo "qualifying=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fix ISO 8601 date parsing for cool-down check (GNU `date -d` doesn't work on Ubuntu Actions runners)
- Fix qualifying commit detection: check PR body changelog headers (`### Bug Fixes`, `### Features`) instead of PR commits (which are always `chore`)

Without this fix, the release gate never auto-merges: it always reports "less than 1 hour old" and "no qualifying commits."

## Test plan

- [ ] Release gate workflow runs successfully after merge
- [ ] PR #302 (release 0.11.1) auto-merges within next gate evaluation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)