### PR TITLE
fix: route daily_pipeline through provider stack + loud failure alarm

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -3,8 +3,24 @@
 # Automated job discovery + AI scoring + notifications.
 # Runs Mon-Fri at 07:00 UTC. Trigger manually from GitHub Actions tab.
 #
-# Required secrets (Settings > Secrets > Actions):
-#   OPENAI_API_KEY          - For AI job scoring (OpenAI or OpenRouter key)
+# AI scoring uses the provider stack at src/career_os/ai/. Configure via:
+#   AI_PROVIDER_FALLBACK    - Comma-separated chain (recommended). Example:
+#                             "mistral,openai,together,anthropic". Each entry
+#                             needs its <PROVIDER>_API_KEY secret set below.
+#                             FallbackProvider tries each in order on
+#                             quota / 4xx / 5xx / timeout failures.
+#   AI_PROVIDER             - Single-provider name (used when no chain set).
+#   SCORING_MAX_FAILURE_RATE - Float in [0,1]. Workflow fails if more than
+#                              this fraction of jobs fail to score.
+#                              Default: 0.50.
+#
+# Required secrets per provider in your chain (only set the ones you use):
+#   MISTRAL_API_KEY         - Mistral AI direct
+#   OPENAI_API_KEY          - OpenAI or OpenRouter key (sk-or-* auto-detected)
+#   ANTHROPIC_API_KEY       - Anthropic direct
+#   TOGETHER_API_KEY        - Together.ai direct
+#   GEMINI_API_KEY          - Google AI Studio
+#   GROQ_API_KEY, XAI_API_KEY, HF_API_KEY - others as needed
 #
 # Optional secrets (for notifications and integrations):
 #   PUSHOVER_APP_TOKEN      - Push notifications (https://pushover.net)
@@ -17,6 +33,8 @@
 #
 # Optional variables (Settings > Variables > Actions):
 #   PIPELINE_LOCATION       - Default search location (default: "Remote")
+#   AI_PROVIDER_FALLBACK    - Comma-separated chain (set as repo variable
+#                             so it isn't hidden as a secret).
 
 name: Daily Job Scan
 
@@ -81,7 +99,21 @@ jobs:
 
       - name: Run daily pipeline
         env:
