### PR TITLE
feat(G-630): add EU-tech sources (remotely.de, arbeitnow) to daily_pipeline

### DIFF
--- a/tests/test_new_sources.py
+++ b/tests/test_new_sources.py
@@ -7,10 +7,12 @@ from scrape_new_sources import (
     GREENHOUSE_COMPANIES,
     LEVER_COMPANIES,
     scrape_all_new_sources,
+    scrape_arbeitnow,
     scrape_ashby,
     scrape_greenhouse,
     scrape_himalayas,
     scrape_lever,
+    scrape_remotely_de,
     scrape_startupjobs,
     scrape_thehub,
 )
@@ -489,6 +491,8 @@ class TestScrapeTheHub:
 
 
 class TestScrapeAllNewSources:
+    @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
+    @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
     @patch("scrape_new_sources.scrape_thehub", return_value=[])
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
@@ -497,7 +501,16 @@ class TestScrapeAllNewSources:
     @patch("scrape_new_sources.scrape_himalayas", return_value=[])
     @patch("scrape_new_sources._random_delay")
     def test_calls_all_sources(
-        self, mock_delay, mock_h, mock_gh, mock_lv, mock_as, mock_sj, mock_th
+        self,
+        mock_delay,
+        mock_h,
+        mock_gh,
+        mock_lv,
+        mock_as,
+        mock_sj,
+        mock_th,
+        mock_an,
+        mock_rd,
     ):
         from scrape_resilient import ScrapedJob
 
@@ -509,16 +522,26 @@ class TestScrapeAllNewSources:
                 title="Job2", company="Co2", location="Berlin", url="u2", source="greenhouse"
             )
         ]
+        mock_an.return_value = [
+            ScrapedJob(title="J3", company="C3", location="Berlin", url="u3", source="arbeitnow")
+        ]
+        mock_rd.return_value = [
+            ScrapedJob(title="J4", company="C4", location="Köln", url="u4", source="remotely.de")
+        ]
 
         result = scrape_all_new_sources()
-        assert len(result) == 2
+        assert len(result) == 4
         mock_h.assert_called_once()
         mock_gh.assert_called_once()
         mock_lv.assert_called_once()
         mock_as.assert_called_once()
         mock_sj.assert_called_once()
         mock_th.assert_called_once()
+        mock_an.assert_called_once()
+        mock_rd.assert_called_once()
 
+    @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
+    @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
     @patch("scrape_new_sources.scrape_thehub", side_effect=Exception("boom"))
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
@@ -527,11 +550,256 @@ class TestScrapeAllNewSources:
     @patch("scrape_new_sources.scrape_himalayas", return_value=[])
     @patch("scrape_new_sources._random_delay")
     def test_graceful_on_individual_failure(
-        self, mock_delay, mock_h, mock_gh, mock_lv, mock_as, mock_sj, mock_th
+        self,
+        mock_delay,
+        mock_h,
+        mock_gh,
+        mock_lv,
+        mock_as,
+        mock_sj,
+        mock_th,
+        mock_an,
+        mock_rd,
     ):
         """If one source throws, others still run."""
         result = scrape_all_new_sources()
         assert isinstance(result, list)  # no exception
