### PR TITLE
G-708: docs: add 2026-05 browser-routing matrix to CLAUDE.md + job-search-tools.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,26 @@ Database (database.py, config.py)   → SQLite (WAL mode), async via aiosqlite
 - `.env` / `.env.example` — Backend environment variables
 - `.github/workflows/ci.yml` — CI: Python lint+test, frontend lint+test, CodeQL, PII scan
 
+## Browser routing (2026-05 matrix)
+
+When an *agent session* needs to navigate, scrape, or fill a web page, use these tools in priority order. Fall through to the next tier when the previous fails. Empirical ranking from a Docker-sandboxed 49-attempt sweep on 2026-05-21 (top to bottom = most-correct to least-correct on this corpus; full methodology + numbers in the [web-agent-comparison repo](https://github.com/pleasedodisturb/web-agent-comparison)).
+
+| # | Tool | Use for | Notes |
+|---|------|---------|-------|
+| 1 | **WebFetch** (built-in, no MCP) | Static-HTML reads — JD pages, "About" pages, blog posts | ~20× more token-efficient than browser snapshots. First choice for read-only public content. |
+| 2 | **Playwright MCP** (`@playwright/mcp`) | Interactive agent-driven flows (default driver) | 28 tools, accessibility-tree representation, deterministic. The baseline. |
+| 3 | **chrome-devtools MCP** (`chrome-devtools-mcp`) | DevTools-aware work — network panel, perf traces, console | Official ChromeDevTools team. Needs local Chrome/Brave. |
+| 4 | **browser-use** (`browser-use --mcp`) | Python-agent flows; high-level extract/act primitives | ~95K-star framework. Direct mode = no LLM key needed. Adds session management on top of Playwright primitives. |
+| 5 | **Obscura** (`obscura-mcp`) | Low-RAM stealth scraping — server-rendered or CDP-driven | Rust engine, ~30 MB RAM/tab, anti-fingerprint built in. Container arch packaging is fragile mid-2026 — runs cleanly on macOS host. |
+| 6 | **CloakBrowser** (`cloakbrowsermcp`) | Fingerprint-blocked sites (Workday, Cloudflare-protected ATSes) | Patched-Chromium with ~58 C++ stealth patches. **Sandbox only** — closed binary touches cookies, never point at an authenticated session. |
+| 7 | **Firecrawl** (`firecrawl-mcp`) | Token-optimised cloud markdown scraping | 96% coverage / 0.638 F1 on 1000-URL benchmark, ~7s avg. Needs `FIRECRAWL_API_KEY`. |
+| 8 | **Lightpanda** (`lightpanda mcp`) | Server-rendered HTML only, ~1.8s/page, tiny RAM | Zig engine. SPA/React pages return empty (by design). MCP subcommand verified working on darwin-aarch64 as of 2026-05-21. |
+| 9 | **BrowserMCP** (`@browsermcp/mcp`) | Authenticated host pages (LinkedIn, Greenhouse with real cookies) | Project-level `.mcp.json` only. Needs a Chrome Agent profile. **Never use on banking or credential pages** — content goes to the model provider's API. |
+
+**Removed / superseded:** `vercel-labs/agent-browser` (project unmaintained mid-2026; superseded by browser-use direct mode + Playwright MCP).
+
+**Note for `tools/*.py`:** the raw `playwright.sync_api` / `playwright.async_api` imports in batch scripts are correct as-is — those are server-side automation, not agent-driven. The matrix above governs *agent sessions* (Claude Code interactions, MCP tool calls).
+
 ## Workflow Rules
 
 ### Commits

--- a/docs/research/job-search-tools.md
+++ b/docs/research/job-search-tools.md
@@ -72,5 +72,10 @@ Entities stored in Cursor (preferences, target companies, etc.) are visible to G
 ## Out of Scope (Our Choices)
 
 - **Notion MCP**: We use Linear + TickTick
-- **LinkedIn MCP**: Skipped (account ban risk); use JobSpy anonymous or browsermcp
+- **LinkedIn MCP**: Skipped (account ban risk). Per the 2026-05 browser routing matrix in CLAUDE.md, escalate through:
+  1. **JobSpy anonymous** (no auth, lowest ban risk) — first choice
+  2. **Firecrawl** (cloud markdown, no local fingerprint) — token-optimised
+  3. **Obscura** (low-RAM stealth, server-rendered) — runs cleanly on macOS host
+  4. **CloakBrowser** (binary-patched fingerprint stealth) — sandbox only, *never* point at authenticated session
+  5. **BrowserMCP** (user's real browser with cookies) — last resort, high ban risk if LinkedIn detects automation
 - **Adzuna MCP**: Optional later


### PR DESCRIPTION
## Summary

Closes the biggest agent-doc gap surfaced by terminal-craft G-702 audit: kestrel's CLAUDE.md never mentioned browser-tool routing (focused entirely on FastAPI/Alembic/ruff). As an OSS product, the matrix is **inlined fully** — contributors won't have `~/.claude/docs/browser-tools.md`.

## Changes

- **CLAUDE.md** (+20 lines) — new `## Browser routing (2026-05 matrix)` section after `## Key Configuration`. 9-tier table with one-line use-case + note per tier. Calls out removal of vercel-labs/agent-browser and that the matrix governs *agent sessions*, not batch scripts.
- **docs/research/job-search-tools.md** (+7/-1) — LinkedIn line expanded from "use JobSpy anonymous or browsermcp" to full 5-tier escalation (JobSpy → Firecrawl → Obscura → CloakBrowser → BrowserMCP).

## Not changed

`tools/*.py` raw `playwright.sync_api` / `playwright.async_api` imports — these are server-side batch scripts, not agent-driven flows. Correct as-is per the audit's batch-script verdict.

## Test plan

- [x] CLAUDE.md table renders correctly
- [x] docs/research/job-search-tools.md numbered list renders correctly
- [x] Matrix is self-contained (no external doc links required to understand) — OSS-portable
- [x] No code changes
- [x] Pre-merge review: docs-only, no security concerns

Closes G-708. Tracked under terminal-craft G-702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)