### PR TITLE
chore: group npm dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,31 @@ updates:
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

Groups related npm packages so coupled deps update together. Prevents the failure mode seen in PR #339 where Dependabot bumped \`react\` alone, breaking compat with \`react-dom\`.

Groups:
- **react**: react, react-dom, @types/react, @types/react-dom (must match exactly)
- **eslint**: eslint, eslint-*, @eslint/*, typescript-eslint
- **tanstack**: @tanstack/*
- **tailwind**: tailwindcss, @tailwindcss/*
- **vitest**: vitest, @vitest/*, @testing-library/*

Python and github-actions ecosystem configs unchanged.

## Test plan
- [ ] CI passes (no code change, just config)
- [ ] Next Dependabot run produces grouped PRs for affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)