### PR TITLE
fix(G-491): fix release gate heredoc syntax errors

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -120,17 +120,14 @@ jobs:
           PR_NUMBER=${{ steps.find-pr.outputs.number }}
           echo "All conditions met — auto-merging release PR #$PR_NUMBER"
           gh pr merge "$PR_NUMBER" --squash --auto
-          gh pr comment "$PR_NUMBER" --body "$(cat <<'BODY'
-          ## Auto-merged by Release Gate
+          gh pr comment "$PR_NUMBER" --body "## Auto-merged by Release Gate
 
           All conditions passed:
           - [x] CI checks passed
           - [x] Smoke tests passed
           - [x] No blocker issues open
           - [x] Contains qualifying commits (feat/fix)
-          - [x] Cool-down period elapsed (>1 hour)
-          BODY
-          )"
+          - [x] Cool-down period elapsed (>1 hour)"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -143,16 +140,13 @@ jobs:
           FAILED=${{ steps.checks.outputs.failed_checks }}
 
           echo "Checks failed — commenting on release PR #$PR_NUMBER"
-          gh pr comment "$PR_NUMBER" --body "$(cat <<BODY
-          ## Release rejected by Release Gate
+          gh pr comment "$PR_NUMBER" --body "## Release rejected by Release Gate
 
           The following checks failed: **$FAILED**
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          Release-please will recreate this PR when the fix lands on main.
-          BODY
-          )"
+          Release-please will recreate this PR when the fix lands on main."
 
           # Close the PR — release-please will recreate on next qualifying push
           gh pr close "$PR_NUMBER" --comment "Closing due to failed checks. Will retry after fix."
@@ -165,11 +159,8 @@ jobs:
           steps.blockers.outputs.blocked == 'true'
         run: |
           PR_NUMBER=${{ steps.find-pr.outputs.number }}
-          gh pr comment "$PR_NUMBER" --body "$(cat <<'BODY'
-          ## Release held by Release Gate
+          gh pr comment "$PR_NUMBER" --body "## Release held by Release Gate
 
-          Open blocker issues are preventing auto-merge. The release will proceed once all urgent/release-broken issues are resolved.
-          BODY
-          )"
+          Open blocker issues are preventing auto-merge. The release will proceed once all urgent/release-broken issues are resolved."
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.planning/phases/01-feature-inventory/01-01-PLAN.md
+++ b/.planning/phases/01-feature-inventory/01-01-PLAN.md
@@ -22,10 +22,10 @@ must_haves:
     - "A reader can see all 8 shipped domains (Scoring Engine, Discovery Engine, AI Provider System, Application Pipeline, Web Frontend, CLI & Packaging, Infrastructure, Integrations) in one document without reading source code"
     - "Voice mode and Mobile app appear in a distinct 'Parked Work' section — not mixed into shipped features"
     - "An opening evolution narrative (2-3 paragraphs) tells how Kestrel grew from CLI scoring tool to full-stack platform"
-    - "Every domain section contains a concise bullet list of shipped capabilities plus inline honest gaps about user-facing limitations"
+    - "Every domain section contains warm prose + bullet list of shipped capabilities + inline honest gaps + CHANGELOG cross-links"
     - "A summary table at the top lists all domains with key capabilities and Shipped/Parked status for quick scanning"
-    - "Each domain section includes CHANGELOG.md release tag cross-references"
     - "The inventory is written in warm teaching tone — explains what each domain does for a job seeker, not internal architecture"
+    - "No internal file paths, API routes, or architecture terminology appears in the document"
   artifacts:
     - path: "docs/roadmap/inventory.md"
       provides: "Complete feature inventory document"
@@ -53,7 +53,7 @@ what Kestrel has actually shipped so the master roadmap can present that history
 and compellingly. A job seeker evaluating Kestrel should be able to read this and understand
 what the product does today, without reading code or docs.
 
-Output: docs/roadmap/inventory.md (~2,000–3,000 words)
+Output: docs/roadmap/inventory.md (~2,000-3,000 words)
 </objective>
 
 <execution_context>
@@ -102,8 +102,7 @@ and documented. The "Pitfall 1" caveat in the research doc is outdated — do NO
 ### Correction 3: Cost presets shipped in v0.11.0 (G-442)
 
 The cost presets system (Free/Budget/Quality/Private/Custom) is a shipped feature in v0.11.0.
-Add it to the AI Provider System domain or Scoring Engine as appropriate (AI Provider System
-is the right primary home — it controls which provider + model + batch size is used).
+Add it to the AI Provider System domain — it controls which provider + model + batch size is used.
 
 ### Correction 4: CHANGELOG anchor format
 
@@ -119,65 +118,201 @@ when generating anchor IDs. The anchor for `## [0.11.0]` is `#0110`. The anchor 
 Do NOT use `#v030` or `#0-3-0`. Use the format above.
 </critical_corrections>
 
