### PR TITLE
fix(profiles): refuse DELETE if profile owns child rows; add rotating snapshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ You started with an empty pipeline and a vague sense of dread. Six weeks later, 
 
 This isn't a slogan — it's the architecture. Kestrel runs on your computer. Your database is a SQLite file in your home directory. Your resume, cover letters, STAR stories, salary expectations, networking notes — none of it touches a server unless you explicitly connect an AI provider.
 
+### Snapshots and recovery
+
+Months of job-search history sit in one SQLite file. Lose it and you've lost the search. Kestrel ships with a rotating-snapshot script so an accidental wipe is recoverable in under a minute:
+
+```bash
+python tools/snapshot_db.py                # daily snapshot, last 7 days retained
+python tools/snapshot_db.py --keep 30      # 30-day window instead
+python tools/snapshot_db.py --dry-run      # preview without writing
+```
+
+Snapshots land in `data/snapshots/career_os-YYYY-MM-DD.db`. The script uses SQLite's online backup API, not plain `cp`, so the file is consistent even if the live DB is mid-transaction under WAL.
+
+**Wire it into your daily cron** (Linux/macOS):
+
+```cron
+0 3 * * * cd /path/to/kestrel && /path/to/kestrel/.venv/bin/python tools/snapshot_db.py
+```
+
+Or as a macOS launchd plist / systemd timer if you prefer. Recovery is a copy:
+
+```bash
+cp data/snapshots/career_os-2026-05-04.db data/career_os.db
+rm -f data/career_os.db-shm data/career_os.db-wal
+# restart the server
+```
+
+
 Even then, you control what goes where:
 
 - **Ollama** — everything stays on your machine. Zero network calls. Free.

--- a/src/career_os/api/profiles.py
+++ b/src/career_os/api/profiles.py
@@ -4,7 +4,7 @@ import json
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from career_os.api.constants import PROFILE_NOT_FOUND, RESP_404
@@ -19,6 +19,34 @@ from career_os.schemas.profiles import (
 from career_os.services.scoring import flag_stale_scores, regenerate_weights_for_job_family
 
 router = APIRouter(prefix="/api/profiles", tags=["profiles"])
+
+# Child tables owned by a profile, in (table, label) form. Counted in one
+# round-trip SQL statement to decide whether DELETE /api/profiles/{id} should
+# refuse with 409 (safe default) or proceed (force=true).
+_PROFILE_CHILD_TABLES: tuple[tuple[str, str], ...] = (
+    ("applications", "applications"),
+    ("application_packages", "application_packages"),
+    ("activity_log", "activity_logs"),
+    ("follow_ups", "follow_ups"),
+    ("skills", "skills"),
+    ("learning_resources", "learning_resources"),
+    ("goals", "goals"),
+    ("coaching_suggestions", "coaching_suggestions"),
+    ("job_requirements", "job_requirements"),
+)
+
+
+def _count_profile_children(db: Session, profile_id: int) -> dict[str, int]:
+    """Return a row-count for every child table that references profile_id.
+
+    Single SQL round-trip; relies on (profile_id) indexes for sub-millisecond cost.
+    """
+    selects = ", ".join(
+        f"(SELECT COUNT(*) FROM {table} WHERE profile_id = :pid) AS {label}"
+        for table, label in _PROFILE_CHILD_TABLES
+    )
+    row = db.execute(text(f"SELECT {selects}"), {"pid": profile_id}).mappings().one()
+    return dict(row)
 
 
 @router.get("")
@@ -104,29 +132,46 @@ async def update_profile(
 @router.delete(
     "/{profile_id}",
     status_code=204,
-    responses={**RESP_404, 409: {"description": "Conflict"}},
+    responses={
+        **RESP_404,
+        409: {
+            "description": "Conflict — profile has child rows; pass ?force=true to cascade-delete"
+        },
+    },
 )
 async def delete_profile(
     profile_id: int,
     db: Annotated[Session, Depends(get_db)],
+    force: bool = False,
 ) -> None:
     """Delete a profile.
 
-    Returns 404 if profile doesn't exist. Cascading deletes remove
-    associated applications, activity logs, follow-ups, skills,
-    learning resources, goals, job requirements, and coaching suggestions.
+    By default, refuses with HTTP 409 if the profile owns any rows in
+    applications, application_packages, activity_log, follow_ups, skills,
+    learning_resources, goals, coaching_suggestions, or job_requirements.
+
+    Pass ?force=true to cascade-delete the profile and every child row.
+
+    The previous behavior of this endpoint (cascade on plain DELETE) is what
+    wiped a downstream user's full dataset on 2026-05-11 with one stray API
+    call; the same DELETE on every Kestrel install would have done the same.
     """
     profile = db.query(Profile).filter(Profile.id == profile_id).first()
     if profile is None:
         raise HTTPException(status_code=404, detail=PROFILE_NOT_FOUND)
 
-    try:
-        db.delete(profile)
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail="Cannot delete profile with existing records. "
-            "Please remove associated data first.",
-        ) from None
+    if not force:
+        counts = _count_profile_children(db, profile_id)
+        non_empty = {k: v for k, v in counts.items() if v > 0}
+        if non_empty:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "Profile has child rows; refusing to cascade-delete",
+                    "child_counts": non_empty,
+                    "hint": "Pass ?force=true to delete the profile and all child rows.",
+                },
+            )
+
+    db.delete(profile)
+    db.commit()

