### PR TITLE
G-1215: validate Anthropic batch results_url host (SSRF / API-key exfil fix)

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -9,6 +9,7 @@ Requires ANTHROPIC_API_KEY in environment.
 
 import json
 import logging
+from urllib.parse import urlparse
 
 import httpx
 
@@ -415,6 +416,15 @@ class AnthropicProvider(AIProvider):
 
         results_url = data.get("results_url")
         if not results_url:
+            return {"status": status, "results": {}}
+
+        # Validate results_url points to Anthropic's domain before fetching.
+        # The request below carries the x-api-key header, so a tampered or
+        # unexpected results_url could exfiltrate the API key to an arbitrary
+        # host. Restrict to Anthropic's domains.
+        parsed_url = urlparse(results_url)
+        if parsed_url.hostname not in ("api.anthropic.com", "anthropic.com"):
+            logger.error("Batch results_url points to unexpected host: %s", parsed_url.hostname)
             return {"status": status, "results": {}}
 
         # Fetch JSONL results

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -646,3 +646,73 @@ class TestBatchScoreCaching:
         assert "Backend role" in user_msg_2
         # System blocks are identical (same object reference)
         assert requests[0]["params"]["system"] is requests[1]["params"]["system"]
+
+
+class TestBatchResultsUrlValidation:
+    """results_url host validation prevents API-key exfiltration (SSRF guard).
+
+    get_batch_results() fetches the batch results_url with the x-api-key header
+    attached. A tampered or unexpected results_url must never be requested, or
+    the API key would leak to an arbitrary host.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_anthropic_results_url(self) -> None:
+        provider = AnthropicProvider(api_key=_TEST_CREDENTIAL)
+        requested_urls: list[str] = []
+
+        async def mock_get(url, headers=None, **kwargs):
+            requested_urls.append(url)
+            # Status poll returns a malicious results_url on a foreign host.
+            return httpx.Response(
+                200,
+                json={
+                    "processing_status": "ended",
+                    "results_url": "https://evil.example.com/leak",
+                },
+                request=httpx.Request("GET", url),
+            )
+
+        with patch("httpx.AsyncClient.get", side_effect=mock_get):
+            result = await provider.get_batch_results("batch_123")
+
+        assert result["status"] == "ended"
+        assert result["results"] == {}
+        # The malicious results_url must never be fetched (no key leak).
+        assert not any("evil.example.com" in u for u in requested_urls)
+
+    @pytest.mark.asyncio
+    async def test_accepts_anthropic_results_url(self) -> None:
+        provider = AnthropicProvider(api_key=_TEST_CREDENTIAL)
+        jsonl = json.dumps(
+            {
+                "custom_id": "req_0",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "content": [{"type": "text", "text": "ok"}],
+                        "model": "claude-sonnet-4-20250514",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    },
+                },
+            }
+        )
+
+        async def mock_get(url, headers=None, **kwargs):
+            if "/results" in url:
+                return httpx.Response(200, text=jsonl, request=httpx.Request("GET", url))
+            return httpx.Response(
+                200,
+                json={
+                    "processing_status": "ended",
+                    "results_url": "https://api.anthropic.com/v1/messages/batches/batch_123/results",
+                },
+                request=httpx.Request("GET", url),
+            )
+
+        with patch("httpx.AsyncClient.get", side_effect=mock_get):
+            result = await provider.get_batch_results("batch_123")
+
+        assert result["status"] == "ended"
+        assert "req_0" in result["results"]
+        assert result["results"]["req_0"].content == "ok"


### PR DESCRIPTION
## Security fix

`AnthropicProvider.get_batch_results()` fetches the batch `results_url` with the `x-api-key` header attached, but the URL came straight from the batch-status response with **no validation**. A tampered or unexpected `results_url` could exfiltrate the API key to an arbitrary host (SSRF / credential exfiltration).

**Fix:** validate `urlparse(results_url).hostname ∈ {api.anthropic.com, anthropic.com}` before fetching; otherwise log and return empty results. Self-contained, ~7 lines.

**Tests:** `TestBatchResultsUrlValidation` — rejects a foreign `results_url` (asserts it is never requested, so the key never leaks) and accepts a valid `api.anthropic.com` one. Both pass locally.

Found during the Eyas → syvyy-okean cherry-pick audit. Eyas already carries this guard; this brings the public Kestrel product to parity. Same fix landed in syvyy-okean (G-1214 PR #13).

Closes part of G-1215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)