### PR TITLE
feat(G-636): Tier-0 ATS poller MVP (Greenhouse + Lever + Ashby)

### DIFF
--- a/tests/test_tier0_ats_poller.py
+++ b/tests/test_tier0_ats_poller.py
@@ -1,0 +1,395 @@
+"""Tests for tools.tier0_ats_poller — public ATS JSON polling MVP.
+
+Covers G-636:
+- Per-ATS-type parsing (Greenhouse, Lever, Ashby) from mocked HTTP responses
+- State tracking: first run surfaces all, second run surfaces zero new
+- Graceful error handling: one company 5xx, others still succeed
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from tier0_ats_poller import (  # noqa: E402
+    TIER_0_COMPANIES,
+    Tier0Job,
+    fetch_ashby,
+    fetch_greenhouse,
+    fetch_lever,
+    load_state,
+    poll_once,
+    save_state,
+)
+
+# --- Fixtures: representative ATS payloads -----------------------------------
+
+
+GREENHOUSE_SAMPLE: dict = {
+    "jobs": [
+        {
+            "id": 5161980008,
+            "title": "Account Executive, Beneficial Deployments",
+            "absolute_url": "https://job-boards.greenhouse.io/anthropic/jobs/5161980008",
+            "location": {"name": "London, UK"},
+            "updated_at": "2026-04-01T10:49:08-04:00",
+            "first_published": "2026-03-15T10:49:08-04:00",
+        },
+        {
+            "id": 5161980009,
+            "title": "Research Engineer (Remote)",
+            "absolute_url": "https://job-boards.greenhouse.io/anthropic/jobs/5161980009",
+            "location": {"name": "Remote"},
+            "updated_at": "2026-04-02T10:00:00-04:00",
+            "first_published": "2026-04-02T10:00:00-04:00",
+        },
+    ],
+    "meta": {"total": 2},
+}
+
+LEVER_SAMPLE: list[dict] = [
+    {
+        "id": "2a357282-9d44-4b41-a249-c75ffe878ce2",
+        "text": "Account Executive - Enterprise",
+        "hostedUrl": "https://jobs.lever.co/mistral/2a357282-9d44-4b41-a249-c75ffe878ce2",
+        "categories": {
+            "commitment": "Full-time",
+            "location": "Paris",
+            "team": "Business",
+            "allLocations": ["Paris"],
+        },
+        "createdAt": 1773224977965,
+        "workplaceType": "onsite",
+        "descriptionPlain": "About Mistral. We democratize AI.",
+    },
+    {
+        "id": "remote-job-uuid",
+        "text": "Staff Engineer",
+        "hostedUrl": "https://jobs.lever.co/mistral/remote-job-uuid",
+        "categories": {"commitment": "Full-time", "team": "Engineering", "allLocations": []},
+        "createdAt": 1773224977965,
+        "workplaceType": "remote",
+        "descriptionPlain": "",
+    },
+]
+
+ASHBY_SAMPLE: dict = {
+    "jobs": [
+        {
+            "id": "d3bc1ced-3ce4-4086-a050-555055dbb1ff",
+            "title": "Senior / Staff Fullstack Engineer",
+            "department": "Product",
+            "team": "Engineering",
+            "employmentType": "FullTime",
+            "location": "Europe",
+            "publishedAt": "2021-04-27T20:13:45.158+00:00",
+            "isListed": True,
+            "isRemote": True,
+            "jobUrl": "https://jobs.ashbyhq.com/Linear/d3bc1ced-3ce4-4086-a050-555055dbb1ff",
+            "applyUrl": "https://jobs.ashbyhq.com/Linear/d3bc1ced-3ce4-4086-a050-555055dbb1ff/application",
+            "descriptionPlain": "Build Linear.",
+        },
+        {
+            "id": "unlisted-job",
+            "title": "Hidden Role",
+            "location": "Anywhere",
+            "isListed": False,
+            "isRemote": True,
+            "jobUrl": "https://jobs.ashbyhq.com/Linear/unlisted-job",
+        },
+    ],
+}
+
+
+def _mock_client(routes: dict[str, object]) -> httpx.Client:
+    """Build an httpx.Client wired with a MockTransport for the given URL→payload map.
+
+    ``routes`` values may be:
+      - dict / list  → serialized as JSON, 200 OK
+      - int          → returned as status code with empty JSON body
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        for prefix, payload in routes.items():
+            if url.startswith(prefix):
+                if isinstance(payload, int):
+                    return httpx.Response(payload, json={})
+                return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"error": f"no route for {url}"})
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+# --- Per-ATS parser tests ----------------------------------------------------
+
+
+def test_fetch_greenhouse_parses_jobs():
+    """VAL-TIER0-001 Greenhouse: title/url/location/job_id parsed; remote inferred."""
+    client = _mock_client(
+        {"https://boards-api.greenhouse.io/v1/boards/anthropic/jobs": GREENHOUSE_SAMPLE}
+    )
+    jobs = fetch_greenhouse("anthropic", company_key="anthropic", client=client)
+    assert len(jobs) == 2
+    j0 = jobs[0]
+    assert isinstance(j0, Tier0Job)
+    assert j0.title == "Account Executive, Beneficial Deployments"
+    assert j0.company == "anthropic"
+    assert j0.location == "London, UK"
+    assert j0.url.endswith("/5161980008")
+    assert j0.job_id == "5161980008"
+    assert j0.source == "tier0:greenhouse:anthropic"
+    assert j0.remote is False
+    # Second job has "Remote" in location → remote flag derives true
+    assert jobs[1].remote is True
+
+
+def test_fetch_lever_parses_postings():
+    """VAL-TIER0-002 Lever: list payload, ms-epoch createdAt, workplaceType=remote."""
+    client = _mock_client({"https://api.lever.co/v0/postings/mistral": LEVER_SAMPLE})
+    jobs = fetch_lever("mistral", company_key="mistral", client=client)
+    assert len(jobs) == 2
+    j0 = jobs[0]
+    assert j0.title == "Account Executive - Enterprise"
+    assert j0.location == "Paris"
+    assert j0.url.startswith("https://jobs.lever.co/mistral/")
+    assert j0.job_id == "2a357282-9d44-4b41-a249-c75ffe878ce2"
+    assert j0.source == "tier0:lever:mistral"
+    assert j0.posted.startswith("20")  # ISO from ms epoch
+    assert "Business" in j0.tags
+    assert j0.remote is False
+    # Second posting: workplaceType=remote → remote true
+    assert jobs[1].remote is True
+
+
+def test_fetch_ashby_skips_unlisted_jobs():
+    """VAL-TIER0-003 Ashby: parses listed jobs, skips isListed=False."""
+    client = _mock_client({"https://api.ashbyhq.com/posting-api/job-board/Linear": ASHBY_SAMPLE})
+    jobs = fetch_ashby("Linear", company_key="linear", client=client)
+    assert len(jobs) == 1, "Unlisted job must be filtered out"
+    j = jobs[0]
+    assert j.title == "Senior / Staff Fullstack Engineer"
+    assert j.company == "linear"
+    assert j.location == "Europe"
+    assert j.url.startswith("https://jobs.ashbyhq.com/Linear/")
+    assert j.job_id == "d3bc1ced-3ce4-4086-a050-555055dbb1ff"
+    assert j.source == "tier0:ashby:Linear"
+    assert j.remote is True
+    assert "Product" in j.tags
+    assert "FullTime" in j.tags
+
+
+# --- State tracking tests ----------------------------------------------------
+
+
+def test_state_roundtrip(tmp_path: Path):
+    """VAL-TIER0-010 save_state then load_state returns the same dict."""
+    state_path = tmp_path / "state.json"
+    state = {"anthropic": ["1", "2", "3"], "mistral": ["abc"]}
+    save_state(state_path, state)
+    assert state_path.exists()
+    assert load_state(state_path) == state
+
+
+def test_state_missing_file_returns_empty(tmp_path: Path):
+    """VAL-TIER0-011 Missing state file is treated as empty dict."""
+    assert load_state(tmp_path / "does-not-exist.json") == {}
+
+
+def test_state_corrupt_file_returns_empty(tmp_path: Path):
+    """VAL-TIER0-012 Corrupt JSON is treated as empty dict (with a warning)."""
+    state_path = tmp_path / "bad.json"
+    state_path.write_text("{not json")
+    assert load_state(state_path) == {}
+
+
+def test_poll_once_first_run_surfaces_all_second_run_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """VAL-TIER0-020 Two consecutive runs against same response: 2 new then 0 new."""
+    state_path = tmp_path / "state.json"
+    companies = {"anthropic": ("greenhouse", "anthropic")}
+    client = _mock_client(
+        {"https://boards-api.greenhouse.io/v1/boards/anthropic/jobs": GREENHOUSE_SAMPLE}
+    )
+
+    run1 = poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client,
+    )
+    assert len(run1) == 1
+    assert run1[0].fetched == 2
+    assert run1[0].new == 2
+    assert {j.job_id for j in run1[0].new_jobs} == {"5161980008", "5161980009"}
+
+    # State persisted
+    saved = load_state(state_path)
+    assert "anthropic" in saved
+    assert set(saved["anthropic"]) == {"5161980008", "5161980009"}
+
+    # Second run against same payload → 0 new
+    client2 = _mock_client(
+        {"https://boards-api.greenhouse.io/v1/boards/anthropic/jobs": GREENHOUSE_SAMPLE}
+    )
+    run2 = poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client2,
+    )
+    assert run2[0].fetched == 2
+    assert run2[0].new == 0
+    assert run2[0].new_jobs == []
+
+
+def test_poll_once_no_persist_does_not_write_state(tmp_path: Path):
+    """VAL-TIER0-021 ``persist=False`` does not create the state file."""
+    state_path = tmp_path / "state.json"
+    companies = {"anthropic": ("greenhouse", "anthropic")}
+    client = _mock_client(
+        {"https://boards-api.greenhouse.io/v1/boards/anthropic/jobs": GREENHOUSE_SAMPLE}
+    )
+    poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client,
+        persist=False,
+    )
+    assert not state_path.exists()
+
+
+# --- Error isolation tests ---------------------------------------------------
+
+
+def test_poll_once_isolates_company_failure(tmp_path: Path):
+    """VAL-TIER0-030 One company 5xx → others still succeed; error recorded."""
+    state_path = tmp_path / "state.json"
+    companies = {
+        "anthropic": ("greenhouse", "anthropic"),
+        "mistral": ("lever", "mistral"),
+        "linear": ("ashby", "Linear"),
+    }
+    # Anthropic returns 503; mistral + linear succeed
+    client = _mock_client(
+        {
+            "https://boards-api.greenhouse.io/v1/boards/anthropic/jobs": 503,
+            "https://api.lever.co/v0/postings/mistral": LEVER_SAMPLE,
+            "https://api.ashbyhq.com/posting-api/job-board/Linear": ASHBY_SAMPLE,
+        }
+    )
+    results = poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client,
+    )
+    by_company = {r.company: r for r in results}
+    assert by_company["anthropic"].error is not None
+    assert by_company["anthropic"].fetched == 0
+    assert by_company["mistral"].error is None
+    assert by_company["mistral"].fetched == 2
+    assert by_company["linear"].error is None
+    assert by_company["linear"].fetched == 1
+
+
+def test_poll_once_unsupported_ats_does_not_crash(tmp_path: Path):
+    """VAL-TIER0-031 Unknown ATS type yields error result, never raises."""
+    state_path = tmp_path / "state.json"
+    companies = {"oxide": ("custom", "https://oxide.computer/careers")}
+    client = _mock_client({})  # no routes needed; never called
+    results = poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client,
+    )
+    assert len(results) == 1
+    assert results[0].error is not None
+    assert "unsupported" in results[0].error.lower()
+
+
+# --- Config sanity -----------------------------------------------------------
+
+
+def test_tier_0_companies_config_shape():
+    """VAL-TIER0-040 Every configured company has a known ATS type and non-empty slug."""
+    known = {"greenhouse", "lever", "ashby"}
+    for key, (ats, slug) in TIER_0_COMPANIES.items():
+        assert isinstance(key, str) and key
+        assert ats in known, f"{key} has unsupported ATS {ats}"
+        assert isinstance(slug, str) and slug, f"{key} has empty slug"
+
+
+def test_state_file_is_under_data_directory():
+    """VAL-TIER0-041 Default state path is under data/ (gitignored)."""
+    from tier0_ats_poller import DEFAULT_STATE_PATH
+
+    parts = DEFAULT_STATE_PATH.parts
+    assert "data" in parts
+    assert DEFAULT_STATE_PATH.name == "tier0_state.json"
+
+
+# --- Output schema -----------------------------------------------------------
+
+
+def test_tier0_job_matches_pipeline_shape():
+    """VAL-TIER0-050 Tier0Job exposes the same fields downstream consumers rely on.
+
+    Mirrors ``tools.scrape_resilient.ScrapedJob`` so dedup, scoring, and digest
+    code can consume both interchangeably.
+    """
+    j = Tier0Job(
+        title="t",
+        company="c",
+        location="l",
+        url="u",
+        source="s",
+    )
+    expected = {
+        "title",
+        "company",
+        "location",
+        "url",
+        "source",
+        "description",
+        "posted",
+        "remote",
+        "salary",
+        "tags",
+        "search_keyword",
+        "scraped_at",
+        "job_id",
+    }
+    assert expected.issubset(j.__dict__.keys())
+    # dedup_key produces lowercase tuple
+    assert j.dedup_key() == ("t", "c")
+
+
+def test_poll_once_json_serializable(tmp_path: Path):
+    """VAL-TIER0-051 New jobs serialize cleanly via dataclasses.asdict + json.dumps."""
+    from dataclasses import asdict
+
+    state_path = tmp_path / "state.json"
+    companies = {"mistral": ("lever", "mistral")}
+    client = _mock_client({"https://api.lever.co/v0/postings/mistral": LEVER_SAMPLE})
+    results = poll_once(
+        companies=companies,
+        state_path=state_path,
+        inter_company_delay=0,
+        client=client,
+    )
+    serialized = json.dumps([asdict(j) for j in results[0].new_jobs])
+    assert "Mistral" not in serialized or "Account Executive" in serialized
+    # Round-trip check
+    decoded = json.loads(serialized)
+    assert isinstance(decoded, list)
+    assert decoded[0]["company"] == "mistral"

