### PR TITLE
chore: add .cache_key to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ GSD-CLAUDE.md
 
 # Internal business docs
 docs/pricing-strategy.md
+.cache_key


### PR DESCRIPTION
Session cleanup — generated hash file shouldn't be in public repo.