### PR TITLE
G-851: fix stale test-count badge in REFERENCE.md (1773 → 3744)

### DIFF
--- a/docs/reference/REFERENCE.md
+++ b/docs/reference/REFERENCE.md
@@ -21,7 +21,7 @@ title: Features and API Reference
   <img src="https://img.shields.io/badge/FastAPI-0.115+-009688?style=flat-square&logo=fastapi&logoColor=white" alt="FastAPI">
   <img src="https://img.shields.io/badge/SQLite-3-003B57?style=flat-square&logo=sqlite&logoColor=white" alt="SQLite">
   <img src="https://img.shields.io/badge/Docker-Ready-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker">
-  <img src="https://img.shields.io/badge/Tests-1773_passing-22c55e?style=flat-square" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-3744_passing-22c55e?style=flat-square" alt="Tests">
   <img src="https://img.shields.io/badge/License-AGPL--3.0-blue?style=flat-square" alt="AGPL-3.0 License">
 </p>
 
@@ -251,7 +251,7 @@ kestrel/
 │   │   └── ...
 │   └── api/                   # API client layer (17 modules)
 ├── alembic/                   # Database migrations
-├── tests/                     # 42 test modules, 1773 tests
+├── tests/                     # 143 test modules, 3744 tests
 ├── docker-compose.yml         # Backend + Frontend orchestration
 ├── Dockerfile                 # Backend image
 ├── Dockerfile.frontend        # Frontend image


### PR DESCRIPTION
## What

`docs/reference/REFERENCE.md` advertised **1773 tests / 42 modules** in two places. Both stale by ~2.1x.

Verified on `main` via `pytest --collect-only -q`: **3744 tests across 143 test files**.

| Location | Before | After |
|---|---|---|
| Line 24 (shields badge) | `Tests-1773_passing` | `Tests-3744_passing` |
| Line 254 (tree comment) | `42 test modules, 1773 tests` | `143 test modules, 3744 tests` |

## Why

On a public OSS repo the badge is a credibility signal — undercounting by half makes the suite look less thorough than it is.

## Scope

Docs-only. No source/test changes. Personal-data scrub clean.

## Follow-up (not this PR)

Static count will drift again. Worth a CI step that regenerates the badge from `pytest --collect-only` on release, or a dynamic shields endpoint. Noted in G-851.

Closes G-851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)