### PR TITLE
feat(G-394): make kestrel the primary CLI entry point

### DIFF
--- a/docs/reference/validation-contract-m2-skills.md
+++ b/docs/reference/validation-contract-m2-skills.md
@@ -149,24 +149,24 @@ When a user completes learning items or achieves goals, the coaching suggestions
 ## CLI Commands
 
 ### VAL-CLI-SKILL-001: List skills via CLI
-`career skills list` outputs the full skills inventory in a formatted table with columns: Name, Category, Proficiency, Source. Supports `--category technical` and `--source cv.yaml` filters.
-**Evidence:** Running `career skills list --category technical` prints a table containing only technical skills; exit code 0.
+`kestrel skills list` outputs the full skills inventory in a formatted table with columns: Name, Category, Proficiency, Source. Supports `--category technical` and `--source cv.yaml` filters.
+**Evidence:** Running `kestrel skills list --category technical` prints a table containing only technical skills; exit code 0.
 
 ### VAL-CLI-SKILL-002: Gap analysis via CLI
-`career skills gaps --application <id>` outputs the gap report for a specific application: skill name, required level, current level, severity, distance. Supports `--severity critical` to filter.
-**Evidence:** Running `career skills gaps --application 1 --severity critical` prints only critical gaps; exit code 0.
+`kestrel skills gaps --application <id>` outputs the gap report for a specific application: skill name, required level, current level, severity, distance. Supports `--severity critical` to filter.
+**Evidence:** Running `kestrel skills gaps --application 1 --severity critical` prints only critical gaps; exit code 0.
 
 ### VAL-CLI-SKILL-003: Career goals via CLI
-`career goals` lists all active goals with title, type, target date, and overall progress percentage. `career goals show <id>` displays the full reality map for a specific goal.
-**Evidence:** Running `career goals` prints a goals table; `career goals show 1` prints the reality map with current vs. required state; exit code 0.
+`kestrel goals` lists all active goals with title, type, target date, and overall progress percentage. `kestrel goals show <id>` displays the full reality map for a specific goal.
+**Evidence:** Running `kestrel goals` prints a goals table; `kestrel goals show 1` prints the reality map with current vs. required state; exit code 0.
 
 ### VAL-CLI-SKILL-004: Coaching via CLI
-`career coach` outputs the top 5 coaching suggestions with effort estimates. `career coach --all` shows the full list.
-**Evidence:** Running `career coach` prints 5 prioritized suggestions with effort hours; exit code 0.
+`kestrel coach` outputs the top 5 coaching suggestions with effort estimates. `kestrel coach --all` shows the full list.
+**Evidence:** Running `kestrel coach` prints 5 prioritized suggestions with effort hours; exit code 0.
 
 ### VAL-CLI-SKILL-005: Aggregate gaps via CLI
-`career skills gaps --aggregate` outputs the cross-application gap summary: most common missing skills ranked by frequency and severity.
-**Evidence:** Running `career skills gaps --aggregate` prints a ranked table of skills appearing as gaps across applications; exit code 0.
+`kestrel skills gaps --aggregate` outputs the cross-application gap summary: most common missing skills ranked by frequency and severity.
+**Evidence:** Running `kestrel skills gaps --aggregate` prints a ranked table of skills appearing as gaps across applications; exit code 0.
 
 ---
 

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -1,4 +1,4 @@
-"""Career OS CLI — main entry point."""
+"""Kestrel CLI — main entry point."""
 
 from __future__ import annotations
 
@@ -28,8 +28,8 @@ console = Console()
 _HELP_OUTPUT_FORMAT = "Output format: table or json"
 
 app = typer.Typer(
-    name="career",
-    help="Career OS — AI-Powered Job Search & Career Strategy Platform",
+    name="kestrel",
+    help="Kestrel — AI-Powered Job Search & Career Strategy Platform",
     no_args_is_help=True,
 )
 