+
+    @patch("scrape_new_sources.scrape_thehub", return_value=[])
+    @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
+    @patch("scrape_new_sources.scrape_ashby", return_value=[])
+    @patch("scrape_new_sources.scrape_lever", return_value=[])
+    @patch("scrape_new_sources.scrape_greenhouse", return_value=[])
+    @patch("scrape_new_sources.scrape_himalayas", return_value=[])
+    @patch("scrape_new_sources.scrape_arbeitnow", side_effect=Exception("boom"))
+    @patch("scrape_new_sources.scrape_remotely_de", side_effect=Exception("boom"))
+    @patch("scrape_new_sources._random_delay")
+    def test_eu_source_failures_isolated(
+        self,
+        mock_delay,
+        mock_rd,
+        mock_an,
+        mock_h,
+        mock_gh,
+        mock_lv,
+        mock_as,
+        mock_sj,
+        mock_th,
+    ):
+        """arbeitnow / remotely.de exceptions must not break the orchestrator."""
+        result = scrape_all_new_sources()
+        assert isinstance(result, list)
+
+
+# ==================== arbeitnow scraper ====================
+
+
+class TestScrapeArbeitnow:
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_parses_response(self, mock_client_cls, mock_delay):
+        _mock_httpx_client(
+            mock_client_cls,
+            {
+                "data": [
+                    {
+                        "slug": "senior-pm-berlin-1",
+                        "company_name": "Acme GmbH",
+                        "title": "Senior Product Manager (m/w/d)",
+                        "description": "<p>Build cool stuff.</p>",
+                        "remote": True,
+                        "url": "https://www.arbeitnow.com/jobs/acme/senior-pm-1",
+                        "tags": ["product", "ai"],
+                        "job_types": ["Full Time"],
+                        "location": "Berlin, Deutschland",
+                        "created_at": 1700000000,
+                    }
+                ]
+            },
+        )
+
+        jobs = scrape_arbeitnow()
+        assert len(jobs) == 1
+        j = jobs[0]
+        assert j.title == "Senior Product Manager (m/w/d)"
+        assert j.company == "Acme GmbH"
+        assert j.location == "Berlin, Deutschland"
+        assert j.source == "arbeitnow"
+        assert j.remote is True
+        assert "product" in j.tags
+        # HTML stripped from description
+        assert "<p>" not in j.description
+        assert "Build cool stuff" in j.description
+        # created_at unix → ISO
+        assert j.posted.startswith("20")
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_keyword_filter(self, mock_client_cls, mock_delay):
+        _mock_httpx_client(
+            mock_client_cls,
+            {
+                "data": [
+                    {"title": "Product Manager", "company_name": "A", "url": "u1"},
+                    {"title": "Accountant", "company_name": "B", "url": "u2"},
+                ]
+            },
+        )
+        jobs = scrape_arbeitnow(keyword_filter=["product"])
+        assert len(jobs) == 1
+        assert jobs[0].title == "Product Manager"
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_handles_empty(self, mock_client_cls, mock_delay):
+        _mock_httpx_client(mock_client_cls, {"data": []})
+        assert scrape_arbeitnow() == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_handles_malformed_response(self, mock_client_cls, mock_delay):
+        """Unexpected shape — return [] rather than crash."""
+        _mock_httpx_client(mock_client_cls, {"unexpected": "shape"})
+        assert scrape_arbeitnow() == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_handles_api_failure(self, mock_client_cls, mock_delay):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = Exception("500")
+        mock_client_cls.return_value = mock_client
+        assert scrape_arbeitnow() == []
+
+
+# ==================== remotely.de scraper ====================
+
+
+class TestScrapeRemotelyDe:
+    SITEMAP = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        "<url><loc>https://www.remotely.de/job/orbem-ai-engineer</loc>"
+        "<lastmod>2099-01-01T00:00:00.000Z</lastmod></url>"
+        "<url><loc>https://www.remotely.de/job/old-listing</loc>"
+        "<lastmod>2099-01-01T00:00:00.000Z</lastmod></url>"
+        "</urlset>"
+    )
+
+    JOB_HTML = """
+    <html>
+      <head>
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org/",
+          "@type": "JobPosting",
+          "title": "AI Engineer",
+          "description": "<p>Build ML systems</p>",
+          "datePosted": "2026-03-09T00:00:00+00:00",
+          "hiringOrganization": {"@type": "Organization", "name": "Orbem"},
+          "jobLocation": {
+            "@type": "Place",
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": "Munich",
+              "addressCountry": "DE"
+            }
+          },
+          "occupationalCategory": "AI/ML",
+          "url": "https://www.remotely.de/job/orbem-ai-engineer"
+        }
+        </script>
+      </head>
+      <body></body>
+    </html>
+    """
+
+    def _make_client_mock(self, sitemap_text, detail_html):
+        """Return a mock httpx.Client whose .get dispatches by URL substring."""
+
+        def _get(url, *args, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if "sitemap" in url:
+                resp.text = sitemap_text
+            else:
+                resp.text = detail_html
+            return resp
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = _get
+        return mock_client
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_parses_jobposting(self, mock_client_cls, mock_delay):
+        mock_client_cls.return_value = self._make_client_mock(self.SITEMAP, self.JOB_HTML)
+        jobs = scrape_remotely_de(limit=1, max_age_hours=None)
+        assert len(jobs) == 1
+        j = jobs[0]
+        assert j.title == "AI Engineer"
+        assert j.company == "Orbem"
+        assert "Munich" in j.location
+        assert "DE" in j.location
+        assert j.source == "remotely.de"
+        assert j.remote is True
+        assert "AI/ML" in j.tags
+        # HTML stripped
+        assert "<p>" not in j.description
+        assert "Build ML systems" in j.description
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_keyword_filter(self, mock_client_cls, mock_delay):
+        mock_client_cls.return_value = self._make_client_mock(self.SITEMAP, self.JOB_HTML)
+        # "ai engineer" matches → 1 (both sitemap entries return same JobPosting)
+        jobs = scrape_remotely_de(keyword_filter=["ai engineer"], limit=2, max_age_hours=None)
+        assert len(jobs) == 2
+        # Non-matching keyword → 0
+        mock_client_cls.return_value = self._make_client_mock(self.SITEMAP, self.JOB_HTML)
+        jobs = scrape_remotely_de(keyword_filter=["accountant"], limit=2, max_age_hours=None)
+        assert jobs == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_empty_sitemap(self, mock_client_cls, mock_delay):
+        empty_sitemap = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+        )
+        mock_client_cls.return_value = self._make_client_mock(empty_sitemap, "")
+        assert scrape_remotely_de(limit=10, max_age_hours=None) == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_malformed_detail_no_jsonld(self, mock_client_cls, mock_delay):
+        """Detail page without a JobPosting block must be skipped, not crash."""
+        mock_client_cls.return_value = self._make_client_mock(
+            self.SITEMAP, "<html><body>no structured data</body></html>"
+        )
+        # Two sitemap entries, both lacking JSON-LD → 0 jobs, no exception
+        jobs = scrape_remotely_de(limit=2, max_age_hours=None)
+        assert jobs == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_sitemap_fetch_failure(self, mock_client_cls, mock_delay):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = Exception("503")
+        mock_client_cls.return_value = mock_client
+        assert scrape_remotely_de(limit=10) == []
+
+    @patch("scrape_new_sources._random_delay")
+    @patch("scrape_new_sources.httpx.Client")
+    def test_malformed_sitemap_xml(self, mock_client_cls, mock_delay):
+        """Bad XML must return [] rather than propagate ParseError."""
+        mock_client_cls.return_value = self._make_client_mock("<not-xml", self.JOB_HTML)
+        assert scrape_remotely_de(limit=5, max_age_hours=None) == []
 
 
 # ==================== Keyword preset expansions ====================

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -14,6 +14,7 @@ All scrapers return list[ScrapedJob] and gracefully return [] on failure.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import sys
@@ -581,6 +582,304 @@ def scrape_thehub(
 
 
 # ---------------------------------------------------------------------------
+# arbeitnow.com (free public API, EU/DE tech-heavy job board)
+# https://documenter.getpostman.com/view/18545278/UVJbJdKh
+# ---------------------------------------------------------------------------
+
+ARBEITNOW_BOARD_API = "https://www.arbeitnow.com/api/job-board-api"
+
+
+def scrape_arbeitnow(
+    keyword_filter: list[str] | None = None,
+    max_pages: int = 1,
+    per_page_limit: int = 100,
+) -> list[ScrapedJob]:
+    """Scrape the public arbeitnow.com job board API.
+
+    Returns the latest postings (newest first) across the full board, with
+    optional client-side title-keyword filter. arbeitnow is heavily EU/DE
+    tech-skewed and complements the existing germany_jobs Arbeitnow path
+    (which filters through ``is_likely_german_only`` and burns through
+    keyword presets); this adapter pulls the unfiltered firehose so we
+    don't miss English-language EU postings.
+
+    Args:
+        keyword_filter: Optional list of substrings; if any matches the job
+            title (case-insensitive), the job is kept. ``None`` keeps all.
+        max_pages: How many pages of 100 results to walk (default: 1).
+        per_page_limit: Defensive cap on per-page results.
+
+    Returns:
+        List of ScrapedJob, or ``[]`` on transport failure.
+    """
+    jobs: list[ScrapedJob] = []
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    kw_lower = [k.lower() for k in (keyword_filter or [])]
+
+    for page in range(1, max_pages + 1):
+
+        def _fetch(p=page):
+            with httpx.Client(timeout=30, headers={"User-Agent": _get_user_agent()}) as client:
+                r = client.get(ARBEITNOW_BOARD_API, params={"page": p})
+                r.raise_for_status()
+                return r.json()
+
+        data = _retry_with_backoff(_fetch)
+        if not data:
+            continue
+
+        listings = data.get("data", []) if isinstance(data, dict) else []
+        if not isinstance(listings, list):
+            continue
+
+        for j in listings[:per_page_limit]:
+            if not isinstance(j, dict):
+                continue
+            title = j.get("title", "")
+            if kw_lower and not any(k in title.lower() for k in kw_lower):
+                continue
+
+            tags = j.get("tags", [])
+            if not isinstance(tags, list):
+                tags = []
+
+            # arbeitnow exposes posted timestamp as unix seconds in created_at
+            posted = ""
+            created_at = j.get("created_at")
+            if isinstance(created_at, int):
+                try:
+                    posted = datetime.fromtimestamp(created_at).isoformat()
+                except (OverflowError, OSError, ValueError):
+                    posted = str(created_at)
+            elif created_at:
+                posted = str(created_at)
+
+            desc = str(j.get("description", ""))
+            # Strip HTML tags — arbeitnow descriptions are HTML
+            desc = re.sub(r"<[^>]+>", " ", unescape(desc))[:MAX_DESCRIPTION_LENGTH]
+
+            jobs.append(
+                ScrapedJob(
+                    title=title,
+                    company=str(j.get("company_name", "")),
+                    location=str(j.get("location", "")),
+                    url=str(j.get("url", "")),
+                    source="arbeitnow",
+                    description=desc,
+                    posted=posted,
+                    remote=bool(j.get("remote", False)),
+                    tags=[str(t) for t in tags],
+                    scraped_at=now,
+                )
+            )
+
+        # If page returned fewer than 100, no point asking for the next one.
+        if len(listings) < 100:
+            break
+
+        _random_delay()
+
+    logger.info(f"arbeitnow: {len(jobs)} jobs")
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# remotely.de (German remote/hybrid job board, JSON-LD per page via sitemap)
+# Public sitemap-jobs.xml + JSON-LD JobPosting schema on every job detail page.
+# No public list API, no auth needed for read-only crawl.
+# ---------------------------------------------------------------------------
+
+REMOTELY_SITEMAP = "https://www.remotely.de/sitemap-jobs.xml"
+
+
+def scrape_remotely_de(
+    keyword_filter: list[str] | None = None,
+    limit: int = 50,
+    max_age_hours: int | None = 48,
+) -> list[ScrapedJob]:
+    """Scrape recent job postings from remotely.de.
+
+    Pulls the public sitemap to get the freshest job URLs (sorted newest
+    first by lastmod), then fetches each detail page and parses the
+    embedded ``schema.org/JobPosting`` JSON-LD block. No API key needed.
+
+    Historically high-yield for Munich/Köln deep-tech and AI roles that
+    don't appear on the international boards. See GitHub issue #348 /
+    Linear G-630 for the original motivation (4 strong picks surfaced
+    only from this board on a single March 9 scan).
+
+    Args:
+        keyword_filter: Optional substrings; if any matches the job title
+            (case-insensitive) the posting is kept. ``None`` keeps all.
+        limit: Maximum number of detail-page fetches (default: 50). Keeps
+            the run under the 20-min total pipeline budget.
+        max_age_hours: If set, drop sitemap entries with ``lastmod`` older
+            than this many hours. ``None`` disables the freshness filter.
+
+    Returns:
+        List of ScrapedJob, ``[]`` on sitemap or repeated detail failures.
+    """
+    jobs: list[ScrapedJob] = []
+    now_dt = datetime.now()
+    now = now_dt.strftime("%Y-%m-%dT%H:%M:%S")
+    kw_lower = [k.lower() for k in (keyword_filter or [])]
+
+    def _fetch_sitemap():
+        with httpx.Client(timeout=30, headers={"User-Agent": _get_user_agent()}) as client:
+            r = client.get(REMOTELY_SITEMAP)
+            r.raise_for_status()
+            return r.text
+
+    sitemap_xml = _retry_with_backoff(_fetch_sitemap)
+    if not sitemap_xml:
+        logger.info("remotely.de: sitemap unavailable")
+        return jobs
+
+    # Parse sitemap — sitemap-jobs.xml lists newest entries first
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.fromstring(sitemap_xml)
+    except ET.ParseError as exc:
+        logger.error(f"remotely.de sitemap parse error: {exc}")
+        return jobs
+
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    entries = root.findall(".//sm:url", ns)
+
+    candidates: list[str] = []
+    for entry in entries:
+        loc_el = entry.find("sm:loc", ns)
+        if loc_el is None or not loc_el.text:
+            continue
+        url = loc_el.text.strip()
+
+        if max_age_hours is not None:
+            lastmod_el = entry.find("sm:lastmod", ns)
+            if lastmod_el is not None and lastmod_el.text:
+                try:
+                    lastmod = datetime.fromisoformat(lastmod_el.text.strip().replace("Z", "+00:00"))
+                    age_hours = (now_dt.astimezone(lastmod.tzinfo) - lastmod).total_seconds() / 3600
+                    if age_hours > max_age_hours:
+                        continue
+                except (ValueError, TypeError):
+                    pass  # don't drop on parse failure; keep candidate
+
+        candidates.append(url)
+        if len(candidates) >= limit:
+            break
+
+    logger.info(f"remotely.de: {len(candidates)} candidate URLs from sitemap")
+
+    detail_failures = 0
+    for url in candidates:
+
+        def _fetch_detail(u=url):
+            with httpx.Client(timeout=20, headers={"User-Agent": _get_user_agent()}) as client:
+                r = client.get(u, follow_redirects=True)
+                r.raise_for_status()
+                return r.text
+
+        html = _retry_with_backoff(_fetch_detail)
+        if not html:
+            detail_failures += 1
+            continue
+
+        # Find JSON-LD JobPosting block
+        ld_blocks = re.findall(
+            r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+            html,
+            re.S,
+        )
+        posting = None
+        for raw in ld_blocks:
+            try:
+                d = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(d, dict) and d.get("@type") == "JobPosting":
+                posting = d
+                break
+            if isinstance(d, list):
+                for item in d:
+                    if isinstance(item, dict) and item.get("@type") == "JobPosting":
+                        posting = item
+                        break
+                if posting:
+                    break
+
+        if not posting:
+            detail_failures += 1
+            continue
+
+        title = str(posting.get("title", "")).strip()
+        if kw_lower and not any(k in title.lower() for k in kw_lower):
+            continue
+
+        org = posting.get("hiringOrganization", {})
+        company = (
+            org.get("name", "")
+            if isinstance(org, dict)
+            else str(org)
+        )
+
+        loc_obj = posting.get("jobLocation", {})
+        location = ""
+        if isinstance(loc_obj, dict):
+            addr = loc_obj.get("address", {})
+            if isinstance(addr, dict):
+                location = ", ".join(
+                    filter(
+                        None,
+                        [addr.get("addressLocality", ""), addr.get("addressCountry", "")],
+                    )
+                )
+        elif isinstance(loc_obj, list) and loc_obj:
+            first = loc_obj[0]
+            if isinstance(first, dict):
+                addr = first.get("address", {})
+                if isinstance(addr, dict):
+                    location = ", ".join(
+                        filter(
+                            None,
+                            [
+                                addr.get("addressLocality", ""),
+                                addr.get("addressCountry", ""),
+                            ],
+                        )
+                    )
+
+        desc = posting.get("description", "")
+        if isinstance(desc, str):
+            desc = re.sub(r"<[^>]+>", " ", unescape(desc))[:MAX_DESCRIPTION_LENGTH]
+        else:
+            desc = ""
+
+        category = posting.get("occupationalCategory", "")
+        tags = [category] if isinstance(category, str) and category else []
+
+        jobs.append(
+            ScrapedJob(
+                title=title,
+                company=str(company),
+                location=location,
+                url=str(posting.get("url", url)),
+                source="remotely.de",
+                description=desc,
+                posted=str(posting.get("datePosted", "")),
+                remote=True,
+                tags=tags,
+                scraped_at=now,
+            )
+        )
+
+    if detail_failures:
+        logger.info(f"remotely.de: {detail_failures} detail fetches failed (skipped)")
+    logger.info(f"remotely.de: {len(jobs)} jobs")
+    return jobs
+
+
+# ---------------------------------------------------------------------------
 # Convenience: scrape all new sources at once
 # ---------------------------------------------------------------------------
 
@@ -591,6 +890,7 @@ def scrape_all_new_sources(
     lever_companies: list[str] | None = None,
     ashby_companies: list[str] | None = None,
     ats_keyword_filter: list[str] | None = None,
+    remotely_limit: int = 50,
 ) -> list[ScrapedJob]:
     """Run all new source scrapers. Each source is independent - failures are logged and skipped."""
     all_jobs: list[ScrapedJob] = []
@@ -661,6 +961,29 @@ def scrape_all_new_sources(
         all_jobs.extend(scrape_thehub(keywords=keywords))
     except Exception as e:
         logger.error(f"TheHub failed: {e}")
+
+    _random_delay()
+
+    # arbeitnow (public board, no auth)
+    logger.info("=== New Source: arbeitnow.com ===")
+    try:
+        all_jobs.extend(scrape_arbeitnow(keyword_filter=ats_keyword_filter))
+    except Exception as e:
+        logger.error(f"arbeitnow failed: {e}")
+
+    _random_delay()
+
+    # remotely.de (sitemap + JSON-LD per job page)
+    logger.info("=== New Source: remotely.de ===")
+    try:
+        all_jobs.extend(
+            scrape_remotely_de(
+                keyword_filter=ats_keyword_filter,
+                limit=remotely_limit,
+            )
+        )
+    except Exception as e:
+        logger.error(f"remotely.de failed: {e}")
 
     logger.info(f"New sources total: {len(all_jobs)} jobs (before dedup)")
     return all_jobs

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -671,10 +671,12 @@ def deduplicate(jobs: list[ScrapedJob]) -> list[ScrapedJob]:
 try:
     from scrape_new_sources import (
         scrape_all_new_sources,
+        scrape_arbeitnow,
         scrape_ashby,
         scrape_greenhouse,
         scrape_himalayas,
         scrape_lever,
+        scrape_remotely_de,
         scrape_startupjobs,
         scrape_thehub,
     )


### PR DESCRIPTION
## Summary

Closes #348. Adds two high-yield EU/AI-native job sources missing from the current `tools/daily_pipeline.py` scan, with full test coverage.

- **`scrape_remotely_de`** — walks the public `sitemap-jobs.xml` (newest first), fetches each detail page, parses the `schema.org/JobPosting` JSON-LD block. No auth. This is the priority signal — several of the maintainer's strongest early picks came from this board.
- **`scrape_arbeitnow`** — public job-board JSON API at `https://www.arbeitnow.com/api/job-board-api`. The existing `germany_jobs.fetch_arbeitnow` path burns keyword presets and filters via `is_likely_german_only`, dropping English-language EU postings. This adapter takes the unfiltered firehose so we don't miss them.

Both adapters are wired into `scrape_all_new_sources()` with per-adapter try/except isolation matching the existing project pattern, re-exported via `scrape_resilient.py`, and require no new env vars.

## Live verification (network)

```
scrape_arbeitnow()                    -> 100 jobs  (Berlin Flix, WPP Hamburg, ...)
scrape_remotely_de(limit=15)          ->  15 jobs  (RheinNetz Köln, Aifano AI Data Eng,
                                                    Zalando Berlin, Orbis SE, ...)
```

Both endpoints returned 200 with structured data on first call from the dev box.

## Tests

`tests/test_new_sources.py` — 32 passing, including:
- happy-path parsing for each new source
- keyword filtering
- empty result handling
- malformed response handling (bad JSON / no JSON-LD / bad sitemap XML)
- transport failure returns `[]` rather than raising
- orchestrator stays alive when both EU adapters raise

`pytest tests/test_new_sources.py tests/test_scrape_resilient.py tests/test_daily_pipeline.py tests/test_scraper.py` -> **105 passed**.

`ruff check` + `ruff format --check` on touched files: no new issues over `main` (the 13 pre-existing E501/B023/F401 are unchanged from main).

## Pipeline budget

Issue caps total scan at 20 min (current ~12 min). remotely.de detail fetches dominate the new latency (~0.5s each), default `limit=50` with retry-with-backoff. Worst case adds ~30s, well inside budget.

## Deferred (follow-up ticket needed)

**Welcome to the Jungle** — their Algolia search (`CSEKHVMS53 / wttj_jobs_production`) is referer-gated:

```
403 {"message":"Method not allowed with this referer","status":403}
```

Cleanest path is either a Playwright pass or careful referer-spoofing; either way it's a separate ticket, not bundled here. Noted in commit body and ready to file as a follow-up.

## Test plan

- [x] `pytest tests/test_new_sources.py -q` passes (32/32)
- [x] `pytest tests/test_new_sources.py tests/test_scrape_resilient.py tests/test_daily_pipeline.py tests/test_scraper.py` passes (105/105)
- [x] `ruff check` + `ruff format --check` introduce no new issues
- [x] Live `scrape_arbeitnow()` returns > 0 jobs
- [x] Live `scrape_remotely_de(limit=15)` returns > 0 jobs with structured fields populated
- [ ] First nightly daily-scan run after merge surfaces fresh roles from `arbeitnow` and `remotely.de` (per #348 DoD — verifiable within 24h of merge)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>