### PR TITLE
fix(G-496): wire observability spans into cache and PII masking layers

### DIFF
--- a/src/career_os/ai/cache.py
+++ b/src/career_os/ai/cache.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet, InvalidToken
 
 from career_os.ai.base import AIProvider, ComplexityTier
+from career_os.ai.observability import update_current_span
 from career_os.schemas.ai import AIFeature, AIResponse
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,7 @@ class CachedProvider(AIProvider):
         if cached is not None:
             self._hits += 1
             cached.usage = None  # No tokens consumed on cache hit
+            update_current_span(metadata={"cache": "hit"})
             return cached
 
         self._misses += 1
@@ -145,6 +147,7 @@ class CachedProvider(AIProvider):
             prompt, feature=feature, context=context, tier=tier, **kwargs
         )
         await asyncio.to_thread(self._put, key, response, feature.value)
+        update_current_span(metadata={"cache": "miss"})
         return response
 
     async def score(
@@ -161,11 +164,13 @@ class CachedProvider(AIProvider):
         if cached is not None:
             self._hits += 1
             cached.usage = None  # No tokens consumed on cache hit
+            update_current_span(metadata={"cache": "hit"})
             return cached
 
         self._misses += 1
         response = await self._inner.score(job_description, profile_data, tier=tier, **kwargs)
         await asyncio.to_thread(self._put, key, response, feature.value)
+        update_current_span(metadata={"cache": "miss"})
         return response
 
     # ------------------------------------------------------------------

--- a/src/career_os/ai/pii_masking.py
+++ b/src/career_os/ai/pii_masking.py
@@ -157,9 +157,7 @@ class MaskedProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         masked_prompt, mapping = self._masker.mask(prompt)
-        update_current_span(
-            metadata={"pii_detections": len(mapping.placeholder_to_original)}
-        )
+        update_current_span(metadata={"pii_detections": len(mapping.placeholder_to_original)})
         response = await self._inner.complete(
             masked_prompt, feature=feature, context=context, tier=tier, **kwargs
         )
@@ -184,9 +182,7 @@ class MaskedProvider(AIProvider):
         combined.placeholder_to_original.update(jd_mapping.placeholder_to_original)
         combined.placeholder_to_original.update(profile_mapping.placeholder_to_original)
 
-        update_current_span(
-            metadata={"pii_detections": len(combined.placeholder_to_original)}
-        )
+        update_current_span(metadata={"pii_detections": len(combined.placeholder_to_original)})
         response = await self._inner.score(masked_jd, masked_profile, tier=tier, **kwargs)
         return self._unmask_response(response, combined)
 

--- a/src/career_os/ai/pii_masking.py
+++ b/src/career_os/ai/pii_masking.py
@@ -20,6 +20,7 @@ import re
 from dataclasses import dataclass, field
 
 from career_os.ai.base import AIProvider, ComplexityTier
+from career_os.ai.observability import update_current_span
 from career_os.schemas.ai import AIFeature, AIResponse
 
 # ---------------------------------------------------------------------------
@@ -156,6 +157,9 @@ class MaskedProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         masked_prompt, mapping = self._masker.mask(prompt)
+        update_current_span(
+            metadata={"pii_detections": len(mapping.placeholder_to_original)}
+        )
         response = await self._inner.complete(
             masked_prompt, feature=feature, context=context, tier=tier, **kwargs
         )
@@ -180,6 +184,9 @@ class MaskedProvider(AIProvider):
         combined.placeholder_to_original.update(jd_mapping.placeholder_to_original)
         combined.placeholder_to_original.update(profile_mapping.placeholder_to_original)
 
+        update_current_span(
+            metadata={"pii_detections": len(combined.placeholder_to_original)}
+        )
         response = await self._inner.score(masked_jd, masked_profile, tier=tier, **kwargs)
         return self._unmask_response(response, combined)
 


### PR DESCRIPTION
## Summary
- Import `update_current_span` from `career_os.ai.observability` into `cache.py` and `pii_masking.py`
- Emit `cache: hit/miss` metadata in `CachedProvider.complete()` and `CachedProvider.score()`
- Emit `pii_detections: N` metadata in `MaskedProvider.complete()` and `MaskedProvider.score()`

Fixes 4 failing tests in `test_observability.py` — the observability module existed but was never wired into the cache and PII layers.

## Test plan
- [ ] `pytest tests/test_observability.py -v` — all 21 pass
- [ ] No regressions in full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)