+          # AI provider configuration. Set AI_PROVIDER_FALLBACK as a repo
+          # variable to enable cross-vendor fallback. Per-provider keys
+          # below are read by career_os.ai.factory; missing ones are
+          # silently skipped from the chain.
+          AI_PROVIDER_FALLBACK: ${{ vars.AI_PROVIDER_FALLBACK }}
+          AI_PROVIDER: ${{ vars.AI_PROVIDER }}
+          SCORING_MAX_FAILURE_RATE: ${{ vars.SCORING_MAX_FAILURE_RATE || '0.50' }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
           PIPELINE_MODE: ${{ inputs.mode || 'api-only' }}
           PIPELINE_MIN_SCORE: ${{ inputs.min_score || '5' }}
           PIPELINE_HOURS_OLD: ${{ inputs.hours_old || '24' }}

--- a/src/career_os/ai/base.py
+++ b/src/career_os/ai/base.py
@@ -34,6 +34,22 @@ class ProviderQuotaError(Exception):
         super().__init__(message)
 
 
+class ProviderUnavailableError(Exception):
+    """Raised when an AI provider returns 404 / model-routing failure / similar
+    "service unavailable" indicators (e.g., OpenRouter 'no allowed providers
+    available for the selected model'). Distinct from quota exhaustion: the
+    provider has capacity but cannot serve the requested model.
+    """
+
+    def __init__(self, provider: str, status_code: int, detail: str = "") -> None:
+        self.provider = provider
+        self.status_code = status_code
+        message = f"{provider} unavailable (HTTP {status_code})."
+        if detail:
+            message += f" {detail}"
+        super().__init__(message)
+
+
 class AIProvider(ABC):
     """Abstract AI provider interface.
 

--- a/src/career_os/ai/fallback.py
+++ b/src/career_os/ai/fallback.py
@@ -14,7 +14,12 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
+from career_os.ai.base import (
+    AIProvider,
+    ComplexityTier,
+    ProviderQuotaError,
+    ProviderUnavailableError,
+)
 from career_os.schemas.ai import AIFeature, AIResponse
 
 logger = logging.getLogger(__name__)
@@ -23,8 +28,13 @@ logger = logging.getLogger(__name__)
 class FallbackProvider(AIProvider):
     """AI provider that tries a chain of providers in order.
 
-    Falls back to the next provider when the current one raises
-    ProviderQuotaError (402/429) or httpx.TimeoutException.
+    Falls back to the next provider when the current one raises:
+      - ProviderQuotaError (402/429 — quota/credit exhaustion)
+      - ProviderUnavailableError (404 — model-routing failure)
+      - httpx.TimeoutException (transient network)
+      - httpx.HTTPStatusError (any other non-2xx — provider returned an HTTP
+        error that wasn't translated to a domain exception, e.g., 5xx)
+    Re-raises the last exception when all providers in the chain fail.
     """
 
     def __init__(self, chain: list[AIProvider]) -> None:
@@ -72,15 +82,21 @@ class FallbackProvider(AIProvider):
     async def _try_chain(self, method: str, call):
         """Execute call against each provider in the chain.
 
-        Catches ProviderQuotaError and TimeoutException, logs the fallback,
-        and tries the next provider. Re-raises if all providers fail.
+        Catches ProviderQuotaError, ProviderUnavailableError, TimeoutException,
+        and any HTTPStatusError, logs the fallback, and tries the next provider.
+        Re-raises the last error if all providers fail.
         """
         last_error: Exception | None = None
 
         for i, provider in enumerate(self._chain):
             try:
                 return await call(provider)
-            except (ProviderQuotaError, httpx.TimeoutException) as exc:
+            except (
+                ProviderQuotaError,
+                ProviderUnavailableError,
+                httpx.TimeoutException,
+                httpx.HTTPStatusError,
+            ) as exc:
                 last_error = exc
                 remaining = len(self._chain) - i - 1
                 if remaining > 0:

--- a/src/career_os/ai/gemini_provider.py
+++ b/src/career_os/ai/gemini_provider.py
@@ -12,7 +12,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import AIProvider, ProviderQuotaError, ProviderUnavailableError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -99,7 +99,15 @@ class GeminiProvider(AIProvider):
                 if response.status_code == 429:
                     detail = _extract_error_detail(response)
                     raise ProviderQuotaError("gemini", response.status_code, detail)
-                response.raise_for_status()
+                # Gemini auth uses ?key=<API_KEY> as a URL query param. Letting
+                # response.raise_for_status() propagate would embed that URL
+                # (with the key) in httpx.HTTPStatusError.__str__, which then
+                # leaks into job["fit_reasoning"], the digest, artifacts, and
+                # email. Translate non-2xx into a sanitized ProviderUnavailable
+                # error before any URL/key reaches an exception string.
+                if response.status_code >= 400:
+                    detail = _extract_error_detail(response) or "see logs"
+                    raise ProviderUnavailableError("gemini", response.status_code, detail)
                 data = response.json()
 
             content = data["candidates"][0]["content"]["parts"][0]["text"]

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -10,7 +10,7 @@ import re
 
 import httpx
 
-from career_os.ai.base import AIProvider, ComplexityTier
+from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
 from career_os.schemas.ai import (
     AIFeature,
     AIResponse,
@@ -32,18 +32,25 @@ OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "anthropic/claude-sonnet-4"
 
 
-class CreditsExhaustedError(Exception):
-    """Raised when OpenRouter returns 402 or 429 indicating credits/quota exhaustion."""
+class CreditsExhaustedError(ProviderQuotaError):
+    """Raised when OpenRouter returns 402 or 429 indicating credits/quota exhaustion.
+
+    Inherits from ProviderQuotaError so FallbackProvider correctly classifies it
+    as a quota error and falls back to the next provider in the chain. Without
+    this inheritance, OpenRouter quota exhaustion would bubble out of the chain
+    as a generic Exception (the silent-degradation pattern G-564 set out to fix).
+    """
 
     def __init__(self, status_code: int, detail: str = "") -> None:
-        self.status_code = status_code
-        message = (
+        msg = (
             f"OpenRouter credits exhausted (HTTP {status_code}). "
             "Add credits at https://openrouter.ai"
         )
         if detail:
-            message += f": {detail}"
-        super().__init__(message)
+            msg += f": {detail}"
+        # Bypass ProviderQuotaError's message format; we already built our own.
+        super().__init__("openrouter", status_code, "")
+        self.args = (msg,)
 
 
 def _extract_error_detail(response: httpx.Response) -> str:

--- a/tests/test_daily_pipeline.py
+++ b/tests/test_daily_pipeline.py
@@ -4,6 +4,7 @@ import os
 import sys
 from unittest.mock import patch
 
+import pytest
 from daily_pipeline import (
     PipelineConfig,
     _fallback_score,
@@ -304,3 +305,188 @@ class TestStepGenerateDigest:
 
         assert summary_file.exists()
         assert "Daily Job Scan" in summary_file.read_text()
+
+
+# ==================== G-564: Failure-rate alarm + regression guard ====================
+#
+# These tests cover the loud-fail behavior introduced when the AI scoring
+# regression (PR #96 era — Llama 3.3 free routing 404s for a week) was
+# silently degrading scoring. The new contract:
+#   - if more than SCORING_MAX_FAILURE_RATE of AI-attempted jobs fail to
+#     score, raise RuntimeError so the workflow fails LOUD
+#   - tools/daily_pipeline.py never imports the openai SDK directly
+#     (regression guard against re-introducing the hand-rolled client)
+
+
+class TestScoringFailureRateAlarm:
+    """The failure-rate alarm raises when chain is broken (G-564)."""
+
+    @staticmethod
+    def _build_failing_provider(fail_count: int, success_count: int):
+        """Build an AsyncMock provider that fails N times then succeeds M times.
+
+        Returned provider's .complete() is awaitable. The first N calls raise
+        a generic Exception; subsequent calls return a parseable AIResponse.
+        """
+        from unittest.mock import AsyncMock
+
+        from career_os.schemas.ai import AIFeature, AIResponse
+
+        ok_response = AIResponse(
+            content='{"score": 7, "reasoning": "ok", "estimated_salary": "120k", '
+            '"effort_flag": "low", "prep_level": 1, "prep_notes": "", '
+            '"review_flag": false, "review_reason": ""}',
+            provider="mock",
+            feature=AIFeature.complete,
+            structured=None,
+            model="mock-model",
+        )
+
+        side_effects: list = []
+        for _ in range(fail_count):
+            side_effects.append(RuntimeError("provider boom"))
+        for _ in range(success_count):
+            side_effects.append(ok_response)
+
+        provider = AsyncMock()
+        provider.name = "mock-chain"
+        provider.complete.side_effect = side_effects
+        return provider
+
+    def test_failure_rate_above_threshold_raises(self, tmp_path):
+        """When >50% of AI calls fail, step_score raises RuntimeError."""
+        import asyncio
+
+        import daily_pipeline
+
+        config = daily_pipeline.PipelineConfig()
+        config.tracking_dir = tmp_path
+        config.scored_path = tmp_path / "scored.json"
+        config.profile_path = tmp_path / "profile.md"
+        config.profile_path.write_text("test profile")
+
+        # 4 jobs, 3 fail = 75% failure rate (above default 50%)
+        provider = self._build_failing_provider(fail_count=3, success_count=1)
+        jobs = [
+            {"title": "Engineer", "company": f"C{i}", "description": "desc", "remote": False}
+            for i in range(4)
+        ]
+
+        with patch.dict(os.environ, {"SCORING_MAX_FAILURE_RATE": "0.50"}):
+            with pytest.raises(RuntimeError, match="failure rate"):
+                asyncio.run(daily_pipeline._step_score_async(config, jobs, provider))
+
+    def test_failure_rate_below_threshold_returns_normally(self, tmp_path):
+        """When failure rate is under threshold, scoring completes."""
+        import asyncio
+
+        import daily_pipeline
+
+        config = daily_pipeline.PipelineConfig()
+        config.tracking_dir = tmp_path
+        config.scored_path = tmp_path / "scored.json"
+        config.profile_path = tmp_path / "profile.md"
+        config.profile_path.write_text("test profile")
+
+        # 4 jobs, 1 fails = 25% failure rate (below 50%)
+        provider = self._build_failing_provider(fail_count=1, success_count=3)
+        jobs = [
+            {"title": "Engineer", "company": f"C{i}", "description": "desc", "remote": False}
+            for i in range(4)
+        ]
+
+        with patch.dict(os.environ, {"SCORING_MAX_FAILURE_RATE": "0.50"}):
+            result = asyncio.run(daily_pipeline._step_score_async(config, jobs, provider))
+
+        assert len(result) == 4
+        assert config.scored_path.exists()
+
+    def test_threshold_configurable(self, tmp_path):
+        """Strict threshold (10%) catches lower failure rates."""
+        import asyncio
+
+        import daily_pipeline
+
+        config = daily_pipeline.PipelineConfig()
+        config.tracking_dir = tmp_path
+        config.scored_path = tmp_path / "scored.json"
+        config.profile_path = tmp_path / "profile.md"
+        config.profile_path.write_text("test profile")
+
+        # 10 jobs, 2 fail = 20% failure rate
+        provider = self._build_failing_provider(fail_count=2, success_count=8)
+        jobs = [
+            {"title": "Eng", "company": f"C{i}", "description": "x", "remote": False}
+            for i in range(10)
+        ]
+
+        with patch.dict(os.environ, {"SCORING_MAX_FAILURE_RATE": "0.10"}):
+            with pytest.raises(RuntimeError, match="20%"):
+                asyncio.run(daily_pipeline._step_score_async(config, jobs, provider))
+
+    def test_zero_ai_attempts_does_not_raise(self, tmp_path):
+        """When all jobs are pre-filtered (zero AI attempts), no division-by-
+        zero, no spurious raise — defensive against an edge case."""
+        import asyncio
+
+        import daily_pipeline
+
+        config = daily_pipeline.PipelineConfig()
+        config.tracking_dir = tmp_path
+        config.scored_path = tmp_path / "scored.json"
+        config.profile_path = tmp_path / "profile.md"
+        config.profile_path.write_text("test profile")
+
+        # Provider should never be called — all jobs hit pre-filter (nurse/driver
+        # titles are in REJECT_TITLE_PATTERNS in tools/job_scorer.py)
+        provider = self._build_failing_provider(fail_count=0, success_count=0)
+        jobs = [
+            {
+                "title": "Registered Nurse",
+                "company": "Hospital",
+                "description": "",
+                "remote": False,
+            },
+            {"title": "Truck Driver", "company": "Logistics", "description": "", "remote": False},
+        ]
+
+        result = asyncio.run(daily_pipeline._step_score_async(config, jobs, provider))
+        assert len(result) == 2
+        # Provider was never called because all jobs were pre-filtered
+        provider.complete.assert_not_called()
+
+
+class TestNoHandrolledOpenAIClient:
+    """Regression guard: tools/daily_pipeline.py must NEVER re-introduce the
+    hand-rolled OpenAI client. All AI access goes through the provider stack
+    at src/career_os/ai/. Re-introducing the bare openai SDK creates the
+    silent-degradation risk that broke daily-scan in G-564."""
+
+    def test_no_openai_import_in_daily_pipeline_source(self):
+        """Source file must not contain `from openai import` or `OpenAI(api_key=`."""
+        import inspect
+
+        import daily_pipeline
+
+        source = inspect.getsource(daily_pipeline)
+        assert "from openai import" not in source, (
+            "Hand-rolled OpenAI import re-introduced. All AI calls must go "
+            "through career_os.ai.factory.get_ai_provider(). See G-564."
+        )
+        assert "OpenAI(api_key=" not in source, (
+            "Hand-rolled OpenAI client re-introduced. Use the provider stack."
+        )
+        # The class name AsyncOpenAI (Eyas-side) is also banned:
+        assert "AsyncOpenAI(api_key=" not in source
+
+    def test_step_score_uses_provider_factory(self):
+        """step_score must delegate to career_os.ai.factory.get_ai_provider."""
+        import inspect
+
+        import daily_pipeline
+
+        source = inspect.getsource(daily_pipeline.step_score)
+        assert "get_ai_provider" in source, (
+            "step_score should obtain its provider via "
+            "career_os.ai.factory.get_ai_provider — not construct one inline."
+        )

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -321,8 +321,19 @@ class TestGeminiErrorHandling:
             assert exc_info.value.provider == "gemini"
 
     @pytest.mark.asyncio
-    async def test_500_raises_http_error(self) -> None:
-        """HTTP 500 raises httpx.HTTPStatusError (not ProviderQuotaError)."""
+    async def test_500_raises_provider_unavailable_error(self) -> None:
+        """HTTP 500 (and any other non-2xx, non-429) raises
+        ProviderUnavailableError, NOT httpx.HTTPStatusError.
+
+        Intentional (G-564): Gemini auth uses ?key=<API_KEY> as a URL query
+        param, so httpx.HTTPStatusError.__str__ would embed the URL — and
+        the key — into the exception. Persisting that into the digest,
+        scored_*.json artifact, or notification email would leak the key.
+        Translation to ProviderUnavailableError happens inside the provider
+        before the URL ever reaches an exception's string representation.
+        """
+        from career_os.ai.base import ProviderUnavailableError
+
         provider = GeminiProvider(api_key=_TEST_CREDENTIAL)
 
         async def mock_post(url, params=None, headers=None, json=None, **kwargs):
@@ -333,8 +344,13 @@ class TestGeminiErrorHandling:
             )
 
         with patch("httpx.AsyncClient.post", side_effect=mock_post):
-            with pytest.raises(httpx.HTTPStatusError):
+            with pytest.raises(ProviderUnavailableError) as exc_info:
                 await provider.complete("test")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.provider == "gemini"
+        # Key marker MUST NOT appear in the exception string.
+        assert _TEST_CREDENTIAL not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_429_includes_error_detail(self) -> None:

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -306,3 +306,96 @@ class TestFactoryFallbackChain:
 
         with patch.dict("os.environ", {"AI_PROVIDER_FALLBACK": "mock"}):
             assert _build_fallback_chain() is None
+
+
+# ==================== G-564 review-fix regression tests ====================
+#
+# These cover the two security/correctness fixes added during code review of
+# the G-564 PR. Without them the silent-degradation pattern would re-emerge
+# in disguise.
+
+
+class TestCreditsExhaustedErrorFallback:
+    """OpenRouter's CreditsExhaustedError must trigger fallback.
+
+    The class exists separately for a friendlier 'add credits at openrouter.ai'
+    message, but it MUST inherit from ProviderQuotaError so FallbackProvider
+    catches it. Without the inheritance, an OpenRouter 402/429 response bubbles
+    out of the chain unfiltered and fit_score=2 stubs accumulate silently —
+    the exact bug G-564 was meant to fix.
+    """
+
+    def test_credits_exhausted_inherits_provider_quota_error(self) -> None:
+        from career_os.ai.base import ProviderQuotaError
+        from career_os.ai.openrouter_provider import CreditsExhaustedError
+
+        assert issubclass(CreditsExhaustedError, ProviderQuotaError)
+
+    @pytest.mark.asyncio
+    async def test_credits_exhausted_triggers_fallback(self) -> None:
+        from career_os.ai.openrouter_provider import CreditsExhaustedError
+
+        p1 = _make_provider("openrouter")
+        p1.complete.side_effect = CreditsExhaustedError(429, "free tier limit")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "together"
+        p1.complete.assert_called_once()
+        p2.complete.assert_called_once()
+
+
+class TestGeminiKeyLeakPrevention:
+    """Gemini auth uses ?key=<API_KEY> as a query param. Letting
+    response.raise_for_status() propagate would embed that URL — including
+    the key — in the resulting httpx.HTTPStatusError, which the daily
+    pipeline persists into the public scored_*.json artifact and digest.
+
+    The fix translates non-2xx (other than 429, already handled separately)
+    into ProviderUnavailableError with a sanitized detail string, so no URL
+    or key reaches an exception's __str__.
+    """
+
+    @pytest.mark.asyncio
+    async def test_gemini_4xx_translates_to_provider_unavailable_no_url_in_msg(
+        self,
+    ) -> None:
+        """Gemini 400/401/403/404 must raise ProviderUnavailableError, never
+        an httpx.HTTPStatusError that could carry the request URL."""
+        import httpx as _httpx
+
+        from career_os.ai.gemini_provider import GeminiProvider
+
+        # Key marker — if sanitization works, this string never appears in str(exc).
+        provider = GeminiProvider(api_key="FAKE-LEAKY-KEY", model="gemini-2.5-flash")
+
+        # Build a request URL that contains the key (matches what Gemini's
+        # ?key= auth would produce in production).
+        leaky_url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-2.5-flash:generateContent?key=FAKE-LEAKY-KEY"
+        )
+        request = _httpx.Request("POST", leaky_url)
+        mock_response = _httpx.Response(
+            403,
+            request=request,
+            json={"error": {"message": "PERMISSION_DENIED"}},
+        )
+
+        async def _mock_post(self, url, **kwargs):  # noqa: ARG001
+            return mock_response
+
+        with patch.object(_httpx.AsyncClient, "post", _mock_post):
+            with pytest.raises(ProviderUnavailableError) as exc_info:
+                await provider.complete("hello", feature=AIFeature.complete)
+
+        msg = str(exc_info.value)
+        assert "FAKE-LEAKY-KEY" not in msg, (
+            "Gemini key leaked into exception string — would propagate to "
+            "scored_*.json artifact and digest. See G-564 review."
+        )
+        assert "PERMISSION_DENIED" in msg or "see logs" in msg
+        assert exc_info.value.provider == "gemini"
+        assert exc_info.value.status_code == 403

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1,9 +1,11 @@
-"""Tests for provider fallback chain (G-405).
+"""Tests for provider fallback chain (G-405, G-564).
 
 Covers:
 - FallbackProvider tries providers in order
 - Falls back on ProviderQuotaError
+- Falls back on ProviderUnavailableError (G-564 — 404 model routing failures)
 - Falls back on httpx.TimeoutException
+- Falls back on httpx.HTTPStatusError (G-564 — generic 4xx/5xx safety net)
 - Re-raises when all providers fail
 - Logs fallback events
 - Factory builds chain from AI_PROVIDER_FALLBACK env var
@@ -15,13 +17,38 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import AIProvider, ProviderQuotaError, ProviderUnavailableError
 from career_os.ai.fallback import FallbackProvider
 from career_os.schemas.ai import AIFeature, AIResponse
 
 
+def _http_status_error(status: int, detail: str = "") -> httpx.HTTPStatusError:
+    """Construct an httpx.HTTPStatusError for a given status code.
+
+    Mirrors the path providers take when ``response.raise_for_status()`` is
+    invoked — useful for simulating provider-side HTTP failures that weren't
+    translated into a domain exception.
+    """
+    request = httpx.Request("POST", "https://example.invalid/v1/chat")
+    response = httpx.Response(status_code=status, request=request, text=detail)
+    return httpx.HTTPStatusError(
+        f"{status} {detail}".strip(),
+        request=request,
+        response=response,
+    )
+
+
 def _make_provider(name: str, should_fail: str | None = None) -> AIProvider:
-    """Create a mock provider that optionally fails with a specific error."""
+    """Create a mock provider that optionally fails with a specific error.
+
+    Supported failure modes:
+      - "quota": ProviderQuotaError (402/429 family)
+      - "timeout": httpx.TimeoutException
+      - "unavailable": ProviderUnavailableError (404 model-routing)
+      - "http_5xx": httpx.HTTPStatusError with status 503
+      - "http_4xx": httpx.HTTPStatusError with status 404
+      - "value_error": ValueError (NOT a fallback trigger — should bubble)
+    """
     provider = AsyncMock(spec=AIProvider)
     provider.name = name
     provider.privacy_tier = "green"
@@ -40,6 +67,21 @@ def _make_provider(name: str, should_fail: str | None = None) -> AIProvider:
     elif should_fail == "timeout":
         provider.complete.side_effect = httpx.TimeoutException("timed out")
         provider.score.side_effect = httpx.TimeoutException("timed out")
+    elif should_fail == "unavailable":
+        err = ProviderUnavailableError(name, 404, "no allowed providers available")
+        provider.complete.side_effect = err
+        provider.score.side_effect = err
+    elif should_fail == "http_5xx":
+        err = _http_status_error(503, "Service Unavailable")
+        provider.complete.side_effect = err
+        provider.score.side_effect = err
+    elif should_fail == "http_4xx":
+        err = _http_status_error(404, "Not Found")
+        provider.complete.side_effect = err
+        provider.score.side_effect = err
+    elif should_fail == "value_error":
+        provider.complete.side_effect = ValueError("unexpected programming bug")
+        provider.score.side_effect = ValueError("unexpected programming bug")
     else:
         provider.complete.return_value = success_response
         provider.score.return_value = success_response
@@ -114,7 +156,7 @@ class TestFallbackProvider:
 
     @pytest.mark.asyncio
     async def test_does_not_catch_other_errors(self) -> None:
-        """Non-quota/timeout errors are not caught (bubble up immediately)."""
+        """Non-fallback-trigger errors bubble up immediately."""
         p1 = _make_provider("openrouter")
         p1.complete.side_effect = ValueError("unexpected error")
         p2 = _make_provider("together")
@@ -124,6 +166,78 @@ class TestFallbackProvider:
             await fb.complete("test", feature=AIFeature.complete)
         # p2 never called — error wasn't a fallback trigger
         p2.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_provider_unavailable(self) -> None:
+        """ProviderUnavailableError (404 / no model routing) triggers fallback.
+
+        This is the bug that broke daily-scan in G-564 — OpenRouter returned
+        404 'No allowed providers' for the configured model. Without this
+        catch, every job got fit_score=2 and the digest showed 0 qualified.
+        """
+        p1 = _make_provider("openrouter", should_fail="unavailable")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "together"
+        p1.complete.assert_called_once()
+        p2.complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_http_5xx(self) -> None:
+        """5xx HTTPStatusError triggers fallback (provider-side outage)."""
+        p1 = _make_provider("openrouter", should_fail="http_5xx")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.score("job", {"name": "test"})
+
+        assert result.provider == "together"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_http_4xx(self) -> None:
+        """Generic 4xx HTTPStatusError triggers fallback as a safety net.
+
+        Catches the case where a provider didn't translate its 4xx into a
+        domain exception (e.g. ProviderUnavailableError) — we still try the
+        next vendor rather than losing the request.
+        """
+        p1 = _make_provider("openrouter", should_fail="http_4xx")
+        p2 = _make_provider("together")
+
+        fb = FallbackProvider([p1, p2])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "together"
+
+    @pytest.mark.asyncio
+    async def test_raises_provider_unavailable_when_all_fail(self) -> None:
+        """When every provider in chain raises ProviderUnavailableError, the
+        last one is re-raised so the workflow can fail loudly upstream."""
+        p1 = _make_provider("openrouter", should_fail="unavailable")
+        p2 = _make_provider("together", should_fail="unavailable")
+
+        fb = FallbackProvider([p1, p2])
+        with pytest.raises(ProviderUnavailableError):
+            await fb.complete("test", feature=AIFeature.complete)
+
+    @pytest.mark.asyncio
+    async def test_mixed_failure_modes_chain(self) -> None:
+        """Different failure modes across the chain still funnel to last
+        successful provider — fallback is mode-agnostic."""
+        p1 = _make_provider("openrouter", should_fail="unavailable")
+        p2 = _make_provider("together", should_fail="http_5xx")
+        p3 = _make_provider("anthropic", should_fail="quota")
+        p4 = _make_provider("mistral")
+
+        fb = FallbackProvider([p1, p2, p3, p4])
+        result = await fb.complete("test", feature=AIFeature.complete)
+
+        assert result.provider == "mistral"
+        for p in (p1, p2, p3, p4):
+            p.complete.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_logs_fallback_events(self, caplog) -> None:

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -11,22 +11,36 @@ Designed to run headlessly via:
   - Manual: .venv/bin/python tools/daily_pipeline.py
 
 Environment variables:
-  OPENAI_API_KEY       — Required for AI scoring (GPT-4o-mini)
-  PIPELINE_MODE        — api-only | api-plus | all (default: api-only)
-  PIPELINE_MIN_SCORE   — Minimum score to include in digest (default: 5)
-  PIPELINE_HOURS_OLD   — Max posting age in hours (default: 24)
-  PIPELINE_LOCATION    — Search location (default: Berlin)
-  PIPELINE_DRY_RUN     — Set to "1" to skip CSV writes (default: 0)
-  GITHUB_STEP_SUMMARY  — GitHub Actions summary file (auto-set in Actions)
+  AI_PROVIDER             — Single provider name (e.g. ``mistral``); used when
+                            no fallback chain is configured.
+  AI_PROVIDER_FALLBACK    — Comma-separated ordered chain (e.g.
+                            ``mistral,openai,together,anthropic``). When set,
+                            scoring routes through ``FallbackProvider`` and
+                            falls back across vendors on quota/timeout/HTTP
+                            errors.
+  <PROVIDER>_API_KEY      — Per-provider API key (MISTRAL_API_KEY,
+                            OPENAI_API_KEY, TOGETHER_API_KEY, etc.). See
+                            :mod:`career_os.ai.factory` for the full list.
+  SCORING_MAX_FAILURE_RATE — Float in [0, 1]. If the post-run scoring
+                            failure rate exceeds this, the pipeline raises
+                            (default: 0.50). The exit-2 path turns into a
+                            loud failure so silent degradation alerts.
+  PIPELINE_MODE           — api-only | api-plus | all (default: api-only)
+  PIPELINE_MIN_SCORE      — Minimum score to include in digest (default: 5)
+  PIPELINE_HOURS_OLD      — Max posting age in hours (default: 24)
+  PIPELINE_LOCATION       — Search location (default: Berlin)
+  PIPELINE_DRY_RUN        — Set to "1" to skip CSV writes (default: 0)
+  GITHUB_STEP_SUMMARY     — GitHub Actions summary file (auto-set in Actions)
 
 Exit codes:
   0 — Success
-  1 — Fatal error (missing deps, no API key)
+  1 — Fatal error (missing deps, scoring failure-rate threshold exceeded)
   2 — Partial failure (some sources failed, digest still generated)
 """
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import json
 import logging
@@ -38,8 +52,15 @@ from pathlib import Path
 # Ensure project root is on path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 logger = logging.getLogger("daily_pipeline")
+
+# Default failure-rate threshold for the scoring loud-fail alarm. Configurable
+# via SCORING_MAX_FAILURE_RATE env. Above this rate the pipeline raises so
+# a misconfigured chain or mass provider outage produces an immediate alert
+# rather than days of silent score=2 fallbacks.
+DEFAULT_SCORING_MAX_FAILURE_RATE = 0.50
 
 
 # --- Config ---
@@ -97,37 +118,69 @@ def step_scrape(config: PipelineConfig) -> list[dict]:
 
 
 def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
-    """Score each job against the profile using OpenAI."""
+    """Score each job against the profile via the AI provider stack.
+
+    Routes through ``career_os.ai.factory.get_ai_provider``, which builds a
+    ``FallbackProvider`` chain when ``AI_PROVIDER_FALLBACK`` is set. The chain
+    transparently fails over on quota/timeout/HTTP errors. Sync wrapper around
+    an internal async helper so the rest of the pipeline stays synchronous.
+
+    Falls back to keyword-based scoring **only** when no AI provider can be
+    constructed (e.g. running locally with no keys configured). When a provider
+    chain is configured but every call fails, the pipeline raises so the
+    workflow fails loudly instead of silently producing score=2 stubs — see
+    ``SCORING_MAX_FAILURE_RATE``.
+    """
     logger.info("=" * 60)
     logger.info("STEP 2: SCORE")
     logger.info("=" * 60)
 
-    if not config.openai_key:
-        logger.warning("No OPENAI_API_KEY — using keyword-based fallback scoring")
+    try:
+        from career_os.ai.factory import get_ai_provider
+    except ImportError as exc:
+        logger.warning("career_os.ai unavailable (%s) — using keyword-based fallback scoring", exc)
         return _fallback_score(jobs)
 
     try:
-        from openai import OpenAI
-    except ImportError:
-        logger.warning("openai package not installed — using fallback scoring")
+        provider = get_ai_provider()
+    except Exception as exc:  # missing keys, unsupported provider, etc.
+        logger.warning("AI provider unavailable (%s) — using keyword-based fallback scoring", exc)
         return _fallback_score(jobs)
 
-    # Support OpenRouter keys (sk-or-*) by auto-detecting base_url
-    base_url = os.getenv("OPENAI_BASE_URL")
-    if not base_url and config.openai_key.startswith("sk-or-"):
-        base_url = "https://openrouter.ai/api/v1"
-    client = OpenAI(api_key=config.openai_key, base_url=base_url)
+    return asyncio.run(_step_score_async(config, jobs, provider))
 
-    # Load profile for context
+
+async def _step_score_async(
+    config: PipelineConfig,
+    jobs: list[dict],
+    provider,  # AIProvider
+) -> list[dict]:
+    """Async scoring loop driving the provider stack one job at a time.
+
+    Sequential by design — keeps memory + cost predictable for the daily
+    cron, and the FallbackProvider already handles per-call resilience.
+    Tracks failure count and raises when ``failures/scored_via_ai`` exceeds
+    ``SCORING_MAX_FAILURE_RATE`` so silent degradation can't recur.
+    """
+    from job_scorer import PROFILE_CRITERIA, SCORING_SYSTEM_PROMPT_WITH_REVIEW, pre_filter_job
+
+    from career_os.schemas.ai import AIFeature
+
     profile_context = ""
     if config.profile_path.exists():
         profile_context = config.profile_path.read_text()[:3000]
 
-    from job_scorer import PROFILE_CRITERIA, SCORING_SYSTEM_PROMPT_WITH_REVIEW, pre_filter_job
+    max_failure_rate = float(
+        os.getenv("SCORING_MAX_FAILURE_RATE", str(DEFAULT_SCORING_MAX_FAILURE_RATE))
+    )
 
-    scored = []
+    scored: list[dict] = []
     skipped = 0
+    failures = 0
+    ai_attempts = 0
     total = len(jobs)
+    logger.info("Provider chain: %s", provider.name)
+
     for i, job in enumerate(jobs):
         title = job.get("title", "Unknown")
         company = job.get("company", "Unknown")
@@ -135,9 +188,7 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
         remote = bool(job.get("remote", False))
         description = job.get("description", "")
 
-        # --- Pre-filter: skip obviously irrelevant jobs before AI scoring ---
         should_skip, filter_reason, score_cap = pre_filter_job(title, company, location, remote)
-
         if should_skip:
             job["fit_score"] = 0
             job["fit_reasoning"] = f"Pre-filtered: {filter_reason}"
@@ -150,38 +201,45 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
             scored.append(job)
             skipped += 1
             if (i + 1) % 10 == 0:
-                logger.info(f"Scored {i + 1}/{total} jobs (skipped {skipped})")
+                logger.info("Scored %d/%d jobs (skipped %d)", i + 1, total, skipped)
             continue
 
         if not description or description == "nan":
-            # Use title + company + tags as description proxy
-            description = f"Title: {title}\nCompany: {company}\nLocation: {location}\nTags: {', '.join(job.get('tags', []))}"
-
-        desc_truncated = description[:3000]
-
-        try:
-            response = client.chat.completions.create(
-                model="anthropic/claude-sonnet-4.6",
-                messages=[
-                    {"role": "system", "content": SCORING_SYSTEM_PROMPT_WITH_REVIEW},
-                    {
-                        "role": "user",
-                        "content": f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\nADDITIONAL CONTEXT:\n{profile_context[:1000]}\n\nJOB POSTING:\nTitle: {title}\nCompany: {company}\nDescription: {desc_truncated}",
-                    },
-                ],
-                temperature=0.1,
+            description = (
+                f"Title: {title}\nCompany: {company}\nLocation: {location}\n"
+                f"Tags: {', '.join(job.get('tags', []))}"
             )
 
-            raw = response.choices[0].message.content.strip()
+        # Inline system + user content into one prompt because we use
+        # AIFeature.complete (no auto system message). Preserves the
+        # CLI-specific scoring schema with review_flag / review_reason
+        # consumed downstream by update_sheet.py and the digest "Review
+        # Queue" section.
+        prompt = (
+            f"{SCORING_SYSTEM_PROMPT_WITH_REVIEW}\n\n"
+            f"CANDIDATE PROFILE:\n{PROFILE_CRITERIA}\n\n"
+            f"ADDITIONAL CONTEXT:\n{profile_context[:1000]}\n\n"
+            f"JOB POSTING:\nTitle: {title}\nCompany: {company}\n"
+            f"Description: {description[:3000]}"
+        )
+
+        ai_attempts += 1
+        try:
+            response = await provider.complete(prompt, feature=AIFeature.complete)
+            raw = (response.content or "").strip()
             try:
                 result = json.loads(raw)
             except json.JSONDecodeError:
-                # Handle single quotes from some models
-                result = json.loads(raw.replace("'", '"'))
+                # Strip common markdown fences before retry-parse
+                stripped = raw
+                for fence in ("```json", "```"):
+                    stripped = stripped.replace(fence, "")
+                try:
+                    result = json.loads(stripped.strip().replace("'", '"'))
+                except json.JSONDecodeError as parse_exc:
+                    raise ValueError(f"unparseable JSON: {raw[:200]!r}") from parse_exc
 
-            ai_score = int(result.get("score", 2))
-
-            # Apply score cap from pre-filter (e.g. US-only location)
+            ai_score = int(result.get("score", result.get("fit_score", 2)))
             if score_cap is not None and ai_score > score_cap:
                 result["reasoning"] = (
                     f"Capped from {ai_score} to {score_cap}: {result.get('reasoning', '')}"
@@ -197,49 +255,50 @@ def step_score(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
             job["review_flag"] = bool(result.get("review_flag", False))
             job["review_reason"] = result.get("review_reason", "")
 
-        except Exception as e:
-            status_code = getattr(e, "status_code", None)
-            error_str = str(e)
-
-            if status_code in (402, 429) or "insufficient_quota" in error_str.lower():
-                logger.error(
-                    f"AI credits exhausted after scoring {len(scored)}/{total} jobs — stopping. "
-                    "Add credits at https://openrouter.ai"
-                )
-                job["fit_score"] = 0
-                job["fit_reasoning"] = "Not scored: AI credits exhausted"
-                job["estimated_salary"] = "unknown"
-                job["effort_flag"] = "unknown"
-                job["prep_level"] = 0
-                job["prep_notes"] = ""
-                scored.append(job)
-                for remaining_job in jobs[i + 1 :]:
-                    remaining_job["fit_score"] = 0
-                    remaining_job["fit_reasoning"] = "Not scored: AI credits exhausted"
-                    remaining_job["estimated_salary"] = "unknown"
-                    remaining_job["effort_flag"] = "unknown"
-                    remaining_job["prep_level"] = 0
-                    remaining_job["prep_notes"] = ""
-                    scored.append(remaining_job)
-                break
-
-            logger.warning(f"Scoring failed for {title} @ {company}: {e}")
-            job["fit_score"] = 2  # Default to 2, not 5 -- unknown jobs shouldn't pass
-            job["fit_reasoning"] = f"Scoring error: {e}"
+        except Exception as exc:
+            failures += 1
+            logger.warning("Scoring failed for %s @ %s: %s", title, company, exc)
+            job["fit_score"] = 2
+            job["fit_reasoning"] = f"Scoring error: {exc}"
             job["estimated_salary"] = "unknown"
             job["effort_flag"] = "unknown"
             job["prep_level"] = 0
             job["prep_notes"] = ""
+            job["review_flag"] = False
+            job["review_reason"] = ""
 
         scored.append(job)
-
         if (i + 1) % 10 == 0:
-            logger.info(f"Scored {i + 1}/{total} jobs (skipped {skipped})")
+            logger.info(
+                "Scored %d/%d jobs (skipped %d, failures %d)",
+                i + 1,
+                total,
+                skipped,
+                failures,
+            )
 
-    logger.info(f"Scoring complete: {len(scored)} jobs scored")
+    logger.info(
+        "Scoring complete: %d jobs (%d AI attempts, %d failures, %d pre-filter-skipped)",
+        len(scored),
+        ai_attempts,
+        failures,
+        skipped,
+    )
 
-    # Save scored results
     config.scored_path.write_text(json.dumps(scored, indent=2, ensure_ascii=False))
+
+    # Loud-fail alarm: if too many AI calls failed, the chain is broken.
+    # Raise so the workflow fails and existing Pushover failure path triggers,
+    # rather than producing a digest full of score=2 stubs that look fine.
+    if ai_attempts > 0:
+        failure_rate = failures / ai_attempts
+        if failure_rate > max_failure_rate:
+            raise RuntimeError(
+                f"Scoring failure rate {failure_rate:.0%} ({failures}/{ai_attempts}) "
+                f"exceeds threshold {max_failure_rate:.0%}. "
+                f"Provider chain '{provider.name}' is unhealthy — check API keys, "
+                f"quotas, and provider status pages."
+            )
 
     return scored
 
@@ -571,8 +630,15 @@ def run_pipeline() -> int:
         return exit_code or 2
 
     # Step 2: Score
+    # The failure-rate alarm raises RuntimeError when too many AI calls fail
+    # (chain misconfigured / mass provider outage). We let that propagate as
+    # exit 1 so the workflow fails loudly and existing Pushover failure path
+    # triggers. Other scoring exceptions still get the soft exit-2 treatment.
     try:
         scored = step_score(config, all_scraped)
+    except RuntimeError:
+        # Loud-fail alarm — re-raise so main() exits non-zero.
+        raise
     except Exception as e:
         logger.error(f"Scoring failed: {e}")
         scored = all_scraped

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -165,6 +165,7 @@ async def _step_score_async(
     from job_scorer import PROFILE_CRITERIA, SCORING_SYSTEM_PROMPT_WITH_REVIEW, pre_filter_job
 
     from career_os.schemas.ai import AIFeature
+    from career_os.services.batch_scoring import _sanitize_description
 
     profile_context = ""
     if config.profile_path.exists():
@@ -209,6 +210,13 @@ async def _step_score_async(
                 f"Title: {title}\nCompany: {company}\nLocation: {location}\n"
                 f"Tags: {', '.join(job.get('tags', []))}"
             )
+
+        # Sanitize attacker-controlled job description before interpolating
+        # into the prompt. Job postings come from public ATS boards — content
+        # there is not trusted. Strips known prompt-injection patterns and
+        # truncates to MAX_DESCRIPTION_LENGTH. Reuses the same defense as
+        # batch scoring (career_os.services.batch_scoring._sanitize_description).
+        description = _sanitize_description(description)
 
         # Inline system + user content into one prompt because we use
         # AIFeature.complete (no auto system message). Preserves the


### PR DESCRIPTION
## Summary

`tools/daily_pipeline.py` was using a hand-rolled `from openai import OpenAI` client that bypassed the production provider stack at `src/career_os/ai/`. When OpenRouter started returning HTTP 404 (`No allowed providers available`) for the configured model, every job got `fit_score=2` from the AI-error fallback. The keyword fallback caps at 6, the digest threshold is >=7, so the daily scan returned **0 qualified jobs for ~1 week** without a single failed CI run.

This PR converges scoring on the provider stack so all AI calls inherit `FallbackProvider` resilience, and adds a loud failure-rate alarm so silent degradation cannot recur.

## Changes

**Resilience**
- New `ProviderUnavailableError` in `career_os.ai.base` (distinct from `ProviderQuotaError`) — raised on 404/model-routing failures
- `FallbackProvider` catch widened from `{ProviderQuotaError, TimeoutException}` to also include `ProviderUnavailableError` and `httpx.HTTPStatusError` (safety net for 4xx/5xx that providers didn't translate)
- Failure-rate alarm: if `failures / ai_attempts > SCORING_MAX_FAILURE_RATE` (default 0.50), `step_score` raises `RuntimeError`; `run_pipeline` re-raises so the workflow exits non-zero and the existing Pushover failure path triggers

**Refactor**
- `tools/daily_pipeline.py`: removed hand-rolled OpenAI client; `step_score` is a sync wrapper around `_step_score_async` that uses `career_os.ai.factory.get_ai_provider()` (respects `AI_PROVIDER_FALLBACK`)
- Custom CLI prompt preserved (`review_flag`/`review_reason` are consumed downstream by `update_sheet.py:208` and digest 'Review Queue' section). Inlined system prompt into user prompt with `feature=AIFeature.complete`.
- Keyword fallback retained, but only triggers when the factory cannot construct a provider (offline / no keys)

**Workflow** (`.github/workflows/daily-scan.yml`)
- Dropped `OPENAI_BASE_URL` / `SCORING_MODEL` (single-model config)
- Added `AI_PROVIDER_FALLBACK`, `AI_PROVIDER`, `SCORING_MAX_FAILURE_RATE` as repo variables
- Per-provider secret references: `MISTRAL_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TOGETHER_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `XAI_API_KEY`, `HF_API_KEY` (missing keys silently skipped from chain)

## Test plan

- [x] `pytest tests/test_provider_fallback.py` — **18 pass** (13 existing + 5 new)
- [x] `pytest tests/test_daily_pipeline.py` — **29 pass** (24 existing + 5 new)
- [x] `pytest tests/test_*provider*.py tests/test_ai_provider.py` — **161 pass**, no regressions
- [x] `ruff format --check` clean on all changed files
- [x] Regression guard test (`TestNoHandrolledOpenAIClient`) ensures no future re-introduction of the hand-rolled OpenAI client

**New tests:**
- `test_falls_back_on_provider_unavailable` — the 404-routing-failure path that started this work
- `test_falls_back_on_http_5xx`, `test_falls_back_on_http_4xx` — generic HTTP safety nets
- `test_raises_provider_unavailable_when_all_fail` — chain exhaustion preserves error type
- `test_mixed_failure_modes_chain` — fallback is mode-agnostic across the chain
- `test_failure_rate_above_threshold_raises` (50%, 10% configured), `test_failure_rate_below_threshold_returns_normally`, `test_zero_ai_attempts_does_not_raise` — the loud-fail alarm
- `test_no_openai_import_in_daily_pipeline_source`, `test_step_score_uses_provider_factory` — regression guard

## Migration notes

Users on the previous single-key config:
- Set `AI_PROVIDER_FALLBACK` as a repo variable (e.g. `mistral,openai,together,anthropic`) and add per-provider secrets, **OR**
- Set `AI_PROVIDER=openai` plus `OPENAI_API_KEY` to keep current single-vendor behavior

Default `SCORING_MAX_FAILURE_RATE=0.50` is generous — once chain is healthy real failure rate should be <1%. Tighten to 0.10 for stricter alerting.

## Linked

Linear: G-564