### PR TITLE
feat(G-407): enforce PII safety boundary — block personal data from non-ZDR providers

### DIFF
--- a/src/career_os/ai/privacy.py
+++ b/src/career_os/ai/privacy.py
@@ -3,10 +3,15 @@
 Loads provider privacy policies from ``data/privacy_registry.json`` when
 available, falling back to a hardcoded default.  Each entry carries a
 ``last_verified`` date so consumers (and users) know how fresh the data is.
+
+Also provides PII safety boundary enforcement: personal-data features
+(cover letters, interview prep, STAR stories, voice coaching) are blocked
+from non-ZDR providers to prevent inadvertent personal data exposure.
 """
 
 import json
 import logging
+from enum import StrEnum
 from pathlib import Path
 
 from career_os.schemas.privacy import DataRetention, PrivacyTier, ProviderPrivacyInfo
@@ -174,3 +179,81 @@ def get_privacy_info(provider_name: str) -> ProviderPrivacyInfo | None:
         ProviderPrivacyInfo if the provider is in the registry, else None.
     """
     return PROVIDER_PRIVACY_REGISTRY.get(provider_name.lower())
+
+
+# ---------------------------------------------------------------------------
+# PII safety boundary — feature sensitivity classification
+# ---------------------------------------------------------------------------
+
+
+class DataSensitivity(StrEnum):
+    """Sensitivity level of data handled by an AI feature.
+
+    PUBLIC features only touch job descriptions, career preferences, and other
+    non-personal data.  PERSONAL features touch CV content, cover letters,
+    STAR stories, interview coaching, or other data that can identify the user.
+    """
+
+    PUBLIC = "public"
+    PERSONAL = "personal"
+
+
+# Map AIFeature string values to sensitivity levels.
+# Features not listed default to PUBLIC.
+FEATURE_SENSITIVITY: dict[str, DataSensitivity] = {
+    # Public features — safe with any provider
+    "score": DataSensitivity.PUBLIC,
+    "gap_analysis": DataSensitivity.PUBLIC,
+    "company_research": DataSensitivity.PUBLIC,
+    "goal_recalibration": DataSensitivity.PUBLIC,
+    "learning_recommendations": DataSensitivity.PUBLIC,
+    "interview_format": DataSensitivity.PUBLIC,
+    "interview_patterns": DataSensitivity.PUBLIC,
+    "complete": DataSensitivity.PUBLIC,
+    # Personal features — require a ZDR-safe provider
+    "voice_cover_letter": DataSensitivity.PERSONAL,
+    "voice_coaching": DataSensitivity.PERSONAL,
+    "voice_job_evaluation": DataSensitivity.PERSONAL,
+    "coaching": DataSensitivity.PERSONAL,
+    "interview_prep": DataSensitivity.PERSONAL,
+    "star_stories": DataSensitivity.PERSONAL,
+}
+
+# Providers that guarantee zero data retention by default.
+# OpenRouter is excluded because ZDR requires explicit opt-in per request.
+# Together, OpenAI, Groq, xAI, Gemini: not ZDR by default.
+ZDR_SAFE_PROVIDERS: frozenset[str] = frozenset({"mock", "demo", "ollama", "anthropic"})
+
+
+class PrivacyError(Exception):
+    """Raised when a feature requires privacy guarantees the provider can't give.
+
+    This is a user-visible error — the message is shown directly in the API
+    response.  Keep the message clear and actionable.
+    """
+
+    pass
+
+
+def check_privacy_boundary(feature: str, provider_name: str) -> None:
+    """Enforce PII safety: block personal-data features from non-ZDR providers.
+
+    Call this BEFORE invoking the AI provider for any personal feature.
+    Scoring and other public features always pass through.
+
+    Args:
+        feature: AIFeature string value (e.g. ``"voice_cover_letter"``).
+        provider_name: The active provider name (e.g. ``"openrouter"``).
+
+    Raises:
+        PrivacyError: If the feature handles personal data and the provider
+            does not guarantee zero data retention.
+    """
+    sensitivity = FEATURE_SENSITIVITY.get(feature, DataSensitivity.PUBLIC)
+    if sensitivity == DataSensitivity.PERSONAL and provider_name.lower() not in ZDR_SAFE_PROVIDERS:
+        raise PrivacyError(
+            f"'{feature}' handles personal data and requires a privacy-safe provider. "
+            f"Current provider '{provider_name}' doesn't guarantee zero data retention. "
+            f"Switch to Ollama (local, fully private), Anthropic (zero-day retention "
+            f"policy, DPA available), or configure OpenRouter with ZDR enabled."
+        )

