### PR TITLE
feat(G-626): dispatch React-combobox dropdowns in batch_apply_browser

### DIFF
--- a/tests/test_batch_apply_browser.py
+++ b/tests/test_batch_apply_browser.py
@@ -903,6 +903,223 @@ class TestSelectDropdownOption:
         assert result is True
         select_loc.first.select_option.assert_called_with(label="Europe")
 
+    @pytest.mark.asyncio
+    async def test_dispatches_portaled_combobox_when_no_label_match(self):
+        """When neither label nor div matches but a global combobox trigger
+        with matching aria-label exists, we still drive the portaled menu.
+
+        This covers the Anthropic Greenhouse pattern where the visible label
+        isn't a <label> element and isn't a wrapping div either."""
+        from tools.batch_apply_browser import _select_dropdown_option
+
+        trigger_loc = _make_found_locator(tag="button")
+        option_loc = _make_found_locator()
+
+        page = make_page_with_fields(
+            {
+                'button[aria-haspopup="listbox"]': trigger_loc,
+                'role="option"': option_loc,
+            }
+        )
+
+        result = await _select_dropdown_option(page, "Do you require visa sponsorship?", "No")
+        assert result is True
+        # Trigger was clicked to open the portaled listbox
+        trigger_loc.first.click.assert_called()
+        # Option was clicked AND a mousedown was dispatched (react-select pattern)
+        option_loc.first.click.assert_called()
+        option_loc.first.dispatch_event.assert_called_with("mousedown")
+
+    @pytest.mark.asyncio
+    async def test_portaled_fallback_when_inline_option_missing(self):
+        """When the label is found and a button trigger exists near it but
+        the inline-option lookup returns nothing, we fall through to the
+        portaled-menu path so an option in document.body is still picked."""
+        from tools.batch_apply_browser import _select_dropdown_option
+
+        label_loc = _make_found_locator()
+        parent_loc = AsyncMock()
+        # The inline trigger is a button (so the native-select branch is skipped).
+        button_loc = _make_found_locator(tag="button")
+        parent_loc.locator = MagicMock(return_value=button_loc)
+        label_loc.first.locator = MagicMock(return_value=parent_loc)
+
+        # Inline option lookup returns nothing — simulates a portaled menu
+        # that's NOT inside the label's parent.
+        empty_option_loc = _make_empty_locator()
+        # But a page-scoped portaled option exists.
+        portaled_option_loc = _make_found_locator()
+
+        # Distinguish between inline and portaled selectors using has-text
+        # on different keys: inline option selector contains the option text,
+        # the portaled selector also does. We want the FIRST option lookup
+        # (the inline one) to return empty and the SECOND (portaled) to find.
+        # Easiest: have field_map return the empty locator for
+        # 'role="option"' AND a different match for the portaled path?
+        # Actually the inline lookup uses the same role="option" selector.
+        # We side-step this by making the inline call return empty via a
+        # counter-based factory.
+        call_count = {"n": 0}
+
+        def factory(sel):
+            if 'role="option"' in sel:
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    return empty_option_loc
+                return portaled_option_loc
+            if 'label:has-text("Visa")' in sel:
+                return label_loc
+            return _make_empty_locator()
+
+        page = AsyncMock()
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.locator = MagicMock(side_effect=factory)
+        page.get_by_text = MagicMock(return_value=_make_empty_locator())
+
+        result = await _select_dropdown_option(page, "Visa", "No")
+        assert result is True
+        button_loc.first.click.assert_called()
+        portaled_option_loc.first.click.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _click_portaled_option and _select_portaled_combobox
+# ---------------------------------------------------------------------------
+
+
+class TestPortaledComboboxDispatch:
+    """Cover the new portaled-React-combobox dispatch path (G-626)."""
+
+    @pytest.mark.asyncio
+    async def test_click_portaled_option_dispatches_mousedown_and_click(self):
+        from tools.batch_apply_browser import _click_portaled_option
+
+        option_loc = _make_found_locator()
+        page = make_page_with_fields({'role="option"': option_loc})
+
+        result = await _click_portaled_option(page, "Yes")
+        assert result is True
+        option_loc.first.dispatch_event.assert_called_with("mousedown")
+        option_loc.first.click.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_click_portaled_option_survives_dispatch_failure(self):
+        """If dispatch_event raises (older Playwright / weird mock), we still
+        click. This is the safety net referenced in the docstring."""
+        from tools.batch_apply_browser import _click_portaled_option
+
+        option_loc = _make_found_locator()
+        option_loc.first.dispatch_event = AsyncMock(side_effect=RuntimeError("no dispatch"))
+        page = make_page_with_fields({'role="option"': option_loc})
+
+        result = await _click_portaled_option(page, "Yes")
+        assert result is True
+        option_loc.first.click.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_click_portaled_option_returns_false_when_not_found(self):
+        from tools.batch_apply_browser import _click_portaled_option
+
+        page = make_page_with_fields({})
+
+        result = await _click_portaled_option(page, "Anything")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_select_portaled_combobox_uses_aria_haspopup_trigger(self):
+        """The Anthropic pattern: <button aria-haspopup="listbox"> opens a
+        portaled <div role="listbox"> in document.body."""
+        from tools.batch_apply_browser import _select_portaled_combobox
+
+        trigger_loc = _make_found_locator(tag="button")
+        option_loc = _make_found_locator()
+        page = make_page_with_fields(
+            {
+                'button[aria-haspopup="listbox"]': trigger_loc,
+                'role="option"': option_loc,
+            }
+        )
+
+        result = await _select_portaled_combobox(page, "Are you open to relocation?", "Yes")
+        assert result is True
+        trigger_loc.first.click.assert_called()
+        option_loc.first.click.assert_called()
+        option_loc.first.dispatch_event.assert_called_with("mousedown")
+
+    @pytest.mark.asyncio
+    async def test_select_portaled_combobox_returns_false_with_no_trigger(self):
+        from tools.batch_apply_browser import _select_portaled_combobox
+
+        page = make_page_with_fields({})
+        # All selectors return empty — no combobox trigger anywhere.
+        result = await _select_portaled_combobox(page, "Anything", "Value")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_select_portaled_combobox_skips_failing_selectors(self):
+        """Some Playwright selectors (e.g. :has() with certain inner exprs)
+        may raise. We should swallow those and keep trying other patterns."""
+        from tools.batch_apply_browser import _select_portaled_combobox
+
+        # First selectors raise; final selector finds the trigger.
+        trigger_loc = _make_found_locator(tag="button")
+        option_loc = _make_found_locator()
+
+        def factory(sel):
+            if "aria-label" in sel:
+                # Simulate Playwright rejecting this selector
+                raise ValueError("bad selector")
+            if "aria-haspopup" in sel:
+                return trigger_loc
+            if 'role="option"' in sel:
+                return option_loc
+            return _make_empty_locator()
+
+        page = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.locator = MagicMock(side_effect=factory)
+        page.get_by_text = MagicMock(return_value=_make_empty_locator())
+
+        result = await _select_portaled_combobox(page, "Label", "Value")
+        assert result is True
+        trigger_loc.first.click.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _fill_field_by_label falls through to portaled combobox
+# ---------------------------------------------------------------------------
+
+
+class TestFillFieldByLabelComboboxFallback:
+    @pytest.mark.asyncio
+    async def test_falls_through_to_combobox_when_no_sibling_input(self):
+        """If the label is found but no input/textarea/select sibling exists,
+        and the field is actually a portaled React combobox, the new fallback
+        should drive it."""
+        from tools.batch_apply_browser import _fill_field_by_label
+
+        label_loc = _make_found_locator()
+        label_loc.first.get_attribute = AsyncMock(return_value=None)
+        # Sibling lookup returns empty for every tag.
+        label_loc.first.locator = MagicMock(return_value=_make_empty_locator())
+
+        trigger_loc = _make_found_locator(tag="button")
+        option_loc = _make_found_locator()
+
+        page = make_page_with_fields(
+            {
+                'label:has-text("Visa sponsorship")': label_loc,
+                'button[aria-haspopup="listbox"]': trigger_loc,
+                'role="option"': option_loc,
+            }
+        )
+
+        result = await _fill_field_by_label(page, "Visa sponsorship", "No")
+        assert result is True
+        trigger_loc.first.click.assert_called()
+        option_loc.first.click.assert_called()
+
 
 # ---------------------------------------------------------------------------
 # Company-specific constants

