### PR TITLE
feat(G-627): per-role qualifying-question overlay for batch_apply_browser

### DIFF
--- a/tests/test_batch_apply_overlay.py
+++ b/tests/test_batch_apply_overlay.py
@@ -1,0 +1,221 @@
+"""Tests for the per-role Greenhouse qualifying-question overlay (G-627 / issue #347).
+
+Covers `_get_gh_fields_for_slug` and the pre-seeded `GH_FIELDS_BY_SLUG` map
+in `tools/batch_apply_browser.py`. These tests are intentionally pure-Python
+(no Playwright, no network, no config files) so they run in CI regardless of
+whether `config/personal.yaml` is present.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# `tools.batch_apply_browser` loads `config/personal.yaml` eagerly at import
+# time. CI (.github/workflows/ci.yml and smoke.yml) copies
+# `config/personal.yaml.example -> config/personal.yaml` before running tests.
+# We replicate that here so this test module always loads — pure-logic tests
+# don't need real PII and shouldn't silently skip on fresh worktrees.
+_personal_config = _REPO_ROOT / "config" / "personal.yaml"
+_personal_example = _REPO_ROOT / "config" / "personal.yaml.example"
+if not _personal_config.exists() and _personal_example.exists():
+    shutil.copy(_personal_example, _personal_config)
+
+# If neither file exists, fall back to skip (matches test_batch_apply_browser.py).
+if not _personal_config.exists():
+    pytest.skip(
+        "config/personal.yaml{.example} not found — skipping overlay tests",
+        allow_module_level=True,
+    )
+
+from tools.batch_apply_browser import (  # noqa: E402
+    GH_FIELDS_BY_SLUG,
+    _get_gh_fields_for_slug,
+)
+
+# Stable baseline used across tests — a minimal stand-in for the real
+# Anthropic Greenhouse baseline. Decoupled from production strings so test
+# breaks signal real merge-logic regressions, not copy edits.
+BASELINE: list[tuple[str, str, bool]] = [
+    ("Country", "United Kingdom", False),
+    ("Why Anthropic", "baseline-why", False),
+    ("Working address", "London", False),
+]
+
+
+# ---------------------------------------------------------------------------
+# baseline-only path (no slug match)
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineOnlyPath:
+    """When the slug matches no overlay key, baseline is returned unchanged."""
+
+    def test_unknown_slug_returns_baseline_copy(self):
+        result = _get_gh_fields_for_slug(BASELINE, "stripe-payments-engineer", overlay={})
+        assert result == BASELINE
+
+    def test_empty_slug_returns_baseline_copy(self):
+        result = _get_gh_fields_for_slug(BASELINE, "", overlay={})
+        assert result == BASELINE
+
+    def test_none_slug_returns_baseline_copy(self):
+        # _get_gh_fields_for_slug must tolerate None defensively — app.get("slug")
+        # can return None when slug is missing.
+        result = _get_gh_fields_for_slug(BASELINE, None, overlay={})  # type: ignore[arg-type]
+        assert result == BASELINE
+
+    def test_returns_new_list_not_baseline_reference(self):
+        # Caller must not mutate the canonical baseline when iterating results.
+        result = _get_gh_fields_for_slug(BASELINE, "no-match", overlay={})
+        assert result is not BASELINE
+        result.append(("injected", "value", False))
+        assert ("injected", "value", False) not in BASELINE
+
+    def test_non_anthropic_greenhouse_role_unaffected(self):
+        # Regression guard for issue #347 acceptance criteria — generic
+        # Greenhouse postings must keep working with baseline only.
+        result = _get_gh_fields_for_slug(BASELINE, "vercel-staff-engineer")
+        # Real overlay map should not contain Vercel.
+        assert result == BASELINE
+
+
+# ---------------------------------------------------------------------------
+# overlay-merge for a known slug
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayMerge:
+    """When the slug matches an overlay key, extras are appended after baseline."""
+
+    def test_exact_slug_match_appends_extras(self):
+        overlay = {
+            "anthropic-tdl-paris": [
+                ("French C1", "No", False),
+                ("e2e delivery", "Yes", False),
+            ]
+        }
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-tdl-paris", overlay=overlay)
+        assert result[: len(BASELINE)] == BASELINE
+        assert ("French C1", "No", False) in result
+        assert ("e2e delivery", "Yes", False) in result
+        assert len(result) == len(BASELINE) + 2
+
+    def test_substring_slug_match_appends_extras(self):
+        # Real-world scrapes often append a city/seq suffix to the slug.
+        overlay = {"anthropic-tdl": [("French C1", "No", False)]}
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-tdl-paris-2026q2", overlay=overlay)
+        assert ("French C1", "No", False) in result
+
+    def test_case_insensitive_slug_match(self):
+        overlay = {"anthropic-tdl": [("French C1", "No", False)]}
+        result = _get_gh_fields_for_slug(BASELINE, "Anthropic-TDL-Paris", overlay=overlay)
+        assert ("French C1", "No", False) in result
+
+    def test_overlay_order_preserved(self):
+        overlay = {
+            "anthropic-mgr-fde": [
+                ("managed engineering teams", "Yes", False),
+                ("regulated industries", "Yes", False),
+                ("forward-deployed", "Yes", False),
+            ]
+        }
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-mgr-fde", overlay=overlay)
+        extras = result[len(BASELINE) :]
+        assert [t[0] for t in extras] == [
+            "managed engineering teams",
+            "regulated industries",
+            "forward-deployed",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# no-collision behaviour when baseline + overlay share a label
+# ---------------------------------------------------------------------------
+
+
+class TestNoCollision:
+    """Baseline answers must always win over overlay duplicates."""
+
+    def test_collision_keeps_baseline_value(self):
+        overlay = {
+            "anthropic-tdl": [
+                ("Country", "France", False),  # collides with baseline
+                ("French C1", "No", False),
+            ]
+        }
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-tdl", overlay=overlay)
+        # Exactly one Country entry, and it's the baseline value.
+        countries = [t for t in result if t[0] == "Country"]
+        assert len(countries) == 1
+        assert countries[0] == ("Country", "United Kingdom", False)
+        # The non-colliding overlay extra still gets appended.
+        assert ("French C1", "No", False) in result
+
+    def test_full_overlap_returns_baseline(self):
+        overlay = {
+            "anthropic-tdl": [
+                ("Country", "France", False),
+                ("Why Anthropic", "overlay-why", False),
+            ]
+        }
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-tdl", overlay=overlay)
+        assert result == BASELINE
+
+
+# ---------------------------------------------------------------------------
+# pre-seeded overlay sanity
+# ---------------------------------------------------------------------------
+
+
+class TestPreSeededOverlay:
+    """Smoke-test the three roles called out in issue #347."""
+
+    @pytest.mark.parametrize(
+        "slug_key",
+        [
+            "anthropic-technical-deployment-lead",
+            "anthropic-manager-fde-applied-ai",
+            "anthropic-solutions-architect",
+        ],
+    )
+    def test_each_pre_seeded_slug_has_non_empty_overlay(self, slug_key):
+        assert slug_key in GH_FIELDS_BY_SLUG, f"missing overlay for {slug_key}"
+        extras = GH_FIELDS_BY_SLUG[slug_key]
+        assert len(extras) >= 3, f"overlay for {slug_key} should have 3+ qualifying questions"
+        for entry in extras:
+            assert isinstance(entry, tuple) and len(entry) == 3
+            label, value, exact = entry
+            assert isinstance(label, str) and label
+            assert isinstance(value, str) and value
+            assert isinstance(exact, bool)
+
+    def test_tdl_paris_includes_french_proficiency(self):
+        # The actual gating filter for TDL Paris per issue #347.
+        extras = GH_FIELDS_BY_SLUG["anthropic-technical-deployment-lead"]
+        labels = " ".join(label for label, _v, _e in extras).lower()
+        assert "french" in labels
+
+    def test_architect_munich_includes_german_proficiency(self):
+        extras = GH_FIELDS_BY_SLUG["anthropic-solutions-architect"]
+        labels = " ".join(label for label, _v, _e in extras).lower()
+        assert "german" in labels
+
+    def test_anthropic_irl_falls_through_to_baseline(self):
+        # IRL has no role-specific qualifying questions in the current scrape
+        # (acceptance criterion 4 in issue #347).
+        result = _get_gh_fields_for_slug(BASELINE, "anthropic-international-readiness")
+        assert result == BASELINE
+
+    def test_default_overlay_is_used_when_overlay_arg_omitted(self):
+        # When `overlay=` is not passed, the function should consult the
+        # module-level GH_FIELDS_BY_SLUG. Patch it to verify the lookup path.
+        sentinel = {"anthropic-test-slug": [("sentinel-label", "Yes", False)]}
+        with patch("tools.batch_apply_browser.GH_FIELDS_BY_SLUG", sentinel):
+            result = _get_gh_fields_for_slug(BASELINE, "anthropic-test-slug")
+        assert ("sentinel-label", "Yes", False) in result