--- a/src/career_os/main.py
+++ b/src/career_os/main.py
@@ -163,6 +163,24 @@ async def onboarding_error_handler(request: Request, exc: OnboardingError) -> JS
     )
 
 
+# PII safety boundary error handler — returns 422 with clear user message
+from career_os.ai.privacy import PrivacyError  # noqa: E402
+
+
+@app.exception_handler(PrivacyError)
+async def privacy_error_handler(request: Request, exc: PrivacyError) -> JSONResponse:
+    return JSONResponse(
+        status_code=422,
+        content={
+            "error": str(exc),
+            "resolution": (
+                "Switch to a privacy-safe provider: Ollama (local), Anthropic, "
+                "or OpenRouter with ZDR enabled. Set the AI_PROVIDER environment variable."
+            ),
+        },
+    )
+
+
 # API key auth middleware (disabled by default for local use)
 from career_os.middleware import APIKeyAuthMiddleware  # noqa: E402
 

--- a/src/career_os/services/interview_prep.py
+++ b/src/career_os/services/interview_prep.py
@@ -26,6 +26,7 @@ from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from career_os.ai.factory import get_ai_provider
+from career_os.ai.privacy import check_privacy_boundary
 from career_os.models.interview_prep import InterviewPrepItem, InterviewPrepSession
 from career_os.models.models import Application, Profile
 from career_os.models.skills import JobRequirement, Skill, SkillHistory
