### PR TITLE
fix: harden AI isolation guard against substring spoofing (CodeQL #54)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def block_real_ai_calls(monkeypatch):
     async def guarded_send(self, request, **kwargs):
         host = request.url.host
         for domain in _BLOCKED_AI_DOMAINS:
-            if domain in host:
+            if host == domain or host.endswith("." + domain):
                 raise RuntimeError(
                     f"TEST ISOLATION VIOLATION: attempted real HTTP call to {host}. "
                     f"Tests must use AI_PROVIDER=mock. "

--- a/tests/test_ai_isolation_guard.py
+++ b/tests/test_ai_isolation_guard.py
@@ -77,7 +77,9 @@ async def test_isolation_guard_error_message_includes_domain():
     async with httpx.AsyncClient() as client:
         with pytest.raises(RuntimeError) as exc_info:
             await client.get("https://api.openai.com/v1/models")
-    assert "api.openai.com" in str(exc_info.value)
+    # The error message format pins the host with a trailing period
+    # (see conftest.py guarded_send): "...HTTP call to {host}. Tests must..."
+    assert "HTTP call to api.openai.com." in str(exc_info.value)
 
 
 def test_ai_provider_env_is_mock():


### PR DESCRIPTION
## Summary

Resolves CodeQL alert #54 — \`py/incomplete-url-substring-sanitization\`.

The test isolation guard in \`conftest.py\` used \`domain in host\` to detect forbidden AI provider hosts, which would also match attacker-crafted hostnames like \`api.openai.com.evil.com\`. Failure-safe in the blocking direction (over-blocks rather than under-blocks), but strict FQDN matching is more correct.

## Changes

**\`tests/conftest.py\`** — replace substring check with proper FQDN match:
\`\`\`diff
- if domain in host:
+ if host == domain or host.endswith("." + domain):
\`\`\`

**\`tests/test_ai_isolation_guard.py\`** — tighten the error-message assertion to pin the substring against a known boundary (\`HTTP call to api.openai.com.\`) so CodeQL no longer flags it.

## Test plan
- [x] All 10 isolation guard tests pass locally
- [ ] CI green
- [ ] CodeQL alert #54 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)