--- a/tools/batch_apply_browser.py
+++ b/tools/batch_apply_browser.py
@@ -458,6 +458,91 @@ N8N_WHY = (
     "and it's here. That matters to me."
 )
 
+# ---------------------------------------------------------------------------
+# Per-role Greenhouse qualifying-question overlays (G-627 / issue #347)
+# ---------------------------------------------------------------------------
+#
+# Anthropic Greenhouse postings ask role-specific Yes/No qualifying questions
+# in addition to the shared baseline (Country, visa, Why Anthropic, etc.).
+# These questions vary per role and are often the actual gating filter, so
+# leaving them blank causes silent auto-rejects.
+#
+# `GH_FIELDS_BY_SLUG` maps an application's `slug` (lowercased) to extra
+# `(label_text, value, exact_match)` tuples that get *appended* to the shared
+# baseline at form-fill time via `_get_gh_fields_for_slug()`. Slug lookups are
+# substring matches so minor slug-suffix variations between scrapes
+# (e.g. `anthropic-technical-deployment-lead-paris`) still resolve.
+#
+# TODO(G-627): the values below are conservative placeholders aligned with
+# the maintainer's profile but have NOT been verified field-by-field against
+# any `cv/applications/<slug>/form-answers.md`. Verify with user before live
+# submission. Dry-run is safe.
+
+# Anthropic — Technical Deployment Lead (Paris)
+# Source: GitHub issue #347 body, "TDL Paris asks:" section
+_GH_ANTHROPIC_TDL_PARIS: list[tuple[str, str, bool]] = [
+    ("owned e2e delivery of technical programmes", "Yes", False),
+    ("native or C1-level French", "No", False),  # TODO: verify with user before submit
+    ("delivered AI/ML/LLM into production", "Yes", False),
+    ("led delivery engagements with C-suite", "Yes", False),
+]
+
+# Anthropic — Manager, Forward Deployed Engineering (London)
+# Source: GitHub issue #347 body, "Mgr FDE London asks:" section
+_GH_ANTHROPIC_MGR_FDE_LONDON: list[tuple[str, str, bool]] = [
+    ("directly managed engineering teams", "Yes", False),
+    ("building/leading technical delivery teams in enterprise", "Yes", False),
+    ("navigating regulated industries", "Yes", False),
+]
+
+# Anthropic — Applied AI Architect (Munich)
+# Source: GitHub issue #347 body, "Applied AI Architect Munich asks:" section
+_GH_ANTHROPIC_ARCHITECT_MUNICH: list[tuple[str, str, bool]] = [
+    ("7+ years pre-sales technical role", "Yes", False),  # TODO: verify with user before submit
+    ("Hands-on AI/ML in customer-facing", "Yes", False),
+    ("Technical demonstrations to C-level", "Yes", False),
+    ("Professional fluency in German", "No", False),  # TODO: verify with user before submit
+]
+
+GH_FIELDS_BY_SLUG: dict[str, list[tuple[str, str, bool]]] = {
+    "anthropic-technical-deployment-lead": _GH_ANTHROPIC_TDL_PARIS,
+    "anthropic-manager-fde-applied-ai": _GH_ANTHROPIC_MGR_FDE_LONDON,
+    "anthropic-solutions-architect": _GH_ANTHROPIC_ARCHITECT_MUNICH,
+}
+
+
+def _get_gh_fields_for_slug(
+    baseline: list[tuple[str, str, bool]],
+    slug: str,
+    overlay: dict[str, list[tuple[str, str, bool]]] | None = None,
+) -> list[tuple[str, str, bool]]:
+    """Merge baseline Greenhouse fields with any per-slug qualifying-question overlay.
+
+    Args:
+        baseline: shared Greenhouse field list applied to every role.
+        slug: application slug (case-insensitive); typically `app["slug"]`.
+        overlay: optional override mapping for tests; defaults to GH_FIELDS_BY_SLUG.
+
+    Returns:
+        baseline + extras for the first overlay key found as a substring of slug.
+        If a question label is defined in both baseline and overlay, the baseline
+        entry wins (de-duped by exact label string) so role-specific values can't
+        accidentally override shared answers like "Why Anthropic".
+    """
+    if overlay is None:
+        overlay = GH_FIELDS_BY_SLUG
+    slug_l = (slug or "").lower()
+    extras: list[tuple[str, str, bool]] = []
+    for key, fields in overlay.items():
+        if key in slug_l:
+            extras = fields
+            break
+    if not extras:
+        return list(baseline)
+    seen_labels = {label for label, _value, _exact in baseline}
+    deduped_extras = [t for t in extras if t[0] not in seen_labels]
+    return list(baseline) + deduped_extras
+
 
 async def _fill_field_by_label(page, label_text: str, value: str, exact: bool = False) -> bool:
     """Find an input/textarea/select near a label containing `label_text` and fill it.
@@ -764,7 +849,7 @@ async def fill_custom_questions(page, app: dict) -> None:
     from career_os.utils.url_validation import url_has_domain
 
     if url_has_domain(url, "greenhouse.io") and ("anthropic" in slug or "anthropic" in url.lower()):
-        gh_fields = [
+        gh_fields_baseline: list[tuple[str, str, bool]] = [
             # (label_text, value, exact_match)
             ("Country", "United Kingdom", False),
             ("open to working in-person 25%", "Yes", False),
@@ -777,6 +862,9 @@ async def fill_custom_questions(page, app: dict) -> None:
             ("experience with Claude Code", ANTHROPIC_CLAUDE_CODE_EXP, False),
             ("Working address", PERSONAL["location"], False),
         ]
+        # Append any per-role qualifying-question overlay (G-627). Non-Anthropic
+        # Greenhouse roles fall through with baseline only — no regression.
+        gh_fields = _get_gh_fields_for_slug(gh_fields_baseline, slug)
         for label, value, exact in gh_fields:
             try:
                 filled = await _fill_field_by_label(page, label, value, exact=exact)


### PR DESCRIPTION
## Summary

- Adds `GH_FIELDS_BY_SLUG` + `_get_gh_fields_for_slug()` in `tools/batch_apply_browser.py` so Anthropic Greenhouse roles can layer role-specific Yes/No qualifying questions on top of the shared baseline. Until now these silently submitted blank and triggered auto-rejects.
- Pre-seeded entries for the three roles flagged in issue #347:
  - `anthropic-technical-deployment-lead` (TDL Paris) — 4 quals incl. French C1 proficiency
  - `anthropic-manager-fde-applied-ai` (Mgr FDE London) — 3 quals incl. regulated-industry experience
  - `anthropic-solutions-architect` (Architect Munich) — 4 quals incl. German C1 proficiency
- Anthropic IRL has no role-specific quals in the current scrape, so it falls through with baseline only — explicitly verified by a test.
- Non-Anthropic Greenhouse roles are unaffected (the call site is inside the existing `anthropic in slug` branch, and the baseline is returned unchanged for any non-matching slug).

Closes #347

## Design choice: Option A (slug map), not Option B (form-answers.md parser)

The issue lists both options and recommends Option B for less drift. This PR ships **Option A** as the first cut for two reasons:

1. **Scope match.** Option A is ~90 lines of well-tested Python that solves the immediate auto-reject problem. Option B requires designing a markdown schema, writing a parser with fuzzy field-type detection, and handling the validation/field-type-mismatch test surface laid out in the issue's "Validation & Testing" addendum — closer to a multi-day epic.
2. **Data lives elsewhere.** The `cv/applications/<slug>/form-answers.md` tree referenced in the issue lives in a separate repo (`Eyas`), not in this one. Wiring up a parser would force a cross-repo design decision that's worth doing on its own ticket.

Option B remains a viable follow-up: drop in a parser, register it as another source feeding into `_get_gh_fields_for_slug()`, and Option A becomes the fallback for roles without a form-answers file.

## Pre-seeded roles

| Slug substring | Role | # Quals | Notes |
|---|---|---|---|
| `anthropic-technical-deployment-lead` | TDL Paris | 4 | French C1 is the actual gating filter |
| `anthropic-manager-fde-applied-ai` | Mgr FDE London | 3 | FSI regulated-industry experience |
| `anthropic-solutions-architect` | Architect Munich | 4 | German C1 is the actual gating filter |

Slug matching is case-insensitive substring, so suffix variations between scrapes (e.g. `-paris-2026q2`) still resolve.

## Follow-up: placeholder values to verify

Three values in the pre-seeded overlay are conservative placeholders, flagged with `TODO: verify with user before submit` inline:

- TDL Paris: `"native or C1-level French"` → `"No"`
- Architect Munich: `"7+ years pre-sales technical role"` → `"Yes"`
- Architect Munich: `"Professional fluency in German"` → `"No"`

These need a one-pass verification against `cv/applications/<slug>/form-answers.md` (in the Eyas repo) before the next live submit. Dry-run is safe regardless. Tracked in code; suggest a 5-min G-ticket if review wants this surfaced separately.

## Test plan

- [x] `pytest tests/test_batch_apply_overlay.py -v` — 18/18 pass (baseline-only, overlay-merge, collision handling, pre-seeded sanity)
- [x] `pytest tests/test_batch_apply_browser.py` — 65/65 pass, no regression
- [x] `pytest tests/` — full suite green (3687 passed, 22 skipped)
- [x] `ruff check tests/test_batch_apply_overlay.py` — clean
- [x] `ruff format --check tools/batch_apply_browser.py tests/test_batch_apply_overlay.py` — clean
- [ ] Manual dry-run against live TDL Paris / Mgr FDE / Architect Munich Greenhouse postings (requires browser session; not in CI scope)