@@ -650,6 +651,8 @@ async def get_or_create_interview_prep(
 
     try:
         provider = get_ai_provider()
+        # Enforce PII safety boundary before sending personal data to provider
+        check_privacy_boundary(str(AIFeature.interview_prep), provider.name)
         response = await provider.complete(
             prompt=prompt,
             feature=AIFeature.interview_prep,

--- a/src/career_os/services/voice.py
+++ b/src/career_os/services/voice.py
@@ -9,6 +9,7 @@ Supports three conversational modes, all STT-agnostic (work with any text input)
 from sqlalchemy.orm import Session
 
 from career_os.ai.factory import get_ai_provider
+from career_os.ai.privacy import check_privacy_boundary
 from career_os.models.models import Application, Profile
 from career_os.models.voice import VoiceMessage, VoiceSession
 from career_os.schemas.ai import AIFeature
@@ -194,6 +195,10 @@ async def send_message(
 
     provider = get_ai_provider()
     ai_feature = _mode_to_feature(session.mode)
+
+    # Enforce PII safety boundary before sending personal data to provider
+    check_privacy_boundary(str(ai_feature), provider.name)
+
     ai_response = await provider.complete(prompt=prompt, feature=ai_feature, context=context)
 
     # Store assistant message

--- a/tests/test_privacy_boundary.py
+++ b/tests/test_privacy_boundary.py
@@ -1,0 +1,235 @@
+"""Tests for PII safety boundary enforcement.
+
+Covers:
+- DataSensitivity enum values
+- FEATURE_SENSITIVITY classification (public vs personal)
+- ZDR_SAFE_PROVIDERS set
+- check_privacy_boundary: public features pass for any provider
+- check_privacy_boundary: personal features pass for ZDR-safe providers
+- check_privacy_boundary: personal features raise PrivacyError for non-ZDR providers
+- PrivacyError message is user-friendly and actionable
+- API returns 422 (not 500) when PrivacyError is raised from a service
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from career_os.ai.privacy import (
+    FEATURE_SENSITIVITY,
+    ZDR_SAFE_PROVIDERS,
+    DataSensitivity,
+    PrivacyError,
+    check_privacy_boundary,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests — DataSensitivity enum
+# ---------------------------------------------------------------------------
+
+
+def test_data_sensitivity_values():
+    """DataSensitivity has PUBLIC and PERSONAL values."""
+    assert DataSensitivity.PUBLIC == "public"
+    assert DataSensitivity.PERSONAL == "personal"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — FEATURE_SENSITIVITY mapping
+# ---------------------------------------------------------------------------
+
+
+def test_scoring_is_public():
+    """Scoring is classified as public — safe with any provider."""
+    assert FEATURE_SENSITIVITY["score"] == DataSensitivity.PUBLIC
+
+
+def test_gap_analysis_is_public():
+    """Gap analysis is classified as public."""
+    assert FEATURE_SENSITIVITY["gap_analysis"] == DataSensitivity.PUBLIC
+
+
+def test_company_research_is_public():
+    """Company research is classified as public."""
+    assert FEATURE_SENSITIVITY["company_research"] == DataSensitivity.PUBLIC
+
+
+def test_voice_cover_letter_is_personal():
+    """Voice cover letter feature is classified as personal."""
+    assert FEATURE_SENSITIVITY["voice_cover_letter"] == DataSensitivity.PERSONAL
+
+
+def test_voice_coaching_is_personal():
+    """Voice coaching feature is classified as personal."""
+    assert FEATURE_SENSITIVITY["voice_coaching"] == DataSensitivity.PERSONAL
+
+
+def test_interview_prep_is_personal():
+    """Interview prep feature is classified as personal."""
+    assert FEATURE_SENSITIVITY["interview_prep"] == DataSensitivity.PERSONAL
+
+
+def test_star_stories_is_personal():
+    """STAR stories feature is classified as personal."""
+    assert FEATURE_SENSITIVITY["star_stories"] == DataSensitivity.PERSONAL
+
+
+def test_coaching_is_personal():
+    """Coaching feature is classified as personal."""
+    assert FEATURE_SENSITIVITY["coaching"] == DataSensitivity.PERSONAL
+
+
+def test_unknown_feature_defaults_to_public():
+    """Features not in the map default to PUBLIC."""
+    result = FEATURE_SENSITIVITY.get("unknown_feature", DataSensitivity.PUBLIC)
+    assert result == DataSensitivity.PUBLIC
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ZDR_SAFE_PROVIDERS
+# ---------------------------------------------------------------------------
+
+
+def test_mock_is_zdr_safe():
+    assert "mock" in ZDR_SAFE_PROVIDERS
+
+
+def test_demo_is_zdr_safe():
+    """'demo' alias for mock must also be ZDR-safe."""
+    assert "demo" in ZDR_SAFE_PROVIDERS
+
+
+def test_ollama_is_zdr_safe():
+    assert "ollama" in ZDR_SAFE_PROVIDERS
+
+
+def test_anthropic_is_zdr_safe():
+    assert "anthropic" in ZDR_SAFE_PROVIDERS
+
+
+def test_openrouter_is_not_zdr_safe():
+    """OpenRouter requires explicit ZDR opt-in — not safe by default."""
+    assert "openrouter" not in ZDR_SAFE_PROVIDERS
+
+
+def test_together_is_not_zdr_safe():
+    assert "together" not in ZDR_SAFE_PROVIDERS
+
+
+def test_groq_is_not_zdr_safe():
+    assert "groq" not in ZDR_SAFE_PROVIDERS
+
+
+def test_xai_is_not_zdr_safe():
+    assert "xai" not in ZDR_SAFE_PROVIDERS
+
+
+def test_gemini_is_not_zdr_safe():
+    assert "gemini" not in ZDR_SAFE_PROVIDERS
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — check_privacy_boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["mock", "demo", "ollama", "anthropic", "openrouter", "groq", "together", "xai", "gemini"],
+)
+def test_public_feature_passes_any_provider(provider: str):
+    """Public features (scoring) never raise PrivacyError regardless of provider."""
+    # Should not raise
+    check_privacy_boundary("score", provider)
+    check_privacy_boundary("gap_analysis", provider)
+    check_privacy_boundary("company_research", provider)
+
+
+@pytest.mark.parametrize("provider", ["mock", "demo", "ollama", "anthropic"])
+def test_personal_feature_passes_zdr_providers(provider: str):
+    """Personal features pass for ZDR-safe providers."""
+    # Should not raise
+    check_privacy_boundary("voice_cover_letter", provider)
+    check_privacy_boundary("interview_prep", provider)
+    check_privacy_boundary("voice_coaching", provider)
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "together", "groq", "xai", "gemini"])
+def test_personal_feature_blocked_non_zdr_providers(provider: str):
+    """Personal features raise PrivacyError for non-ZDR providers."""
+    with pytest.raises(PrivacyError) as exc_info:
+        check_privacy_boundary("voice_cover_letter", provider)
+
+    error_msg = str(exc_info.value)
+    assert "personal data" in error_msg
+    assert provider in error_msg
+    assert "zero data retention" in error_msg
+
+
+def test_privacy_error_message_mentions_safe_alternatives():
+    """PrivacyError message tells the user which providers are safe."""
+    with pytest.raises(PrivacyError) as exc_info:
+        check_privacy_boundary("interview_prep", "openrouter")
+
+    error_msg = str(exc_info.value)
+    # Should mention at least one safe alternative
+    assert any(p in error_msg for p in ["Ollama", "Anthropic", "OpenRouter"])
+
+
+def test_privacy_error_message_mentions_feature_name():
+    """PrivacyError message includes the feature name for context."""
+    with pytest.raises(PrivacyError) as exc_info:
+        check_privacy_boundary("voice_cover_letter", "together")
+
+    assert "voice_cover_letter" in str(exc_info.value)
+
+
+def test_check_privacy_boundary_case_insensitive_provider():
+    """Provider name comparison is case-insensitive."""
+    # Anthropic in uppercase — should still be recognised as safe
+    check_privacy_boundary("voice_cover_letter", "ANTHROPIC")
+    check_privacy_boundary("interview_prep", "Ollama")
+
+
+def test_unknown_feature_passes_boundary():
+    """Features not in FEATURE_SENSITIVITY default to PUBLIC — always pass."""
+    check_privacy_boundary("some_new_feature", "openrouter")
+
+
+# ---------------------------------------------------------------------------
+# Integration test — PrivacyError returns HTTP 422
+# ---------------------------------------------------------------------------
+
+
+def test_privacy_error_returns_422_from_api():
+    """PrivacyError raised in a service returns 422 (not 500) from the API.
+
+    We patch the voice send_message service to raise PrivacyError and verify
+    the API maps it to 422 with a structured JSON body.
+    """
+    from career_os.main import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Patch voice.send_message to raise PrivacyError
+    with patch(
+        "career_os.api.voice.send_message",
+        new=AsyncMock(
+            side_effect=PrivacyError(
+                "'voice_cover_letter' handles personal data and requires a "
+                "privacy-safe provider. Current provider 'openrouter' doesn't "
+                "guarantee zero data retention."
+            )
+        ),
+    ):
+        response = client.post(
+            "/api/voice/sessions/1/messages",
+            json={"content": "Hello", "profile_id": 1},
+        )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert "error" in body
+    assert "personal data" in body["error"]
+    assert "resolution" in body


### PR DESCRIPTION
## Summary

Classifies AI features by data sensitivity and blocks personal-data features from providers without zero data retention guarantees.

- **Public** (any provider): scoring, gap analysis, company research, goal recalibration
- **Personal** (ZDR-only): cover letters, voice coaching, interview prep, STAR stories

Safe providers: mock, demo, ollama, anthropic
Blocked for personal data: openrouter, together, openai, groq, xai, gemini

Users get a clear 422 error with resolution steps — not a 500 stack trace.

## Changes

- `src/career_os/ai/privacy.py` — DataSensitivity enum, feature classification, enforcement function
- `src/career_os/services/voice.py` — check before AI call in send_message()
- `src/career_os/services/interview_prep.py` — check before AI call in prep generation
- `src/career_os/main.py` — PrivacyError → 422 exception handler
- `tests/test_privacy_boundary.py` — 42 tests

## Test plan

- [ ] All 42 privacy boundary tests pass
- [ ] Scoring works with any provider (public feature, unaffected)
- [ ] Cover letter/interview prep raise PrivacyError with openrouter
- [ ] Error response is 422 with actionable message
- [ ] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)