--- a/tools/tier0_ats_poller.py
+++ b/tools/tier0_ats_poller.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Tier-0 ATS poller — direct ATS JSON for dream companies.
+
+Beats aggregator lag (hours to days) by hitting each dream company's public ATS
+JSON endpoint directly. Supports Greenhouse, Lever, Ashby. Custom-site companies
+(Oxide, Proton, Tuta) are deferred to follow-up tickets per G-636 MVP scope.
+
+Endpoint patterns:
+  - Greenhouse: https://boards-api.greenhouse.io/v1/boards/{slug}/jobs
+  - Lever:      https://api.lever.co/v0/postings/{slug}?mode=json
+  - Ashby:      https://api.ashbyhq.com/posting-api/job-board/{slug}
+
+Each company's response is normalized to the same dict shape consumed elsewhere
+in the pipeline (mirrors ``tools.scrape_resilient.ScrapedJob`` field set):
+``title``, ``company``, ``location``, ``url``, ``source``, ``description``,
+``posted``, ``remote``, ``salary``, ``tags``, ``search_keyword``, ``scraped_at``.
+
+State tracking (``data/tier0_state.json``, gitignored) persists last-seen job
+IDs per company so only NEW postings are surfaced on each run.
+
+CLI:
+  python tools/tier0_ats_poller.py --once          # one-shot
+  python tools/tier0_ats_poller.py --watch         # 15-min loop
+  python tools/tier0_ats_poller.py --once --json   # JSON output for piping
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_STATE_PATH = PROJECT_ROOT / "data" / "tier0_state.json"
+DEFAULT_TIMEOUT = 20.0
+DEFAULT_INTER_COMPANY_DELAY = 1.5  # seconds between company fetches
+WATCH_INTERVAL_SECONDS = 15 * 60
+USER_AGENT = "kestrel-tier0-poller/1.0 (+https://github.com/pleasedodisturb/kestrel)"
+
+logger = logging.getLogger("tier0_ats_poller")
+
+
+# --- Config: company → (ATS type, slug) --------------------------------------
+
+# MVP shortlist (one per ATS type, plus extras). Custom-ATS companies
+# (Oxide, Proton, Tuta) and any slug we couldn't verify on a single ATS
+# (HuggingFace's listed Lever board returns 404 as of 2026-05) are explicit
+# follow-ups, see PR for G-636.
+#
+# Slugs verified live against each ATS on 2026-05-12. Note that companies
+# sometimes use a different ATS than the issue's research suggested — Cohere
+# and Attio are on Ashby, not Greenhouse — so the canonical evidence for this
+# table is the live HTTP probe, not the original research doc.
+TIER_0_COMPANIES: dict[str, tuple[str, str]] = {
+    # Greenhouse
+    "anthropic": ("greenhouse", "anthropic"),
+    "block": ("greenhouse", "block"),
+    # Lever
+    "mistral": ("lever", "mistral"),
+    # Ashby
+    "linear": ("ashby", "Linear"),
+    "n8n": ("ashby", "n8n"),
+    "lovable": ("ashby", "lovable"),
+    "cohere": ("ashby", "cohere"),
+    "attio": ("ashby", "attio"),
+}
+
+
+# --- Normalized result shape -------------------------------------------------
+
+
+@dataclass
+class Tier0Job:
+    """Normalized Tier-0 ATS job record.
+
+    Field set mirrors ``tools.scrape_resilient.ScrapedJob`` so downstream
+    pipeline steps (dedup, scoring, digest) consume both interchangeably.
+    """
+
+    title: str
+    company: str
+    location: str
+    url: str
+    source: str  # "tier0:greenhouse:anthropic" etc.
+    description: str = ""
+    posted: str = ""
+    remote: bool = False
+    salary: str = ""
+    tags: list[str] = field(default_factory=list)
+    search_keyword: str = ""
+    scraped_at: str = ""
+    job_id: str = ""  # ATS-native id, used for dedup
+
+    def dedup_key(self) -> tuple[str, str]:
+        return (self.title.lower().strip(), self.company.lower().strip())
+
+
+# --- Per-ATS fetchers --------------------------------------------------------
+
+
+def _http_get_json(url: str, *, client: httpx.Client) -> Any:
+    """GET + parse JSON, raising on non-2xx."""
+    resp = client.get(url, headers={"User-Agent": USER_AGENT}, timeout=DEFAULT_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_greenhouse(slug: str, *, company_key: str, client: httpx.Client) -> list[Tier0Job]:
+    """Fetch Greenhouse jobs for ``slug``.
+
+    Endpoint: ``https://boards-api.greenhouse.io/v1/boards/{slug}/jobs``
+    Returns ``{"jobs": [...], "meta": {...}}`` with each job having
+    ``id``, ``title``, ``absolute_url``, ``location.name``, ``updated_at``.
+    """
+    url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs"
+    payload = _http_get_json(url, client=client)
+    now = _utcnow_iso()
+    out: list[Tier0Job] = []
+    for j in payload.get("jobs", []):
+        loc = ""
+        if isinstance(j.get("location"), dict):
+            loc = j["location"].get("name") or ""
+        out.append(
+            Tier0Job(
+                title=j.get("title", "").strip(),
+                company=company_key,
+                location=loc,
+                url=j.get("absolute_url", ""),
+                source=f"tier0:greenhouse:{slug}",
+                posted=j.get("updated_at", "") or j.get("first_published", ""),
+                remote=_looks_remote(loc),
+                scraped_at=now,
+                job_id=str(j.get("id", "")),
+            )
+        )
+    return out
+
+
+def fetch_lever(slug: str, *, company_key: str, client: httpx.Client) -> list[Tier0Job]:
+    """Fetch Lever postings for ``slug``.
+
+    Endpoint: ``https://api.lever.co/v0/postings/{slug}?mode=json``
+    Returns a list of postings with ``id``, ``text``, ``hostedUrl``,
+    ``categories.location``, ``categories.allLocations``, ``createdAt`` (ms epoch),
+    ``workplaceType``, ``descriptionPlain``.
+    """
+    url = f"https://api.lever.co/v0/postings/{slug}?mode=json"
+    payload = _http_get_json(url, client=client)
+    now = _utcnow_iso()
+    out: list[Tier0Job] = []
+    for p in payload or []:
+        cats = p.get("categories") or {}
+        location = cats.get("location") or ""
+        if not location:
+            all_locs = cats.get("allLocations") or []
+            location = ", ".join(all_locs) if all_locs else ""
+        created_ms = p.get("createdAt")
+        posted_iso = ""
+        if isinstance(created_ms, (int, float)):
+            posted_iso = datetime.fromtimestamp(created_ms / 1000, UTC).isoformat()
+        workplace = (p.get("workplaceType") or "").lower()
+        remote = workplace == "remote" or _looks_remote(location)
+        out.append(
+            Tier0Job(
+                title=p.get("text", "").strip(),
+                company=company_key,
+                location=location,
+                url=p.get("hostedUrl", ""),
+                source=f"tier0:lever:{slug}",
+                description=(p.get("descriptionPlain") or "")[:1000],
+                posted=posted_iso,
+                remote=remote,
+                tags=[t for t in [cats.get("team"), cats.get("commitment")] if t],
+                scraped_at=now,
+                job_id=str(p.get("id", "")),
+            )
+        )
+    return out
+
+
+def fetch_ashby(slug: str, *, company_key: str, client: httpx.Client) -> list[Tier0Job]:
+    """Fetch Ashby jobs for ``slug``.
+
+    Endpoint: ``https://api.ashbyhq.com/posting-api/job-board/{slug}``
+    Note: Ashby slugs are sometimes case-sensitive (e.g. ``Linear`` not ``linear``).
+    Returns ``{"jobs": [...]}`` with each job having ``id``, ``title``,
+    ``location``, ``jobUrl``, ``publishedAt``, ``isRemote``, ``employmentType``,
+    ``department``, ``team``, ``descriptionPlain``.
+    """
+    url = f"https://api.ashbyhq.com/posting-api/job-board/{slug}"
+    payload = _http_get_json(url, client=client)
+    now = _utcnow_iso()
+    out: list[Tier0Job] = []
+    for j in payload.get("jobs", []):
+        # Only surface listed jobs when the flag is present.
+        if j.get("isListed") is False:
+            continue
+        out.append(
+            Tier0Job(
+                title=j.get("title", "").strip(),
+                company=company_key,
+                location=j.get("location") or "",
+                url=j.get("jobUrl") or j.get("applyUrl") or "",
+                source=f"tier0:ashby:{slug}",
+                description=(j.get("descriptionPlain") or "")[:1000],
+                posted=j.get("publishedAt", ""),
+                remote=bool(j.get("isRemote")),
+                tags=[
+                    t for t in [j.get("department"), j.get("team"), j.get("employmentType")] if t
+                ],
+                scraped_at=now,
+                job_id=str(j.get("id", "")),
+            )
+        )
+    return out
+
+
+_FETCHERS = {
+    "greenhouse": fetch_greenhouse,
+    "lever": fetch_lever,
+    "ashby": fetch_ashby,
+}
+
+
+# --- State tracking ----------------------------------------------------------
+
+
+def load_state(state_path: Path) -> dict[str, list[str]]:
+    """Load last-seen job IDs per company, or empty dict if missing/corrupt."""
+    if not state_path.exists():
+        return {}
+    try:
+        raw = json.loads(state_path.read_text())
+        if not isinstance(raw, dict):
+            return {}
+        # Normalize value to list[str]
+        return {k: list(map(str, v)) for k, v in raw.items() if isinstance(v, list)}
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to load state at %s: %s; treating as empty", state_path, exc)
+        return {}
+
+
+def save_state(state_path: Path, state: dict[str, list[str]]) -> None:
+    """Atomic-ish write of state to disk."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(state_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True))
+    tmp.replace(state_path)
+
+
+# --- Polling orchestration ---------------------------------------------------
+
+
+@dataclass
+class PollResult:
+    """Per-company poll result."""
+
+    company: str
+    ats: str
+    fetched: int
+    new: int
+    error: str | None = None
+    new_jobs: list[Tier0Job] = field(default_factory=list)
+
+
+def poll_once(
+    *,
+    companies: dict[str, tuple[str, str]] | None = None,
+    state_path: Path = DEFAULT_STATE_PATH,
+    inter_company_delay: float = DEFAULT_INTER_COMPANY_DELAY,
+    client: httpx.Client | None = None,
+    persist: bool = True,
+) -> list[PollResult]:
+    """Poll all configured companies once. Returns per-company results.
+
+    Failure isolation: a single company 5xx never blocks others. Errors are
+    captured on the per-company ``PollResult`` and logged.
+
+    When ``persist`` is True, ``state_path`` is updated with current job IDs.
+    """
+    companies = companies or TIER_0_COMPANIES
+    state = load_state(state_path)
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(follow_redirects=True)
+    results: list[PollResult] = []
+    try:
+        for idx, (company_key, (ats_type, slug)) in enumerate(companies.items()):
+            if idx > 0 and inter_company_delay > 0:
+                time.sleep(inter_company_delay)
+            fetcher = _FETCHERS.get(ats_type)
+            if fetcher is None:
+                logger.warning("No fetcher for ATS type %s (company=%s)", ats_type, company_key)
+                results.append(
+                    PollResult(
+                        company=company_key,
+                        ats=ats_type,
+                        fetched=0,
+                        new=0,
+                        error=f"unsupported ATS type: {ats_type}",
+                    )
+                )
+                continue
+            try:
+                jobs = fetcher(slug, company_key=company_key, client=client)
+            except Exception as exc:  # noqa: BLE001 — per-company isolation
+                logger.warning("Fetch failed for %s (%s/%s): %s", company_key, ats_type, slug, exc)
+                results.append(
+                    PollResult(
+                        company=company_key,
+                        ats=ats_type,
+                        fetched=0,
+                        new=0,
+                        error=str(exc),
+                    )
+                )
+                continue
+            seen_ids = set(state.get(company_key, []))
+            new_jobs = [j for j in jobs if j.job_id and j.job_id not in seen_ids]
+            # Update state to current snapshot (we trust the ATS as source of truth).
+            state[company_key] = sorted({j.job_id for j in jobs if j.job_id})
+            results.append(
+                PollResult(
+                    company=company_key,
+                    ats=ats_type,
+                    fetched=len(jobs),
+                    new=len(new_jobs),
+                    new_jobs=new_jobs,
+                )
+            )
+            logger.info(
+                "[%s] %s — fetched=%d new=%d", ats_type, company_key, len(jobs), len(new_jobs)
+            )
+    finally:
+        if owns_client:
+            client.close()
+    if persist:
+        save_state(state_path, state)
+    return results
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _looks_remote(text: str) -> bool:
+    if not text:
+        return False
+    t = text.lower()
+    return "remote" in t or "anywhere" in t
+
+
+def _summary_line(r: PollResult) -> str:
+    if r.error:
+        return f"  {r.company:>14} [{r.ats:<10}] ERROR: {r.error}"
+    return f"  {r.company:>14} [{r.ats:<10}] fetched={r.fetched:<4} new={r.new}"
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Tier-0 ATS poller (Greenhouse/Lever/Ashby)")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--once", action="store_true", help="Run one poll cycle and exit (default)")
+    g.add_argument("--watch", action="store_true", help="Loop every 15 min until killed")
+    p.add_argument(
+        "--company",
+        help="Only poll this single company key from TIER_0_COMPANIES",
+    )
+    p.add_argument(
+        "--state",
+        type=Path,
+        default=DEFAULT_STATE_PATH,
+        help=f"State file path (default: {DEFAULT_STATE_PATH})",
+    )
+    p.add_argument(
+        "--no-persist",
+        action="store_true",
+        help="Do not write state to disk (dry-run for dedup)",
+    )
+    p.add_argument(
+        "--delay",
+        type=float,
+        default=DEFAULT_INTER_COMPANY_DELAY,
+        help=f"Seconds between company fetches (default: {DEFAULT_INTER_COMPANY_DELAY})",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit new jobs as JSON to stdout (one array)",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose logging (DEBUG)",
+    )
+    return p
+
+
+def _run_once(args: argparse.Namespace) -> list[PollResult]:
+    if args.company:
+        if args.company not in TIER_0_COMPANIES:
+            logger.error(
+                "Unknown company %r; known: %s",
+                args.company,
+                ", ".join(sorted(TIER_0_COMPANIES)),
+            )
+            return []
+        companies = {args.company: TIER_0_COMPANIES[args.company]}
+    else:
+        companies = TIER_0_COMPANIES
+    return poll_once(
+        companies=companies,
+        state_path=args.state,
+        inter_company_delay=args.delay,
+        persist=not args.no_persist,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    def _emit(results: list[PollResult]) -> None:
+        total_new = sum(r.new for r in results)
+        total_fetched = sum(r.fetched for r in results)
+        errors = sum(1 for r in results if r.error)
+        logger.info(
+            "Poll summary: companies=%d fetched=%d new=%d errors=%d",
+            len(results),
+            total_fetched,
+            total_new,
+            errors,
+        )
+        for r in results:
+            logger.info(_summary_line(r))
+        if args.json:
+            new_jobs: list[dict] = []
+            for r in results:
+                for j in r.new_jobs:
+                    new_jobs.append(asdict(j))
+            sys.stdout.write(json.dumps(new_jobs, indent=2))
+            sys.stdout.write("\n")
+
+    if args.watch:
+        logger.info("Entering watch loop (interval=%ds)", WATCH_INTERVAL_SECONDS)
+        while True:
+            try:
+                _emit(_run_once(args))
+            except KeyboardInterrupt:
+                logger.info("Interrupted, exiting watch loop")
+                return 0
+            except Exception as exc:  # noqa: BLE001 — keep the loop alive
+                logger.exception("Unexpected error in watch loop: %s", exc)
+            time.sleep(WATCH_INTERVAL_SECONDS)
+    else:
+        _emit(_run_once(args))
+        return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a Tier-0 ATS poller that hits public ATS JSON endpoints directly for dream companies, beating aggregator lag (hours-to-days) on day-one postings where speed-to-apply correlates with screen-call rate.

Three ATS types wired up: **Greenhouse, Lever, Ashby**. Custom-ATS companies (Oxide, Proton, Tuta) are explicit follow-ups.

Refs #349 (MVP — wires the pattern; aggregator integration + cron scheduling + custom scrapers are follow-ups).

## What ships

- `tools/tier0_ats_poller.py` — per-ATS fetchers, normalized `Tier0Job` dataclass that mirrors `tools.scrape_resilient.ScrapedJob` so downstream dedup/scoring/digest consume both interchangeably, state tracking in `data/tier0_state.json` (gitignored under existing `data/` rule), and a CLI with `--once`, `--watch`, `--company`, `--state`, `--no-persist`, `--json`.
- `tests/test_tier0_ats_poller.py` — 14 unit tests, mocked HTTP via `httpx.MockTransport`. Covers parsing, state roundtrip, dedup, per-company failure isolation.

## Companies wired up (slugs verified live 2026-05-12)

| Company | ATS | Slug | Jobs fetched |
|---------|-----|------|-------------:|
| anthropic | Greenhouse | `anthropic` | 420 |
| block | Greenhouse | `block` | 174 |
| mistral | Lever | `mistral` | 161 |
| linear | Ashby | `Linear` | 23 |
| n8n | Ashby | `n8n` | 44 |
| lovable | Ashby | `lovable` | 76 |
| cohere | Ashby | `cohere` | 127 |
| attio | Ashby | `attio` | 29 |
| **Total** | | | **1054** |

**Live run result:** `companies=8 fetched=1054 new=1054 errors=0`.

Sample titles:
- Anthropic: *Account Executive, Beneficial Deployments (French Speaking)* (London, UK)
- Mistral: *Account Executive – AI for Citizens* (Paris)
- Linear: *Senior / Staff Fullstack Engineer* (Europe, remote=true)

Note: the research doc had Cohere/Attio on Greenhouse, but live probing shows they're on Ashby — the config reflects reality, not the doc.

## Dedup verified end-to-end

```
run 1: fetched=420 new=420   (cold state file)
run 2: fetched=420 new=0     (same state file, same response)
```

## Out of scope (follow-ups)

- Custom-ATS scrapers for **Oxide / Proton / Tuta** (their own ticket)
- **HuggingFace** — issue says Lever, but `api.lever.co/v0/postings/huggingface` returns 404. Need to find their current ATS.
- **GitHub Actions cron workflow** for the 15-min cadence (`automation/tier_0_poller_workflow.yml` in the issue)
- Wire the poller into `tools/daily_pipeline.py` as another source
- Blacklist filter integration (`feedback_blocked_companies.md`)
- Pushover alerts on `score >= 7`

## Test plan

- [x] `ruff check tools/tier0_ats_poller.py tests/test_tier0_ats_poller.py` — clean
- [x] `ruff format --check` — clean
- [x] `pytest tests/test_tier0_ats_poller.py -q` — 14 passed
- [x] Full backend suite (`pytest tests/ -q`) — 3498 passed, 23 skipped
- [x] Live one-shot run against all 8 configured companies — 1054 jobs, 0 errors
- [x] Live dedup: second run reports 0 new
- [x] `data/tier0_state.json` is gitignored under existing `data/` rule

Closes G-636 MVP slice. Will open follow-up tickets for the items listed above.