--- a/tools/batch_apply_browser.py
+++ b/tools/batch_apply_browser.py
@@ -16,6 +16,7 @@ Usage:
 
 import argparse
 import asyncio
+import contextlib
 import os
 import re
 import sqlite3
@@ -495,6 +496,12 @@ async def _fill_field_by_label(page, label_text: str, value: str, exact: bool = 
                     await sibling.first.fill(value)
                 return True
 
+        # Portaled React combobox fallback (Anthropic Greenhouse pattern):
+        # the labeled control is a <button role="combobox"> whose menu is
+        # rendered into document.body, so the sibling lookup above misses it.
+        if await _select_portaled_combobox(page, label_text, value):
+            return True
+
     # Fallback: search by placeholder or aria-label
     for sel in [
         f'textarea[aria-label*="{label_text}" i]',
@@ -574,9 +581,20 @@ async def _click_radio_by_label(page, label_text: str) -> bool:
 
 
 async def _select_dropdown_option(page, label_text: str, option_text: str) -> bool:
-    """For Ashby-style custom dropdowns: click the dropdown near `label_text`,
-    then select the option matching `option_text`.
-    Returns True if successful.
+    """Dispatch a dropdown-style answer to the field labeled `label_text`.
+
+    Supports three dropdown shapes, tried in order:
+    1. Native ``<select>`` — use Playwright's ``select_option``.
+    2. Inline custom dropdown (Ashby-style) — click the sibling trigger, then
+       click a ``[role="option"]`` rendered in-place.
+    3. Portaled React combobox (Anthropic-style Greenhouse) — click the
+       ``<button>`` trigger (often ``aria-haspopup="listbox"`` or
+       ``role="combobox"``), wait for a ``[role="listbox"]`` that may be
+       portaled to ``document.body``, then click a ``[role="option"]``
+       and dispatch a synthetic ``mousedown`` for libraries that listen
+       on mousedown instead of click.
+
+    Returns True if a dropdown was successfully filled, False otherwise.
     """
     # Find the dropdown trigger near the label
     label_loc = page.locator(f'label:has-text("{label_text}")')
@@ -584,7 +602,11 @@ async def _select_dropdown_option(page, label_text: str, option_text: str) -> bo
         # Try finding by text in a parent div
         label_loc = page.locator(f'div:has-text("{label_text}")')
     if await label_loc.count() == 0:
-        return False
+        # Last resort: portaled combobox where the trigger button carries
+        # aria-label / aria-labelledby with the label text, but the visible
+        # label sits in a separate, non-wrapping element. Fall through to the
+        # portaled-combobox path below using a global trigger search.
+        return await _select_portaled_combobox(page, label_text, option_text)
 
     # Click on the dropdown/select element near the label
     parent = label_loc.first.locator("..")
@@ -595,7 +617,7 @@ async def _select_dropdown_option(page, label_text: str, option_text: str) -> bo
         if tag == "select":
             await el.select_option(label=option_text)
             return True
-        # Custom dropdown: click to open, then click option
+        # Custom dropdown: click to open, then click option (inline first).
         await el.click()
         await page.wait_for_timeout(500)
         option = page.locator(
@@ -605,7 +627,86 @@ async def _select_dropdown_option(page, label_text: str, option_text: str) -> bo
             await option.first.click()
             return True
 
-    return False
+        # Portaled-menu fallback: the listbox may have been rendered into
+        # document.body, outside the label's parent. Try a page-scoped
+        # option lookup and dispatch mousedown for React combobox libs that
+        # commit selection on mousedown rather than click.
+        if await _click_portaled_option(page, option_text):
+            return True
+
+    # Final fallback: search the entire page for a combobox trigger whose
+    # accessible name contains the label, then drive the portaled menu.
+    return await _select_portaled_combobox(page, label_text, option_text)
+
+
+async def _click_portaled_option(page, option_text: str) -> bool:
+    """Click a ``[role="option"]`` rendered anywhere in the document.
+
+    Used after the listbox has been opened — handles React libraries that
+    portal the menu into ``document.body`` (Anthropic Greenhouse pattern).
+    Dispatches a synthetic ``mousedown`` in addition to ``click`` because
+    some libraries (e.g. react-select) commit the selection on mousedown.
+
+    Returns True if an option was clicked, False otherwise.
+    """
+    option = page.locator(
+        f'[role="option"]:has-text("{option_text}"), [role="listbox"] >> text="{option_text}"'
+    )
+    if await option.count() == 0:
+        return False
+    first = option.first
+    # Dispatch mousedown first (some React libs commit on mousedown), then
+    # also click() to cover the click-listening libraries. Either alone is
+    # not sufficient across the ecosystem. Suppress dispatch errors so a
+    # detached node or older Playwright still falls through to click().
+    with contextlib.suppress(Exception):
+        await first.dispatch_event("mousedown")
+    await first.click()
+    return True
+
+
+async def _select_portaled_combobox(page, label_text: str, option_text: str) -> bool:
+    """Open a portaled React combobox keyed by accessible name and pick a value.
+
+    Looks for ``<button>`` elements that act as combobox triggers
+    (``aria-haspopup="listbox"`` or ``role="combobox"``) whose accessible
+    label matches ``label_text``. Clicks the trigger, waits for the
+    portaled listbox to mount, then dispatches the option click via
+    :func:`_click_portaled_option`.
+
+    Returns True on success, False if no matching trigger is found.
+    """
+    # Candidate trigger selectors — order matters: most-specific first.
+    # We match by aria-label or aria-labelledby text via :has(), then fall
+    # back to a button living next to a label that contains the text.
+    trigger_selectors = [
+        f'button[aria-haspopup="listbox"][aria-label*="{label_text}" i]',
+        f'button[role="combobox"][aria-label*="{label_text}" i]',
+        f'[role="combobox"][aria-label*="{label_text}" i]',
+        # Trigger sits inside a container whose label child has the text.
+        f'div:has(> label:has-text("{label_text}")) button[aria-haspopup="listbox"]',
+        f'div:has(> label:has-text("{label_text}")) button[role="combobox"]',
+        f'div:has(label:has-text("{label_text}")) button[aria-haspopup="listbox"]',
+        f'div:has(label:has-text("{label_text}")) button[role="combobox"]',
+    ]
+    trigger = None
+    for sel in trigger_selectors:
+        try:
+            loc = page.locator(sel)
+            if await loc.count() > 0:
+                trigger = loc.first
+                break
+        except Exception:
+            # Some selectors may be rejected by Playwright when the engine
+            # behind :has() doesn't accept the inner expression. Skip and
+            # keep looking — we have several alternatives.
+            continue
+    if trigger is None:
+        return False
+    await trigger.click()
+    # React portals can take a tick to mount; wait briefly before scanning.
+    await page.wait_for_timeout(300)
+    return await _click_portaled_option(page, option_text)
 
 
 async def fill_custom_questions(page, app: dict) -> None:


### PR DESCRIPTION
## Summary

Closes #346.

Anthropic's Greenhouse application forms render dropdowns as React-managed combobox components — a `<button role="combobox">` (or `aria-haspopup="listbox"`) that opens a portaled `<div role="listbox">` in `document.body`, not as native `<select>` elements. The previous implementation in `_select_dropdown_option` and the dropdown branch of `_fill_field_by_label` only looked for `<select>` or `[role="combobox"]` siblings of the labeled container, so every Anthropic dropdown was left empty on auto-submit (visa sponsorship, relocation, prior interviews, French proficiency, etc.).

## How it handles the portaled-menu pattern

Two new helpers in `tools/batch_apply_browser.py`:

- `_select_portaled_combobox(page, label, value)` — looks for `<button>` triggers via `aria-haspopup="listbox"` or `role="combobox"`, matched by accessible name. Clicks the trigger, waits 300ms for the React portal to mount, then delegates to `_click_portaled_option`. Tries several selector patterns (aria-label match, parent `:has()` patterns) and swallows individual selector errors so it keeps trying alternatives.
- `_click_portaled_option(page, option_text)` — locates a `[role="option"]` anywhere in the document (the listbox is portaled outside the form). **Dispatches `mousedown` FIRST** because some React combobox libraries (react-select pattern) commit the selection on `mousedown` rather than `click`. Then also calls `click()` to cover the click-listening libraries. Dispatch failure is suppressed so a detached node still falls through to click().

Both helpers are wired in:
1. `_select_dropdown_option` — fires the portaled path when (a) the existing inline-option click finds nothing (menu was portaled) and (b) as a final fallback when no label is found at all.
2. `_fill_field_by_label` — fires after the sibling-input lookup fails, so dropdown-shaped fields routed through the generic filler still get dispatched.

## Preserved patterns (no regressions)

- **Native `<select>`** — Playwright's `select_option(label=value)` path is unchanged. Existing test `test_selects_native_dropdown` still passes.
- **Inline custom dropdown ([role="combobox"] sibling of label)** — Ashby/Cohere/Mistral pattern. Click trigger → click `[role="option"]` rendered in place. Existing test `test_clicks_custom_dropdown_option` still passes.
- **`<select>` via `<label for="...">`** in `_fill_field_by_label` — unchanged.
- All 74 `tests/test_batch_apply_browser.py` tests pass. Full suite: **3558 passed, 22 skipped, no regressions.**

## Test plan

- [x] Synthetic-mock unit tests for `_click_portaled_option` (success, dispatch failure tolerance, option-missing)
- [x] Synthetic-mock unit tests for `_select_portaled_combobox` (aria-haspopup trigger, no-trigger miss, selector-error resilience)
- [x] End-to-end test through `_select_dropdown_option` for Anthropic pattern
- [x] Fallback test confirming `_fill_field_by_label` routes dropdown-shaped fields through the new dispatcher
- [x] Regression test — all existing native-select and inline-combobox tests still pass
- [x] `ruff check` clean for changes (no new lints; pre-existing SIM105/E501 in untouched code untouched)
- [x] `ruff format --check` clean
- [x] `pytest tests/ -q` — 3558 passed, 22 skipped
- [ ] **Manual live verification (cannot run in CI):** dry-run `batch_apply_browser.py --dry-run --only anthropic` against an active Anthropic Greenhouse posting and confirm all `gh_fields` dropdowns show a selected value. CI cannot reach external ATS endpoints, so this is a maintainer step before declaring G-626 fully shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)