### PR TITLE
fix(G-625): type-aware setter for textarea fill in batch_apply_browser

### DIFF
--- a/tests/test_batch_apply_browser_js_textarea.py
+++ b/tests/test_batch_apply_browser_js_textarea.py
@@ -1,0 +1,48 @@
+"""Regression tests for G-625 / GH issue #345 — textarea setter in Greenhouse JS fallback.
+
+The React-dynamic-fields JS fallback inside ``fill_custom_questions`` (Greenhouse/
+Anthropic branch) used to call ``HTMLInputElement.prototype``'s value setter on
+every input — including ``<textarea>`` elements. That throws ``TypeError:
+Illegal invocation`` at apply time because a setter pulled off one prototype
+cannot be invoked on an instance of a different prototype. The ``||``-fallback
+to ``HTMLTextAreaElement`` never fired because the descriptor on
+``HTMLInputElement.prototype.value`` is always truthy.
+
+The fix dispatches the prototype based on ``input.tagName``. These tests
+inspect the source file's embedded JS string (it executes inside Playwright at
+apply time, so a Python unit test cannot exercise it directly without a real
+browser session). They are intentionally lightweight — the end-to-end check is
+a real Greenhouse form, which is not part of CI.
+
+Living separately from ``test_batch_apply_browser.py`` so they run even when
+``config/personal.yaml`` is absent (that file skips the whole import-time
+module load).
+"""
+
+from pathlib import Path
+
+
+def _read_source() -> str:
+    src = Path(__file__).resolve().parent.parent / "tools" / "batch_apply_browser.py"
+    return src.read_text()
+
+
+def test_uses_type_aware_proto_dispatch():
+    """The JS must pick the prototype based on input.tagName === 'TEXTAREA'."""
+    source = _read_source()
+    assert "input.tagName === 'TEXTAREA'" in source, (
+        "Expected type-aware setter dispatch keyed on input.tagName === 'TEXTAREA'"
+    )
+    assert "window.HTMLTextAreaElement.prototype" in source
+    assert "window.HTMLInputElement.prototype" in source
+
+
+def test_does_not_use_broken_or_fallback():
+    """The old ``||`` fallback between two getOwnPropertyDescriptor calls for
+    ``value.set`` must not return — it never fires for textareas and is the
+    exact bug fixed by G-625."""
+    source = _read_source()
+    broken_chain = (
+        "HTMLInputElement.prototype, 'value'\n                                        ).set ||"
+    )
+    assert broken_chain not in source, "Broken ||-fallback pattern from G-625 reintroduced"

--- a/tools/batch_apply_browser.py
+++ b/tools/batch_apply_browser.py
@@ -815,13 +815,17 @@ async def fill_custom_questions(page, app: dict) -> None:
                                         }
                                     }
                                 } else {
-                                    const setter =
-                                        Object.getOwnPropertyDescriptor(
-                                            window.HTMLInputElement.prototype, 'value'
-                                        ).set ||
-                                        Object.getOwnPropertyDescriptor(
-                                            window.HTMLTextAreaElement.prototype, 'value'
-                                        ).set;
+                                    // Use the correct prototype setter based on element type.
+                                    // HTMLInputElement.prototype.value.set throws "Illegal
+                                    // invocation" when called on a textarea, so dispatch by
+                                    // tagName rather than relying on a ||-fallback (the input
+                                    // descriptor always exists, so the fallback never fired).
+                                    const proto = input.tagName === 'TEXTAREA'
+                                        ? window.HTMLTextAreaElement.prototype
+                                        : window.HTMLInputElement.prototype;
+                                    const setter = Object.getOwnPropertyDescriptor(
+                                        proto, 'value'
+                                    ).set;
                                     setter.call(input, value);
                                     input.dispatchEvent(new Event('input', { bubbles: true }));
                                     input.dispatchEvent(new Event('change', { bubbles: true }));


### PR DESCRIPTION
## Summary

The React-dynamic-fields JS fallback in `fill_custom_questions` (Greenhouse/Anthropic branch) called `HTMLInputElement.prototype`'s value setter on every input — including `<textarea>` elements — which throws `TypeError: Illegal invocation` because a setter pulled off one prototype cannot be invoked on a different prototype's instance. The intended `||`-fallback to `HTMLTextAreaElement` never fired because the `HTMLInputElement` descriptor is always truthy.

## Fix

Dispatch the prototype by `input.tagName`:

```javascript
const proto = input.tagName === 'TEXTAREA'
    ? window.HTMLTextAreaElement.prototype
    : window.HTMLInputElement.prototype;
const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
setter.call(input, value);
```

## Linear

Closes #345 / G-625

## Test plan

- [x] `pytest tests/test_batch_apply_browser_js_textarea.py -v` — 2/2 pass (string-inspects the embedded JS; the actual JS executes inside Playwright, so a true unit test isn't possible without a real browser session)
- [x] `ruff check` + `ruff format --check` on changed files — clean (9 pre-existing errors on `batch_apply_browser.py` unchanged)
- [ ] Manual: live Greenhouse application with a custom textarea — verified by maintainer post-merge (no Anthropic fixture in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)