+<tone_guide>
+## Warm Teaching Tone — Reference Examples (per D-05)
+
+Use these as calibration for the prose voice across all domain sections:
+
+**Good (warm, user-facing):**
+"The scoring engine learns what kinds of jobs you actually want. Feed it a job description and
+your profile, and it returns a score from 0 to 10 with a letter grade, a breakdown by dimension,
+and a list of red flags. The more you use it and correct its mistakes, the better it gets."
+
+**Bad (technical, internal):**
+"Multi-factor rubric with 288 presets across 16 sectors, using Bayesian preference learning
+from historical feedback signals and ESCO skill taxonomy normalization."
+
+**Good (honest gap, useful):**
+"The web app is built for desktop browsers — there's no mobile-optimized layout yet, and it
+needs an active connection to the backend to work."
+
+**Bad (apologetic or vague):**
+"We're sorry to say that mobile support is not yet available. We hope to address this in a
+future release."
+
+The tone should feel like a knowledgeable friend explaining the product — neither a press
+release nor a technical spec.
+</tone_guide>
+
+<gap_examples>
+## User-Impact Gaps vs. Internal Tech Debt (per D-10)
+
+Include in inventory (user-impact — affects a job seeker using the app):
+- "No native desktop installer — you need Docker, Python, or a terminal to run Kestrel"
+- "The web app is designed for desktop width — no mobile-optimized layout yet"
+- "Discovery depends on job boards making data available for scraping"
+- "No email delivery for notifications — Pushover only"
+- "No built-in database backup — your data is a single SQLite file"
+
+Exclude from inventory (internal tech debt — affects developers, not users):
+- Scoring monolith at 4,262 lines
+- No pip lockfile
+- Synchronous clients blocking event loop
+- Frontend type drift between API responses and component props
+- SQLite-only limitation (users experience it as "no external database support" which is fine)
+- Mock provider serving as both demo mode and test fixture
+
+These internal concerns go in Phase 2's tech debt section (ROAD-06), NOT in this inventory.
+</gap_examples>
+
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Create docs/roadmap/ directory</name>
+  <name>Task 1: Create directory and validate source freshness</name>
   <files>docs/roadmap/</files>
   <read_first>
-    - Run `ls /Users/pleasedodisturb/Projects/kestrel/docs/roadmap/ 2>/dev/null || echo "DOES NOT EXIST"` to confirm directory is absent before creating
+    Run these commands to validate sources before proceeding:
+    1. `ls /Users/pleasedodisturb/Projects/kestrel/docs/roadmap/ 2>/dev/null || echo "DOES NOT EXIST"` — confirm directory is absent
+    2. `ls -la /Users/pleasedodisturb/Projects/kestrel/.planning/codebase/` — confirm all 7 codebase docs exist and check modification dates
+    3. `head -5 /Users/pleasedodisturb/Projects/kestrel/CHANGELOG.md` — confirm latest version is v0.11.0
   </read_first>
   <action>
-    Create the docs/roadmap/ directory. This directory does not exist yet (confirmed).
-    Run: `mkdir -p docs/roadmap/`
+    **Step 1: Create the directory.**
+    Run: `mkdir -p /Users/pleasedodisturb/Projects/kestrel/docs/roadmap/`
 
-    This is a prerequisite for Task 2. Do not write inventory.md until this directory exists.
-    Verify with: `test -d docs/roadmap && echo "OK"`
+    **Step 2: Validate source document freshness.** (Addresses review concern: source pre-validation)
+    Run the following checks and log results:
+    - `ls -la .planning/codebase/*.md` — all 7 files should exist (ARCHITECTURE.md, CONCERNS.md, CONVENTIONS.md, INTEGRATIONS.md, STACK.md, STRUCTURE.md, TESTING.md)
+    - `head -5 CHANGELOG.md` — confirm the first version heading is `## [0.11.0]` (not v0.10.0)
+    - `test -f docs/reference/AI-PROVIDERS.md && echo "OK" || echo "MISSING"` — AI provider reference
+    - `test -f docs/reference/DEPLOY.md && echo "OK" || echo "MISSING"` — deployment reference
+
+    If any source file is missing, STOP and report to the user before proceeding.
+    If CHANGELOG.md does not show v0.11.0 as latest, STOP and report — the critical corrections
+    may need updating.
+
+    **Step 3: Verify directory was created.**
+    Run: `test -d /Users/pleasedodisturb/Projects/kestrel/docs/roadmap && echo "directory exists"`
   </action>
   <verify>
