### PR TITLE
docs(G-464): relocate 'How we build' to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,22 @@ If you add a new AI provider:
 4. Update the mock provider to support any new features
 5. Add tests
 
+## How we build
+
+Every major decision — scoring, testing, CI/CD, token optimization — starts with research. We run parallel research passes, write up findings, then pick the sanest approach (not the fanciest).
+
+The research is public. If you're wondering *why* something works the way it does, the answer is probably in one of these:
+
+| Topic | Guide | Research | Raw data |
+|-------|-------|----------|----------|
+| Scoring | [How it works](docs/guides/how-scoring-works.md) | [Strategy](docs/research/scoring-research.md) | [Findings](docs/research/scoring-raw-research.md) |
+| Testing | [How it works](docs/guides/how-testing-works.md) | [Strategy](docs/research/testing-research.md) | [Findings](docs/research/testing-raw-research.md) |
+| CI/CD | [How it works](docs/guides/how-cicd-works.md) | [Strategy](docs/research/cicd-research.md) | [Findings](docs/research/cicd-raw-research.md) |
+| Observability | [How it works](docs/guides/how-observability-works.md) | [Strategy](docs/research/observability-research.md) | [Setup](docs/reference/observability-setup.md) |
+| Token costs | [How it works](docs/guides/how-token-optimization-works.md) | [Strategy](docs/research/token-optimization-research.md) | [Findings](docs/research/token-optimization-raw-research.md) |
+
+[Full documentation index →](docs/index.md)
+
 ## Questions?
 
 Open an issue on GitHub.


### PR DESCRIPTION
## Summary

- Moves the "How we build" research methodology table from README (removed in #323) to CONTRIBUTING.md
- Rewritten tighter — 2 sentences of context + the research links table + docs index link
- Lives between "AI Provider Changes" and "Questions?" in CONTRIBUTING.md

The content wasn't deleted, just relocated to where developers will actually find it.

## Test plan

- [ ] Links in the table resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)