### PR TITLE
fix(G-498): update stale test assertions for X-Title and batch prompt

### DIFF
--- a/tests/test_ai_cost_tracking.py
+++ b/tests/test_ai_cost_tracking.py
@@ -124,7 +124,7 @@ class TestOpenRouterXTitle:
 
     @pytest.mark.asyncio
     async def test_x_title_header_is_kestrel(self) -> None:
-        """X-Title header should be 'kestrel' for cost attribution."""
+        """X-Title header should be 'Career OS' for cost attribution."""
         from unittest.mock import patch
 
         import httpx
@@ -149,4 +149,4 @@ class TestOpenRouterXTitle:
         with patch("httpx.AsyncClient.post", side_effect=mock_post):
             await provider.complete("test", feature=AIFeature.complete)
 
-        assert captured_headers.get("X-Title") == "kestrel"
+        assert captured_headers.get("X-Title") == "Career OS"

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -105,7 +105,9 @@ class TestBatchScore:
         assert len(req["params"]["messages"]) == 1
         assert req["params"]["messages"][0]["role"] == "user"
         assert "Software Engineer at Acme Corp" in req["params"]["messages"][0]["content"]
-        assert "Jane Doe" in req["params"]["messages"][0]["content"]
+        # Profile data is in the system prompt (cache_control block), not the user message
+        system_text = req["params"]["system"][0]["text"]
+        assert "Jane Doe" in system_text
 
     @pytest.mark.asyncio
     async def test_sends_to_batch_api_endpoint(self) -> None:


### PR DESCRIPTION
## Summary
- Update X-Title assertion from `"kestrel"` to `"Career OS"` in `test_ai_cost_tracking.py`
- Fix batch prompt assertion in `test_batch_api.py` — profile data is in system prompt block, not user message
- xAI privacy warning tests already pass (were environment-specific failures)

Fixes 2 failing tests (2 others were already passing).

## Test plan
- [ ] `pytest tests/test_ai_cost_tracking.py::TestOpenRouterXTitle -v` — passes
- [ ] `pytest tests/test_batch_api.py::TestBatchScore::test_builds_correct_request_payload -v` — passes
- [ ] No regressions in full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)