-    <automated>test -d /Users/pleasedodisturb/Projects/kestrel/docs/roadmap && echo "directory exists"</automated>
+    <automated>test -d /Users/pleasedodisturb/Projects/kestrel/docs/roadmap && ls /Users/pleasedodisturb/Projects/kestrel/.planning/codebase/*.md | wc -l | grep -q 7 && echo "OK: directory exists, 7 codebase docs confirmed"</automated>
   </verify>
-  <done>docs/roadmap/ directory exists on disk</done>
+  <acceptance_criteria>
+    - `docs/roadmap/` directory exists on disk
+    - All 7 `.planning/codebase/*.md` files confirmed present
+    - CHANGELOG.md confirmed showing v0.11.0 as latest release
+    - `docs/reference/AI-PROVIDERS.md` and `docs/reference/DEPLOY.md` confirmed present
+  </acceptance_criteria>
+  <done>docs/roadmap/ directory exists and all source documents are validated as present and current</done>
 </task>
 
 <task type="checkpoint:human-verify" gate="blocking">
   <what-built>
-    Task 1 creates the docs/roadmap/ directory. This checkpoint is a lightweight
-    quality gate before the main writing task begins. The inventory content is
-    assembled below — review it before the executor writes the file.
+    Task 1 created the docs/roadmap/ directory and validated all source documents are present.
+    Before the main writing task begins, review the concrete outline below and approve or adjust.
   </what-built>
   <how-to-verify>
-    Confirm you want the executor to write docs/roadmap/inventory.md with:
-    - 8 domain sections in this order: Scoring Engine, Discovery Engine, AI Provider System,
-      Application Pipeline, Web Frontend, CLI & Packaging, Infrastructure, Integrations
-    - Parked Work section (Mobile + Voice)
-    - Opening evolution narrative (2-3 paragraphs, warm teaching tone)
-    - Summary table at top
-    - Warm tone throughout (~150-250 words per domain, 2,000-3,000 words total)
-    - All 9 AI providers listed (including Groq, xAI, OpenAI, Gemini from v0.11.0)
-    - Inline honest gaps (user-impact only — no internal tech debt)
-    - CHANGELOG.md cross-links for each domain
+    (Addresses review concern: concrete outline artifact for checkpoint approval)
 
-    If you want to adjust anything before the write proceeds, now is the time.
+    **Review this outline for the inventory document and approve or adjust:**
+
+    ```
+    # Kestrel Feature Inventory
+    > Subtitle: catalogue through v0.11.0, for job seekers and contributors
+
+    ## At a Glance
+    | 10-row table: 8 domains (Shipped) + Mobile (Parked) + Voice (Parked) |
+    | Columns: Domain | Key Capabilities | Status |
+
+    ## How Kestrel Got Here (evolution narrative, 2-3 paragraphs)
+    - Para 1: CLI scoring tool origin -> v0.1.0 foundation
+    - Para 2: Scoring depth (dual scores, presets, feedback loops) + multi-provider AI (v0.2-v0.5)
+    - Para 3: Cost control + hardening + v0.11.0 (batch scoring, cost presets, 4 new providers, onboarding)
+
+    ## Scoring Engine (~200 words)
+    Prose: brain of Kestrel, scores 0-10, letter grades, learns your preferences
+    Bullets: 14 capabilities (multi-factor scoring through pre-filter)
+    Gap: scoring depends on profile completeness, no score history chart
+    Tags: v0.2.0, v0.4.0, v0.6.0, v0.10.0, v0.11.0
+
+    ## Discovery Engine (~200 words)
+    Prose: finds jobs automatically from multiple boards
+    Bullets: 10 capabilities (multi-board scraping through pre-filter integration)
+    Gap: depends on scrapeable boards, must be running for scheduling
+    Tags: v0.2.0, v0.6.0, v0.7.0, v0.11.0
+
+    ## AI Provider System (~250 words — largest section)
+    Prose: 9 providers, choose by privacy/budget/comfort, cost presets
+    Bullets: 17 capabilities (9 providers + cost presets + PII + cache + privacy registry + MCP)
+    Gap: Mistral not yet shipped, provider choice still requires understanding tradeoffs
+    Tags: v0.3.0, v0.4.0, v0.5.0, v0.8.0, v0.9.0, v0.11.0
+
+    ## Application Pipeline (~200 words)
+    Prose: tracks every job, enforced workflow, reminders
+    Bullets: 13 capabilities (lifecycle through onboarding wizard)
+    Gap: no auto-capture of interview invites, doesn't submit applications
+    Tags: v0.1.0, v0.2.0, v0.4.0, v0.11.0
+
+    ## Web Frontend (~200 words)
+    Prose: React 19 dashboard, 13 pages, visual job search
+    Bullets: 16 items (pages + UI components)
+    Gap: desktop-only layout, no dark mode, no offline mode
+    Tags: v0.1.0, v0.2.0, v0.11.0
+
+    ## CLI & Packaging (~200 words)
+    Prose: terminal interface + multiple distribution channels
+    Bullets: 13 capabilities (CLI through Codespaces)
+    Gap: NO DESKTOP INSTALLER — highest-priority forward milestone
+    Tags: v0.1.0, v0.2.0, v0.6.0, v0.11.0
+
+    ## Infrastructure (~200 words)
+    Prose: engineering foundation — CI, security, privacy, testing
+    Bullets: 15 capabilities (CI through RFC 3339 compliance)
+    Gap: no structured logs, no built-in backup
+    Tags: v0.2.0, v0.3.0, v0.6.0, v0.7.0, v0.10.0, v0.11.0
+
+    ## Integrations (~175 words)
+    Prose: external service connections, credentials stored locally
+    Bullets: 8 capabilities (TickTick through Google Sheets)
+    Gap: Mailgun configured but not wired, no Slack/Discord, TickTick only
+    Tags: v0.3.0, v0.4.0, v0.11.0
+
+    ## Parked Work
+    ### Mobile App — scaffold exists, paused for web v1
+    ### Voice Mode — API + page exist, UNTESTED, needs audit
+    ```
+
+    **Key decisions baked into this outline:**
+    - Domain order: Scoring > Discovery > AI Provider > Pipeline > Frontend > CLI > Infra > Integrations (user-facing impact order)
+    - AI Provider System gets the largest word budget (~250 words) because it has 9 providers + cost presets
+    - CLI & Packaging gap about no desktop installer is the most prominently stated gap (per ROADMAP.md context)
+    - All 9 AI providers listed as shipped and documented (v0.11.0 correction applied)
+
+    If you want to reorder domains, adjust word budgets, add/remove bullet items, or change
+    the gap framing for any section, describe the changes now.
   </how-to-verify>
-  <resume-signal>Type "approved" to proceed, or describe adjustments needed</resume-signal>
+  <resume-signal>Type "approved" to proceed with writing, or describe adjustments needed</resume-signal>
 </task>
 
 <task type="auto">
   <name>Task 2: Write docs/roadmap/inventory.md</name>
   <files>docs/roadmap/inventory.md</files>
   <read_first>
-    Before writing, read these source files to ensure the inventory content is accurate
-    and current. Do NOT rely solely on the research doc — it has known-stale sections
-    (see Critical Corrections above):
+    Read ALL of these source files before writing. (Addresses review concern: expanded source coverage)
 
-    1. `.planning/codebase/ARCHITECTURE.md` — system layers, entry points, AI provider abstraction
-    2. `.planning/codebase/STRUCTURE.md` — module counts, page list, file-level feature verification
-    3. `.planning/codebase/INTEGRATIONS.md` — external services, auth patterns, notification systems
-    4. `.planning/codebase/STACK.md` — framework versions, dependency list
-    5. `CHANGELOG.md` — read the first 100 lines to confirm v0.11.0 release contents
-    6. `docs/reference/AI-PROVIDERS.md` — user-facing provider descriptions
-    7. `docs/reference/DEPLOY.md` — deployment paths and known gaps
+    **Codebase analysis docs (all 7 — read each one):**
+    1. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/ARCHITECTURE.md` — system layers, entry points, AI provider abstraction, data flow
+    2. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/STRUCTURE.md` — module counts, page list, file-level feature verification
+    3. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/INTEGRATIONS.md` — external services, auth patterns, notification systems
+    4. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/STACK.md` — framework versions, dependency list
+    5. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/TESTING.md` — test infrastructure, markers, coverage
+    6. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/CONVENTIONS.md` — code style, naming, commit patterns (for voice on naming/terminology)
+    7. `/Users/pleasedodisturb/Projects/kestrel/.planning/codebase/CONCERNS.md` — known issues (read ONLY to understand which gaps are internal vs. user-facing; do NOT include internal tech debt in inventory per D-10)
+
+    **Release history and reference docs:**
+    8. `/Users/pleasedodisturb/Projects/kestrel/CHANGELOG.md` — read fully; confirm v0.11.0 contents match critical corrections
+    9. `/Users/pleasedodisturb/Projects/kestrel/docs/reference/AI-PROVIDERS.md` — user-facing provider descriptions
+    10. `/Users/pleasedodisturb/Projects/kestrel/docs/reference/DEPLOY.md` — deployment paths and known gaps
   </read_first>
   <action>
     Write docs/roadmap/inventory.md using the structure and content specified below.
@@ -218,7 +353,7 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
 
     | Domain | Key Capabilities | Status |
     |--------|-----------------|--------|
-    | Scoring Engine | AI scoring, letter grades (A+–F), red flags, feedback loops, 288 presets, dual fit/desire scores | Shipped |
+    | Scoring Engine | AI scoring, letter grades (A+--F), red flags, feedback loops, 288 presets, dual fit/desire scores | Shipped |
     | Discovery Engine | Multi-board job scraping, auto-schedule, deduplication, WARN Act data | Shipped |
     | AI Provider System | 9 providers (Mock through Gemini), cost presets, PII masking, encrypted cache, privacy registry | Shipped |
     | Application Pipeline | Kanban stages, state machine, contacts, interview prep, STAR stories, gap analysis | Shipped |
@@ -263,6 +398,7 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
 
     Use your own words for the actual prose — this is a content brief, not a script. The tone
     should feel like a knowledgeable friend explaining the product, not a press release.
+    Refer to the tone guide above for calibration.
 
     ---
 
@@ -281,13 +417,13 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
     - D-07: ~150-250 words per domain section total (prose + bullets)
     - D-08: Release tags only — NO file paths, API routes, or architecture details
     - D-09: Inline honest assessment — gaps in prose, not a separate section
-    - D-10: User-impact gaps ONLY — skip internal tech debt (no scoring monolith, no pip lockfile,
-      no sync clients)
+    - D-10: User-impact gaps ONLY — skip internal tech debt. See the gap examples section
+      above for concrete examples of what to include vs. exclude.
 
     ### Domain 1: Scoring Engine
 
     **User-facing description to convey in prose:** The scoring engine is the brain of Kestrel —
-    it reads job descriptions and your profile, then returns a score from 0–10 with a letter
+    it reads job descriptions and your profile, then returns a score from 0-10 with a letter
     grade (A+ through F), a breakdown by dimension, and a list of red flags. The more you use
     it and correct its mistakes, the better it learns what you actually want.
 
@@ -391,7 +527,7 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
     approachable for new users out of the box.
 
     **Bullets to include:**
-    - Full application lifecycle: Discovered → Interested → Applied → Interviewing → Offer → Accepted/Rejected/Ghosted
+    - Full application lifecycle: Discovered -> Interested -> Applied -> Interviewing -> Offer -> Accepted/Rejected/Ghosted
     - Enforced state transitions: can't accidentally skip stages
     - Activity log: every status change and manual note timestamped automatically
     - Follow-up reminders with configurable timing
@@ -461,7 +597,7 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
     - npm wrapper package for `npx kestrel` install path
     - curl one-liner installer
     - PyPI distribution as `kestrel-app` (`pip install kestrel-app`)
-    - Docker multi-stage build: Node 22 Alpine (frontend build) → Python 3.11 slim (runtime)
+    - Docker multi-stage build: Node 22 Alpine (frontend build) -> Python 3.11 slim (runtime)
     - `docker compose up` for local development (two containers, hot-reload)
     - `docker compose -f docker-compose.prod.yml up` for single-container production
     - Deploy to Railway, Fly.io, or any VPS with included configs
@@ -529,7 +665,7 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
     - Calendar export: iCal (.ics files), Google Calendar URL generation, Fantastical URL scheme
     - Integration management UI: connect/disconnect services, test connections, view credential status
     - OpenRouter OAuth PKCE: click "Connect" in Settings to provision your API key without manual copy/paste
-    - Cloudflare Worker for bi-directional Linear↔TickTick sync and calendar feed generation
+    - Cloudflare Worker for bi-directional Linear<->TickTick sync and calendar feed generation
     - Google Sheets daily scan logging (optional)
 
     **Honest gaps to weave in:** Mailgun email notifications are configured (env vars exist)
@@ -569,32 +705,104 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
 
     ---
 
-    ## FINAL PROSE QUALITY CHECKS
+    ## FINAL QUALITY PASSES
 
-    Before writing, internalize these tone guidelines (D-05):
-    - Write for a job seeker, not a developer
-    - "The scoring engine learns what kinds of jobs you actually want" not "multi-factor rubric with 288 presets"
-    - Explain WHY each capability matters to their job search, not WHAT it is technically
-    - Honest gaps should read as useful information, not apologies
-    - Avoid: "leverages", "robust", "seamlessly", "state-of-the-art"
+    After writing the complete document, perform these three passes before saving:
 
-    Target length: 2,000–3,000 words total for the whole document (per D-07).
+    **Pass 1: Public-audience scrub (addresses review concern: architecture leakage)**
+    Scan the entire document for any of these — remove or rephrase if found:
+    - Internal file paths (e.g., `src/career_os/`, `api/voice.py`, `frontend/src/pages/`)
+    - API route patterns (e.g., `/api/scoring`, `GET /api/presets`)
+    - Architecture terminology (e.g., "ORM", "middleware", "dependency injection", "decorator")
+    - Internal function or class names
+    - The only acceptable code-like text is the `kestrel` CLI command name and `pip install kestrel-app`
+
+    **Pass 2: Decision-consistency checklist (addresses review concern: decision adherence)**
+    Verify each of these locked decisions is satisfied:
+    - D-01: 8 domain clusters present as section headings
+    - D-02: Mobile and Voice in Parked Work section, NOT in shipped domains
+    - D-05: Warm teaching tone — no developer jargon
+    - D-07: Each domain ~150-250 words; total ~2,000-3,000 words
+    - D-08: Release tags only — no file paths or API routes
+    - D-09: Gaps woven into prose, no separate "Gaps" or "Known Issues" heading
+    - D-10: Only user-impact gaps (not internal tech debt)
+    - D-13: Summary table at the top
+    - D-14: Each domain has CHANGELOG.md cross-links
+
+    **Pass 3: Coverage spot-check**
+    Verify these specific items are present (most likely to be missed):
+    - All 9 AI providers named
+    - Cost presets (Free/Budget/Quality/Private/Custom) mentioned
+    - Onboarding wizard mentioned
+    - No-desktop-installer gap stated clearly in CLI & Packaging
+    - Voice mode framed as "untested, needs audit" not as shipped
+    - Mailgun "configured but not wired" noted in Integrations
+
+    Target length: 2,000-3,000 words total for the whole document (per D-07).
     Each domain section should be ~150-250 words total (prose + bullets).
   </action>
   <verify>
-    <automated>MISSING — this is a documentation phase with no automated test framework. Use the manual checklist below.</automated>
-    Manual verification checklist:
-    1. `test -f docs/roadmap/inventory.md && echo "file exists"` — file was created
-    2. `wc -w docs/roadmap/inventory.md` — word count should be 1,800–3,500 (markdown overhead included)
-    3. `grep -c "^## " docs/roadmap/inventory.md` — should be 10 or 11 (8 domains + Parked Work + At a Glance)
-    4. `grep "## Parked Work" docs/roadmap/inventory.md` — Parked Work section exists
-    5. `grep "Untested" docs/roadmap/inventory.md` — Voice mode is framed as untested
-    6. `grep -c "CHANGELOG.md#" docs/roadmap/inventory.md` — at least 8 CHANGELOG links (one per domain)
-    7. `grep "## AI Provider System\|## Scoring Engine\|## Discovery Engine\|## Application Pipeline\|## Web Frontend\|## CLI & Packaging\|## Infrastructure\|## Integrations" docs/roadmap/inventory.md | wc -l` — should be 8
-    8. Read the "Parked Work" section — confirm Mobile says "paused" and Voice says "untested, needs audit"
-    9. Read the opening narrative — confirm it covers CLI-tool origin through v0.11.0 hardening
-    10. Read the CLI & Packaging domain — confirm no-desktop-installer gap is clearly stated
+    <automated>
+      cd /Users/pleasedodisturb/Projects/kestrel && \
+      echo "=== File exists ===" && test -f docs/roadmap/inventory.md && echo "YES" && \
+      echo "=== Word count ===" && wc -w docs/roadmap/inventory.md && \
+      echo "=== H2 section count ===" && grep -c "^## " docs/roadmap/inventory.md && \
+      echo "=== All 8 domain headings present ===" && \
+      for domain in "Scoring Engine" "Discovery Engine" "AI Provider System" "Application Pipeline" "Web Frontend" "CLI & Packaging" "Infrastructure" "Integrations"; do \
+        grep -q "## $domain" docs/roadmap/inventory.md && echo "  FOUND: $domain" || echo "  MISSING: $domain"; \
+      done && \
+      echo "=== Parked Work ===" && grep -c "## Parked Work" docs/roadmap/inventory.md && \
+      echo "=== Voice untested ===" && grep -ci "untested" docs/roadmap/inventory.md && \
+      echo "=== CHANGELOG links ===" && grep -c "CHANGELOG.md#" docs/roadmap/inventory.md && \
+      echo "=== At a Glance table ===" && grep -c "## At a Glance" docs/roadmap/inventory.md && \
+      echo "=== No file paths leaked ===" && grep -c "src/career_os" docs/roadmap/inventory.md | grep -q "^0$" && echo "CLEAN" || echo "LEAK DETECTED" && \
+      echo "=== No API routes leaked ===" && grep -c "/api/" docs/roadmap/inventory.md | grep -q "^0$" && echo "CLEAN" || echo "LEAK DETECTED"
+    </automated>
+
+    **Expected results:**
+    - File exists: YES
+    - Word count: 1,800-3,500 (markdown overhead included beyond the 2,000-3,000 prose target)
+    - H2 section count: >= 10 (At a Glance + 8 domains + Parked Work, possibly evolution narrative)
+    - All 8 domain headings: FOUND for each
+    - Parked Work: 1
+    - Voice "untested": >= 1
+    - CHANGELOG links: >= 8 (at least one per domain)
+    - At a Glance table: 1
+    - No file paths: CLEAN
+    - No API routes: CLEAN
+
+    **Manual verification (10 items — read once, check all):**
+    1. Opening narrative covers CLI-tool origin through v0.11.0 hardening in 2-3 paragraphs
+    2. Warm teaching tone throughout — explains WHY not just WHAT for a job seeker
+    3. All 9 AI providers named in AI Provider System domain
+    4. Cost presets (Free/Budget/Quality/Private/Custom) mentioned
+    5. Onboarding wizard mentioned in Application Pipeline
+    6. No-desktop-installer gap clearly stated in CLI & Packaging
+    7. Mailgun "configured but not wired" noted in Integrations
+    8. Mobile says "paused" in Parked Work
+    9. Voice says "untested, needs audit" in Parked Work (NOT described as shipped)
+    10. No internal tech debt items (scoring monolith, pip lockfile, sync clients) present anywhere
   </verify>
+  <acceptance_criteria>
+    - `test -f docs/roadmap/inventory.md` exits 0
+    - `wc -w docs/roadmap/inventory.md` reports between 1800 and 3500 words
+    - `grep -c "^## " docs/roadmap/inventory.md` returns >= 10
+    - `grep "## Scoring Engine" docs/roadmap/inventory.md` matches
+    - `grep "## Discovery Engine" docs/roadmap/inventory.md` matches
+    - `grep "## AI Provider System" docs/roadmap/inventory.md` matches
+    - `grep "## Application Pipeline" docs/roadmap/inventory.md` matches
+    - `grep "## Web Frontend" docs/roadmap/inventory.md` matches
+    - `grep "## CLI & Packaging" docs/roadmap/inventory.md` matches
+    - `grep "## Infrastructure" docs/roadmap/inventory.md` matches
+    - `grep "## Integrations" docs/roadmap/inventory.md` matches
+    - `grep "## Parked Work" docs/roadmap/inventory.md` matches
+    - `grep "## At a Glance" docs/roadmap/inventory.md` matches
+    - `grep -ci "untested" docs/roadmap/inventory.md` returns >= 1
+    - `grep -c "CHANGELOG.md#" docs/roadmap/inventory.md` returns >= 8
+    - `grep -c "src/career_os" docs/roadmap/inventory.md` returns 0 (no file path leakage)
+    - `grep "Groq" docs/roadmap/inventory.md` matches (v0.11.0 provider present)
+    - `grep "Cost presets\|cost presets" docs/roadmap/inventory.md` matches
+  </acceptance_criteria>
   <done>
     docs/roadmap/inventory.md exists with:
     - Opening evolution narrative of 2-3 paragraphs covering CLI-tool origin through v0.11.0
@@ -603,9 +811,11 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
     - Parked Work section with Mobile (paused) and Voice (untested) subsections
     - All 9 AI providers listed in AI Provider System domain (including v0.11.0 additions)
     - Honest user-facing gaps woven inline into domain prose (no separate "Gaps" heading)
-    - Total word count approximately 2,000–3,000 words
+    - Total word count approximately 2,000-3,000 words
     - Warm teaching tone throughout — written for job seekers, not developers
     - No file paths, API routes, or internal architecture details (per D-08)
+    - Zero internal tech debt items (per D-10)
+    - Cost presets, onboarding wizard, and all v0.11.0 features reflected
   </done>
 </task>
 
@@ -616,43 +826,59 @@ Do NOT use `#v030` or `#0-3-0`. Use the format above.
 
 | Boundary | Description |
 |----------|-------------|
-| Inventory content → public GitHub | This document will be publicly visible; any internal paths, personal data, or non-public information included accidentally would be a disclosure |
-| Source docs → inventory claims | The executor translates internal codebase analysis docs into public-facing prose; hallucinated or unverified feature claims damage credibility |
+| Inventory content -> public GitHub | This document will be publicly visible; any internal paths, personal data, or non-public information included accidentally would be a disclosure |
+| Source docs -> inventory claims | The executor translates internal codebase analysis docs into public-facing prose; hallucinated or unverified feature claims damage credibility |
 
 ## STRIDE Threat Register
 
 | Threat ID | Category | Component | Disposition | Mitigation Plan |
 |-----------|----------|-----------|-------------|-----------------|
-| T-01-01 | Information Disclosure | inventory.md content | mitigate | Do not include internal file paths, API routes, database schema details, or architecture-layer terminology; D-08 explicitly forbids this. The read_first list includes CONCERNS.md for gap awareness only — none of its internal tech debt content should appear in the output. |
+| T-01-01 | Information Disclosure | inventory.md content | mitigate | Do not include internal file paths, API routes, database schema details, or architecture-layer terminology; D-08 explicitly forbids this. Task 2 includes a public-audience scrub pass (Pass 1). The read_first list includes CONCERNS.md for gap awareness only — none of its internal tech debt content should appear in the output. |
 | T-01-02 | Information Disclosure | CHANGELOG.md anchor links | accept | CHANGELOG.md is a public file in the repo; linking to it discloses nothing non-public. Low risk. |
-| T-01-03 | Spoofing (accuracy) | Feature claims in inventory | mitigate | Every capability listed must be cross-referenced against at least one source doc (ARCHITECTURE.md, STRUCTURE.md, INTEGRATIONS.md, or CHANGELOG.md). The research doc's known-stale sections are called out in Critical Corrections — executor must not use the stale Groq/xAI/OpenAI/Gemini framing. |
-| T-01-04 | Repudiation (false claims) | Voice mode framing | mitigate | Voice mode MUST be framed as "untested, needs audit" not as a shipped feature. This is a factual accuracy requirement, not an editorial choice. Claiming a broken/untested feature as shipped damages user trust. |
+| T-01-03 | Spoofing (accuracy) | Feature claims in inventory | mitigate | Every capability listed must be cross-referenced against at least one of the 10 source documents in read_first. The research doc's known-stale sections are called out in Critical Corrections. Task 2 includes a coverage spot-check pass (Pass 3). Task 1 validates source freshness before writing begins. |
+| T-01-04 | Repudiation (false claims) | Voice mode framing | mitigate | Voice mode MUST be framed as "untested, needs audit" not as a shipped feature. This is a factual accuracy requirement, not an editorial choice. Verification checks for "untested" keyword presence. |
 | T-01-05 | Information Disclosure | Private project docs | mitigate | The docs/research/ and private/ directories contain business strategy, competitive intel, and non-public research. None of this should be referenced or quoted in inventory.md. Source docs are limited to .planning/codebase/, CHANGELOG.md, docs/reference/, and pyproject.toml. |
 </threat_model>
 
 <verification>
-Phase 1 is complete when:
+Phase 1 is complete when ALL of these pass:
 
+**Automated checks (run as a single script):**
 1. `test -f docs/roadmap/inventory.md` exits 0
-2. `grep -c "^## " docs/roadmap/inventory.md` returns >= 10 (summary table + 8 domains + Parked Work)
-3. `grep "## Parked Work" docs/roadmap/inventory.md` matches
-4. `grep "Untested\|untested" docs/roadmap/inventory.md` matches (Voice mode framing)
+2. `wc -w docs/roadmap/inventory.md` shows between 1,800 and 3,500 words (upper bound enforced)
+3. Each of these exact headings present (grep for each):
+   - `## At a Glance`
+   - `## Scoring Engine`
+   - `## Discovery Engine`
+   - `## AI Provider System`
+   - `## Application Pipeline`
+   - `## Web Frontend`
+   - `## CLI & Packaging`
+   - `## Infrastructure`
+   - `## Integrations`
+   - `## Parked Work`
+4. `grep -ci "untested" docs/roadmap/inventory.md` returns >= 1 (Voice mode framing)
 5. `grep -c "CHANGELOG.md#" docs/roadmap/inventory.md` returns >= 8
-6. `wc -w docs/roadmap/inventory.md` shows >= 1,500 words
-7. Manual read confirms:
-   - Warm teaching tone throughout (no developer jargon, explains WHY not just WHAT)
-   - All 9 AI providers mentioned in AI Provider System domain
-   - Cost presets (Free/Budget/Quality/Private/Custom) mentioned
-   - Onboarding wizard mentioned in Application Pipeline
-   - No-desktop-installer gap called out in CLI & Packaging
-   - Mailgun "configured but not wired" noted in Integrations
-   - Evolution narrative spans CLI tool through v0.11.0 hardening
+6. `grep -c "src/career_os" docs/roadmap/inventory.md` returns 0 (no file path leakage)
+7. `grep -c "/api/" docs/roadmap/inventory.md` returns 0 (no API route leakage)
+
+**Manual verification (single read-through):**
+8. Warm teaching tone throughout — no developer jargon, explains WHY not just WHAT
+9. All 9 AI providers named in AI Provider System domain
+10. Cost presets (Free/Budget/Quality/Private/Custom) mentioned
+11. Onboarding wizard mentioned in Application Pipeline
+12. No-desktop-installer gap clearly stated in CLI & Packaging
+13. Mailgun "configured but not wired" noted in Integrations
+14. Evolution narrative spans CLI tool through v0.11.0 hardening in 2-3 paragraphs
+15. Mobile says "paused" and Voice says "untested, needs audit" in Parked Work
+16. No internal tech debt items present (scoring monolith, pip lockfile, sync clients, frontend type drift)
 </verification>
 
 <success_criteria>
 - docs/roadmap/ directory exists
-- docs/roadmap/inventory.md exists with approximately 2,000–3,000 words
-- 8 domain sections present, all with warm prose + bullets + CHANGELOG cross-links
+- docs/roadmap/inventory.md exists with approximately 2,000-3,000 words (upper bound: 3,500 with markdown overhead)
+- 10 exact H2 headings present: At a Glance, 8 domains, Parked Work
+- Each domain has warm prose + bullets + CHANGELOG cross-links
 - Parked Work section present with Mobile (paused) and Voice (untested) correctly framed
 - All 9 AI providers listed, including v0.11.0 additions (Groq, OpenAI, xAI, Gemini)
 - v0.11.0 features reflected: cost presets, batch scoring, onboarding wizard, pre-filter integration


### PR DESCRIPTION
## Summary

Heredoc terminators (`BODY`) were indented inside YAML `run:` blocks — bash requires them at column 0. Replaced with inline multiline strings. This was causing the release gate to crash on auto-reject and auto-merge comment steps.

## Test plan

- [ ] Release gate workflow runs without shell errors
- [ ] PR #302 auto-merges on next evaluation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)