@@ -89,7 +89,7 @@ goals_app = typer.Typer(
 app.add_typer(goals_app, name="goals")
 
 # Interview-prep subcommand group (uses Click Group to handle both
-# `career interview-prep <id>` and `career interview-prep stories <subcmd>`)
+# `kestrel interview-prep <id>` and `kestrel interview-prep stories <subcmd>`)
 
 
 class InterviewPrepGroup(typer_core.TyperGroup):
@@ -149,7 +149,7 @@ def _get_default_profile(db: Session) -> Profile:
 
 
 # ---------------------------------------------------------------------------
-# career pipeline list
+# kestrel pipeline list
 # ---------------------------------------------------------------------------
 
 
@@ -223,7 +223,7 @@ def pipeline_list(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline add
+# kestrel pipeline add
 # ---------------------------------------------------------------------------
 
 
@@ -271,7 +271,7 @@ def pipeline_add(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline update
+# kestrel pipeline update
 # ---------------------------------------------------------------------------
 
 
@@ -373,7 +373,7 @@ def pipeline_update(
 
 
 # ---------------------------------------------------------------------------
-# career pipeline stats
+# kestrel pipeline stats
 # ---------------------------------------------------------------------------
 
 
@@ -464,7 +464,7 @@ def pipeline_stats() -> None:
 
 
 # ---------------------------------------------------------------------------
-# career pipeline follow-ups
+# kestrel pipeline follow-ups
 # ---------------------------------------------------------------------------
 
 
@@ -530,7 +530,7 @@ def pipeline_follow_ups() -> None:
 
 
 # ---------------------------------------------------------------------------
-# career skills list
+# kestrel skills list
 # ---------------------------------------------------------------------------
 
 
@@ -596,7 +596,7 @@ def skills_list(
 
 
 # ---------------------------------------------------------------------------
-# career skills gaps
+# kestrel skills gaps
 # ---------------------------------------------------------------------------
 
 
@@ -780,7 +780,7 @@ def _show_aggregate_gaps(db: Session, profile_id: int, aggregate_fn) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career goals (list + show)
+# kestrel goals (list + show)
 # ---------------------------------------------------------------------------
 
 
@@ -912,7 +912,7 @@ def goals_show(
 
 
 # ---------------------------------------------------------------------------
-# career coach
+# kestrel coach
 # ---------------------------------------------------------------------------
 
 
@@ -1042,7 +1042,7 @@ def _is_valid_url(url: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# career discover
+# kestrel discover
 # ---------------------------------------------------------------------------
 
 
@@ -1266,7 +1266,7 @@ def _handle_schedule(
 
 
 # ---------------------------------------------------------------------------
-# career score <url>
+# kestrel score <url>
 # ---------------------------------------------------------------------------
 
 
@@ -1480,7 +1480,7 @@ def _score_output_json(scored) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career market
+# kestrel market
 # ---------------------------------------------------------------------------
 
 
@@ -1521,7 +1521,7 @@ def market(
         if not has_data:
             console.print(
                 "[yellow]No market data available. "
-                "Run `career discover` first to populate market intelligence.[/yellow]"
+                "Run `kestrel discover` first to populate market intelligence.[/yellow]"
             )
             return
 
@@ -1719,7 +1719,7 @@ def _run_interview_prep_async(
 
 
 # ---------------------------------------------------------------------------
-# career research <company>
+# kestrel research <company>
 # ---------------------------------------------------------------------------
 
 
@@ -1869,7 +1869,7 @@ def _render_research_report(report) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career interview-prep <application_id> (default command)
+# kestrel interview-prep <application_id> (default command)
 # ---------------------------------------------------------------------------
 
 
@@ -2018,7 +2018,7 @@ def _render_interview_prep(prep) -> None:
 
 
 # ---------------------------------------------------------------------------
-# career interview-prep stories (list / add / view / edit)
+# kestrel interview-prep stories (list / add / view / edit)
 # ---------------------------------------------------------------------------
 
 
@@ -2054,7 +2054,7 @@ def stories_list_default(ctx: typer.Context) -> None:
         if not stories:
             console.print(
                 "[yellow]No STAR stories yet. "
-                "Add one with: career interview-prep stories add[/yellow]"
+                "Add one with: kestrel interview-prep stories add[/yellow]"
             )
             return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,10 +44,10 @@ def db_session(monkeypatch, tmp_path):
 
 
 def test_career_help() -> None:
-    """career --help exits 0 and shows help text."""
+    """kestrel --help exits 0 and shows help text."""
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "Career OS" in result.output
+    assert "Kestrel" in result.output
 
 
 def test_pipeline_subcommand_present() -> None:


### PR DESCRIPTION
## Summary

- CLI app name: `career` → `kestrel` (help text, comments, user-facing strings)
- `career` entry point kept as backwards-compatible alias in pyproject.toml
- Updated docs and test assertions to reference `kestrel`

No Python package rename — `career_os` stays as-is.

## Test plan

- [ ] `kestrel --help` shows "Kestrel" not "Career OS"
- [ ] `career --help` still works (alias)
- [ ] test_cli.py passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)