### PR TITLE
fix(G-roadmap): fix md_to_pdf test failures

### DIFF
--- a/tests/test_md_to_pdf.py
+++ b/tests/test_md_to_pdf.py
@@ -100,7 +100,7 @@ class TestRenderCoverLetterFull:
 
         render_cover_letter(md_file, pdf_file)
 
-        _content = pdf_file.read_bytes()  # noqa: F841
+        content = pdf_file.read_bytes()
         # Basic structural check: PDF should have at least one page
         assert b"/Type /Page" in content
 

--- a/tools/md_to_pdf_cover_letter.py
+++ b/tools/md_to_pdf_cover_letter.py
@@ -61,7 +61,7 @@ def render_cover_letter(md_path: Path, pdf_path: Path):
             continue
 
         # Name (first line)
-        if i == 0 and line.startswith(line.split()[0]) and len(line.split()) <= 3:
+        if i == 0 and line.split() and len(line.split()) <= 3:
             pdf.set_font(*name_font)
             pdf.set_text_color(0, 102, 255)
             pdf.cell(0, 8, line, new_x="LMARGIN", new_y="NEXT")


### PR DESCRIPTION
## Summary

- Fix `NameError` in `test_all_elements_present` — variable named `_content` (lint suppression) but referenced as `content` on next line
- Fix `IndexError` in `render_cover_letter` when processing empty markdown files — `line.split()[0]` crashes on empty strings
- Brings test suite from 2 failures to 0 (3584 passed, 0 failed)

## Test plan

- [x] `pytest tests/test_md_to_pdf.py` — all 12 tests pass
- [x] Full suite: 3584 passed, 25 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)