--- a/tests/test_profile_delete_safety.py
+++ b/tests/test_profile_delete_safety.py
@@ -1,0 +1,258 @@
+"""Tests for the safety guard on DELETE /api/profiles/{id}.
+
+Before this guard, calling DELETE silently cascaded every child row (applications,
+packages, activity_log, follow-ups, skills, goals, coaching suggestions, learning
+resources, job_requirements) thanks to SQLAlchemy `cascade="all, delete-orphan"`.
+A single stray API call wiped a downstream user's full job-search dataset on
+2026-05-11.
+
+The guard:
+- Plain DELETE refuses with 409 if any child rows exist; reports counts per table.
+- ?force=true bypasses the guard (preserves the old behavior, now opt-in).
+- 404 still wins over 409 when the profile id doesn't exist.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.database import Base, get_db
+from career_os.main import app
+from career_os.models.models import (
+    ActivityLog,
+    Application,
+    ApplicationPackage,
+    FollowUp,
+    Profile,
+)
+from career_os.models.skills import (
+    CoachingSuggestion,
+    Goal,
+    JobRequirement,
+    LearningResource,
+    Skill,
+)
+
+
+@pytest.fixture(autouse=True)
+def db_session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    TestSession = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = TestSession()
+
+    session.add(Profile(id=1, name="Owner", email="owner@example.com"))
+    session.commit()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def _seed_application(session: Session, profile_id: int) -> int:
+    app_row = Application(profile_id=profile_id, company="Acme", role="PM", status="applied")
+    session.add(app_row)
+    session.commit()
+    return app_row.id
+
+
+class TestRefusesDefaultDelete:
+    """Plain DELETE must refuse with 409 if any child rows exist."""
+
+    def test_refuses_when_application_exists(self, client: TestClient, db_session: Session):
+        _seed_application(db_session, 1)
+        resp = client.delete("/api/profiles/1")
+        assert resp.status_code == 409
+        body = resp.json()["detail"]
+        assert body["child_counts"]["applications"] == 1
+        # Profile and child row both still present.
+        assert db_session.query(Profile).count() == 1
+        assert db_session.query(Application).count() == 1
+
+    def test_refuses_when_skill_exists(self, client: TestClient, db_session: Session):
+        db_session.add(
+            Skill(
+                profile_id=1,
+                name="Python",
+                category="technical",
+                proficiency="advanced",
+                evidence_source="manual",
+            )
+        )
+        db_session.commit()
+        resp = client.delete("/api/profiles/1")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["child_counts"]["skills"] == 1
+
+    def test_refuses_when_goal_exists(self, client: TestClient, db_session: Session):
+        db_session.add(Goal(profile_id=1, title="Land Senior TPM", goal_type="realistic"))
+        db_session.commit()
+        resp = client.delete("/api/profiles/1")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["child_counts"]["goals"] == 1
+
+    def test_409_lists_only_non_empty_tables(self, client: TestClient, db_session: Session):
+        """child_counts must omit zero-count tables (signal-to-noise)."""
+        _seed_application(db_session, 1)
+        resp = client.delete("/api/profiles/1")
+        body = resp.json()["detail"]
+        assert "applications" in body["child_counts"]
+        assert "skills" not in body["child_counts"]
+        assert "follow_ups" not in body["child_counts"]
+
+
+class TestForceTrueCascades:
+    """?force=true preserves the old cascade behavior, now opt-in."""
+
+    def test_force_true_returns_204_and_cascades(self, client: TestClient, db_session: Session):
+        app_id = _seed_application(db_session, 1)
+        db_session.add(
+            ApplicationPackage(
+                profile_id=1,
+                application_id=app_id,
+                package_dir="/tmp/pkg",
+                cover_letter_path="/tmp/cl.pdf",
+            )
+        )
+        db_session.commit()
+
+        resp = client.delete("/api/profiles/1?force=true")
+        assert resp.status_code == 204
+        assert db_session.query(Profile).count() == 0
+        assert db_session.query(Application).count() == 0
+        assert db_session.query(ApplicationPackage).count() == 0
+
+    def test_force_false_explicit_still_refuses(self, client: TestClient, db_session: Session):
+        _seed_application(db_session, 1)
+        resp = client.delete("/api/profiles/1?force=false")
+        assert resp.status_code == 409
+
+
+class TestEdgeCases:
+    """Things that must keep working alongside the guard."""
+
+    def test_empty_profile_deletes_without_force(self, client: TestClient, db_session: Session):
+        """Profile with zero child rows: plain DELETE returns 204."""
+        create = client.post("/api/profiles", json={"name": "Lonely"})
+        pid = create.json()["id"]
+        resp = client.delete(f"/api/profiles/{pid}")
+        assert resp.status_code == 204
+
+    def test_nonexistent_returns_404_not_409(self, client: TestClient):
+        """404 wins over 409 when the profile does not exist."""
+        resp = client.delete("/api/profiles/9999")
+        assert resp.status_code == 404
+
+    def test_409_does_not_partially_delete(self, client: TestClient, db_session: Session):
+        """If we refuse, no row anywhere may be touched."""
+        app_id = _seed_application(db_session, 1)
+        db_session.add(
+            FollowUp(
+                profile_id=1,
+                application_id=app_id,
+                follow_up_type="thanks",
+                due_date=datetime(2026, 6, 1, tzinfo=UTC),
+                notes="x",
+            )
+        )
+        db_session.add(ActivityLog(profile_id=1, action="note", details="x"))
+        db_session.add(LearningResource(profile_id=1, title="x", resource_type="free_course"))
+        db_session.add(
+            JobRequirement(
+                application_id=app_id,
+                profile_id=1,
+                skill_name="Python",
+                required_level="advanced",
+                severity="critical",
+            )
+        )
+        db_session.add(CoachingSuggestion(profile_id=1, action="x", priority=1))
+        db_session.commit()
+        before = {
+            "profile": db_session.query(Profile).count(),
+            "application": db_session.query(Application).count(),
+            "follow_up": db_session.query(FollowUp).count(),
+            "activity_log": db_session.query(ActivityLog).count(),
+            "learning_resource": db_session.query(LearningResource).count(),
+            "job_requirement": db_session.query(JobRequirement).count(),
+            "coaching_suggestion": db_session.query(CoachingSuggestion).count(),
+        }
+        resp = client.delete("/api/profiles/1")
+        assert resp.status_code == 409
+        after = {
+            "profile": db_session.query(Profile).count(),
+            "application": db_session.query(Application).count(),
+            "follow_up": db_session.query(FollowUp).count(),
+            "activity_log": db_session.query(ActivityLog).count(),
+            "learning_resource": db_session.query(LearningResource).count(),
+            "job_requirement": db_session.query(JobRequirement).count(),
+            "coaching_suggestion": db_session.query(CoachingSuggestion).count(),
+        }
+        assert before == after
+
+
+class TestRealWorldReproduction:
+    """The exact incident from the 2026-05-11 downstream wipe."""
+
+    def test_one_delete_call_does_not_lose_full_dataset(
+        self, client: TestClient, db_session: Session
+    ):
+        # Seed something representative: 3 applications + 1 package + 1 follow-up.
+        for company in ("Anthropic", "DeepMind", "Linear"):
+            db_session.add(
+                Application(
+                    profile_id=1,
+                    company=company,
+                    role="TPM",
+                    status="applied",
+                )
+            )
+        db_session.commit()
+        app_one = db_session.query(Application).first().id
+        db_session.add(
+            ApplicationPackage(
+                profile_id=1,
+                application_id=app_one,
+                package_dir="/tmp/pkg",
+                cv_path="/tmp/cv.pdf",
+            )
+        )
+        db_session.add(
+            FollowUp(
+                profile_id=1,
+                application_id=app_one,
+                follow_up_type="thanks",
+                due_date=datetime(2026, 6, 1, tzinfo=UTC),
+            )
+        )
+        db_session.commit()
+
+        # The exact call shape that triggered the production wipe.
+        resp = client.delete("/api/profiles/1")
+        assert resp.status_code == 409, "guard must refuse — this was the wipe path"
+        # Nothing lost.
+        assert db_session.query(Application).count() == 3
+        assert db_session.query(ApplicationPackage).count() == 1
+        assert db_session.query(FollowUp).count() == 1

--- a/tests/test_profiles_crud.py
+++ b/tests/test_profiles_crud.py
@@ -215,7 +215,7 @@ class TestDeleteProfile:
         db_session.commit()
         skill_id = skill.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(Skill, skill_id) is None
 
@@ -242,7 +242,7 @@ class TestDeleteProfile:
         db_session.commit()
         history_id = history.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(SkillHistory, history_id) is None
 
@@ -259,7 +259,7 @@ class TestDeleteProfile:
         db_session.commit()
         resource_id = resource.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(LearningResource, resource_id) is None
 
@@ -276,7 +276,7 @@ class TestDeleteProfile:
         db_session.commit()
         goal_id = goal.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(Goal, goal_id) is None
 
@@ -304,7 +304,7 @@ class TestDeleteProfile:
         db_session.commit()
         req_id = req.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(JobRequirement, req_id) is None
 
@@ -321,7 +321,7 @@ class TestDeleteProfile:
         db_session.commit()
         suggestion_id = suggestion.id
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         assert db_session.get(CoachingSuggestion, suggestion_id) is None
 
@@ -388,7 +388,7 @@ class TestDeleteProfile:
         )
         db_session.commit()
 
-        resp = client.delete(f"/api/profiles/{pid}")
+        resp = client.delete(f"/api/profiles/{pid}?force=true")
         assert resp.status_code == 204
         # Verify profile is gone
         assert client.get(f"/api/profiles/{pid}").status_code == 404

--- a/tests/test_snapshot_db.py
+++ b/tests/test_snapshot_db.py
@@ -1,0 +1,137 @@
+"""Tests for tools.snapshot_db — atomic, rotating SQLite snapshots."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from snapshot_db import (  # noqa: E402
+    SNAPSHOT_PREFIX,
+    _list_snapshots,
+    snapshot,
+)
+
+
+@pytest.fixture
+def live_db(tmp_path: Path) -> Path:
+    """A live SQLite DB with one row, returned as a Path."""
+    db_path = tmp_path / "career_os.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("CREATE TABLE apps (id INTEGER, name TEXT);")
+    conn.execute("INSERT INTO apps VALUES (1, 'Acme')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def snapshot_dir(tmp_path: Path) -> Path:
+    return tmp_path / "snapshots"
+
+
+def _row_count(db: Path) -> int:
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute("SELECT COUNT(*) FROM apps").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _seed_snapshot(snapshot_dir: Path, when: date) -> Path:
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    p = snapshot_dir / f"{SNAPSHOT_PREFIX}-{when.isoformat()}.db"
+    sqlite3.connect(str(p)).close()
+    return p
+
+
+class TestSnapshotCreation:
+    def test_creates_snapshot_with_data(self, live_db: Path, snapshot_dir: Path):
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, keep=7)
+        assert result.snapshot_path.exists()
+        assert _row_count(result.snapshot_path) == 1
+
+    def test_filename_is_iso_dated(self, live_db: Path, snapshot_dir: Path):
+        today = date(2026, 5, 12)
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=7)
+        assert result.snapshot_path.name == f"{SNAPSHOT_PREFIX}-2026-05-12.db"
+
+    def test_dry_run_writes_nothing(self, live_db: Path, snapshot_dir: Path):
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, keep=7, dry_run=True)
+        assert result.dry_run is True
+        assert not result.snapshot_path.exists()
+        assert not snapshot_dir.exists()
+
+    def test_missing_source_raises(self, tmp_path: Path, snapshot_dir: Path):
+        with pytest.raises(FileNotFoundError):
+            snapshot(db_path=tmp_path / "does-not-exist.db", snapshot_dir=snapshot_dir)
+
+    def test_overwrites_same_day_snapshot(self, live_db: Path, snapshot_dir: Path):
+        today = date(2026, 5, 12)
+        snapshot(db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=7)
+        # Add another row, snapshot again on the same day.
+        conn = sqlite3.connect(str(live_db))
+        conn.execute("INSERT INTO apps VALUES (2, 'Globex')")
+        conn.commit()
+        conn.close()
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=7)
+        assert _row_count(result.snapshot_path) == 2
+
+
+class TestRotation:
+    def test_prunes_beyond_keep_window(self, live_db: Path, snapshot_dir: Path):
+        today = date(2026, 5, 12)
+        # Seed 9 prior dated snapshots, oldest first.
+        seeded = [_seed_snapshot(snapshot_dir, today - timedelta(days=i)) for i in range(9, 0, -1)]
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=7)
+        remaining = _list_snapshots(snapshot_dir)
+        # 7-day window includes today's new one + 6 most-recent prior.
+        assert len(remaining) == 7
+        assert result.snapshot_path in remaining
+        # The two oldest from the seed should be in the pruned set.
+        assert seeded[0] in result.pruned
+        assert seeded[1] in result.pruned
+        # The newest two seed entries should survive.
+        assert seeded[-1] in remaining
+        assert seeded[-2] in remaining
+
+    def test_keep_one_only_today_survives(self, live_db: Path, snapshot_dir: Path):
+        today = date(2026, 5, 12)
+        _seed_snapshot(snapshot_dir, today - timedelta(days=1))
+        _seed_snapshot(snapshot_dir, today - timedelta(days=2))
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=1)
+        remaining = _list_snapshots(snapshot_dir)
+        assert remaining == [result.snapshot_path]
+
+    def test_dry_run_reports_prune_set_without_acting(self, live_db: Path, snapshot_dir: Path):
+        today = date(2026, 5, 12)
+        old = _seed_snapshot(snapshot_dir, today - timedelta(days=30))
+        result = snapshot(
+            db_path=live_db, snapshot_dir=snapshot_dir, when=today, keep=7, dry_run=True
+        )
+        assert old in result.pruned
+        # Nothing was actually written or pruned.
+        assert old.exists()
+        assert not result.snapshot_path.exists()
+
+
+class TestAtomicity:
+    def test_no_partial_file_lingers_on_success(self, live_db: Path, snapshot_dir: Path):
+        snapshot(db_path=live_db, snapshot_dir=snapshot_dir, keep=7)
+        partials = list(snapshot_dir.glob("*.partial"))
+        assert partials == []
+
+    def test_snapshot_isolated_from_live_writes(self, live_db: Path, snapshot_dir: Path):
+        """A snapshot taken before a write must not reflect that write."""
+        result = snapshot(db_path=live_db, snapshot_dir=snapshot_dir, keep=7)
+        conn = sqlite3.connect(str(live_db))
+        conn.execute("INSERT INTO apps VALUES (99, 'AfterSnapshot')")
+        conn.commit()
+        conn.close()
+        assert _row_count(result.snapshot_path) == 1
+        assert _row_count(live_db) == 2

--- a/tools/snapshot_db.py
+++ b/tools/snapshot_db.py
@@ -1,0 +1,187 @@
+"""Atomic, rotating SQLite snapshot of the Career-OS database.
+
+Why this exists
+---------------
+On 2026-05-11 a downstream user's full job-search dataset (127 applications +
+79 packages + 90 audit rows) was wiped by a single API call. The previous
+recovery path was "hope a periodic backup happened to land in the right week."
+This script makes recovery cheap and predictable:
+
+  - Daily snapshot at a known location: data/snapshots/career_os-YYYY-MM-DD.db
+  - Rotation keeps the last N days (default 7); older snapshots are pruned
+  - SQLite online backup API (NOT plain ``cp``) so the snapshot is consistent
+    even if the live DB is mid-transaction under WAL
+  - Atomic publish: write to ``*.partial``, fsync, rename — a crash mid-script
+    never leaves a corrupt file as the newest "good" snapshot
+
+Usage
+-----
+    python tools/snapshot_db.py                 # default: data/career_os.db -> data/snapshots/
+    python tools/snapshot_db.py --dry-run       # show what would happen, do not write
+    python tools/snapshot_db.py --keep 14       # retain 14 days instead of 7
+    python tools/snapshot_db.py --db PATH       # snapshot a different DB
+
+Recovery
+--------
+    cp data/snapshots/career_os-2026-05-04.db data/career_os.db
+    rm -f data/career_os.db-shm data/career_os.db-wal
+    # restart the server, verify counts
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+DEFAULT_DB = Path("data/career_os.db")
+DEFAULT_SNAPSHOT_DIR = Path("data/snapshots")
+DEFAULT_KEEP = 7
+SNAPSHOT_PREFIX = "career_os"
+
+
+@dataclass
+class SnapshotResult:
+    snapshot_path: Path
+    pruned: list[Path]
+    dry_run: bool
+
+
+def _snapshot_filename(when: date) -> str:
+    return f"{SNAPSHOT_PREFIX}-{when.isoformat()}.db"
+
+
+def _date_from_filename(name: str) -> date | None:
+    prefix = f"{SNAPSHOT_PREFIX}-"
+    suffix = ".db"
+    if not (name.startswith(prefix) and name.endswith(suffix)):
+        return None
+    try:
+        return date.fromisoformat(name[len(prefix):-len(suffix)])
+    except ValueError:
+        return None
+
+
+def _list_snapshots(snapshot_dir: Path) -> list[Path]:
+    if not snapshot_dir.exists():
+        return []
+    return sorted(
+        p for p in snapshot_dir.iterdir()
+        if p.is_file()
+        and p.name.startswith(f"{SNAPSHOT_PREFIX}-")
+        and p.name.endswith(".db")
+    )
+
+
+def _backup_sqlite(src: Path, dst: Path) -> None:
+    """Use SQLite's online backup API to copy ``src`` to ``dst``.
+
+    Reads the live DB consistently even with concurrent writers.
+    """
+    src_conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+    try:
+        dst_conn = sqlite3.connect(str(dst))
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
+
+
+def _fsync_file(path: Path) -> None:
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def snapshot(
+    db_path: Path = DEFAULT_DB,
+    snapshot_dir: Path = DEFAULT_SNAPSHOT_DIR,
+    keep: int = DEFAULT_KEEP,
+    when: date | None = None,
+    dry_run: bool = False,
+) -> SnapshotResult:
+    """Create a dated snapshot and prune anything older than ``keep`` days.
+
+    Today's snapshot replaces any previous one with the same date.
+    """
+    if not db_path.exists():
+        raise FileNotFoundError(f"Source DB not found: {db_path}")
+    when = when or date.today()
+
+    target = snapshot_dir / _snapshot_filename(when)
+    partial = target.with_suffix(target.suffix + ".partial")
+
+    # Date-based retention: anything dated more than (keep - 1) days before
+    # `when` is pruned. `keep=7` with today=2026-05-12 keeps 2026-05-06..12.
+    # Filenames not matching the expected date pattern are left alone.
+    cutoff = when - timedelta(days=keep - 1)
+    existing = _list_snapshots(snapshot_dir)
+    to_prune: list[Path] = []
+    for p in existing:
+        snap_date = _date_from_filename(p.name)
+        if snap_date is not None and snap_date < cutoff:
+            to_prune.append(p)
+
+    if dry_run:
+        return SnapshotResult(snapshot_path=target, pruned=to_prune, dry_run=True)
+
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    if partial.exists():
+        partial.unlink()
+    _backup_sqlite(db_path, partial)
+    _fsync_file(partial)
+    os.replace(partial, target)
+    _fsync_file(target)
+
+    for p in to_prune:
+        p.unlink()
+
+    return SnapshotResult(snapshot_path=target, pruned=to_prune, dry_run=False)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB,
+                        help=f"Source DB path (default: {DEFAULT_DB})")
+    parser.add_argument("--snapshot-dir", type=Path, default=DEFAULT_SNAPSHOT_DIR,
+                        help=f"Directory for snapshots (default: {DEFAULT_SNAPSHOT_DIR})")
+    parser.add_argument("--keep", type=int, default=DEFAULT_KEEP,
+                        help=f"Days of snapshots to retain (default: {DEFAULT_KEEP})")
+    parser.add_argument("--dry-run", action="store_true", help="report only, do not write")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        result = snapshot(
+            db_path=args.db,
+            snapshot_dir=args.snapshot_dir,
+            keep=args.keep,
+            dry_run=args.dry_run,
+        )
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    label = "[dry-run] would write" if result.dry_run else "wrote"
+    print(f"{label}: {result.snapshot_path}")
+    if result.pruned:
+        verb = "would prune" if result.dry_run else "pruned"
+        for p in result.pruned:
+            print(f"  {verb}: {p}")
+    elif args.dry_run:
+        print("  nothing to prune")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #366.

## Summary

`DELETE /api/profiles/{id}` wrapped `db.delete(profile)` in a `try/except IntegrityError` that was never reachable. SQLAlchemy's `cascade="all, delete-orphan"` on every Profile relationship silently wipes child rows at the ORM layer before the database ever sees a foreign-key violation, so the `except` block is dead code. One stray API call (curl, web-UI button, future REST client bug) was enough to wipe the entire job-search dataset for a profile.

A real downstream incident on 2026-05-11 confirmed the shape: 127 applications + 79 packages + 90 audit rows lost in one call, recovered only because a ~12-day-old backup happened to exist.

## What this PR does

**Safer default + opt-in cascade:**
- Plain `DELETE /api/profiles/{id}` now counts every child table that references `profile_id` in a single SQL round-trip and returns **409 Conflict** with per-table counts if any are non-zero. The unreachable `IntegrityError` block is removed.
- `DELETE /api/profiles/{id}?force=true` preserves the previous cascade behavior as an explicit opt-in.
- The 7 existing `test_delete_cascades_*` tests in `test_profiles_crud.py` now pass `?force=true` (the cascade behavior they verify is still supported — just no longer default).

**Recovery becomes a one-liner:**
- New `tools/snapshot_db.py` makes daily SQLite snapshots using the online backup API (not `cp` — WAL safety), writes atomically (`*.partial` → `fsync` → `rename`), and prunes anything older than the keep window (default 7 days).
- README has a new "Snapshots and recovery" section under "Your data stays yours" with the cron snippet and recovery one-liner.

## Test plan

- [x] `pytest tests/test_profile_delete_safety.py` → **10 passed** (new file)
- [x] `pytest tests/test_snapshot_db.py` → **10 passed** (new file, includes atomicity + retention coverage)
- [x] `pytest tests/test_profiles_*` → **87 passed** (full profile API regression)
- [x] `pytest -q --ignore=tests/legacy --ignore=tests/fuzz` → **3670 passed**, 7 pre-existing provider/env failures unrelated to this PR (also fail on `main`)
- [x] Manual `.venv/bin/python tools/snapshot_db.py --dry-run` → reports expected target
- [ ] Reviewer: confirm the `child_counts` shape in the 409 body is the right contract; alternative is a simpler text message

## Breaking change note

For downstream users who currently rely on `DELETE /api/profiles/{id}` cascading: the call now returns 409 unless `?force=true` is added. The existing test suite was updated to reflect this. Frontend code (if any) calling `DELETE` should be updated to pass `?force=true` when intentional cleanup is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)