### PR TITLE
fix(G-1288): revert auto-merged python:3.14 base image, add runtime-version guards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5
+    ignore:
+      # Types track the pinned Node 22 runtime (see docker ignore below).
+      - dependency-name: "@types/node"
+        versions: [">=26"]
     groups:
       react:
         patterns:
@@ -54,3 +58,13 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps"
+    ignore:
+      # Runtime pins — Python 3.x bumps classify as semver-MINOR and would
+      # auto-merge, but for a runtime they are de-facto majors. The project
+      # targets Python 3.11 (requires-python, ruff target) and Node 22 LTS.
+      # Bumping either is a deliberate upgrade ticket, not a dep PR (G-1288;
+      # policy carried over from the retired renovate.json).
+      - dependency-name: "python"
+        versions: [">=3.12"]
+      - dependency-name: "node"
+        versions: [">=23"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 # Stage 2: Python runtime — FastAPI + static frontend
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim AS runtime
+FROM python:3.11-slim AS runtime
 
 # Prevent Python from writing .pyc files and enable unbuffered output
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/tests/test_dependency_config.py
+++ b/tests/test_dependency_config.py
@@ -47,6 +47,27 @@ class TestDependabotConfig:
             limit = update.get("open-pull-requests-limit", 5)
             assert limit <= 10, f"{update['package-ecosystem']}: PR limit {limit} too high"
 
+    def test_runtime_version_guards(self, config):
+        """Runtime images must not auto-bump (G-1288: python 3.14 slipped
+        through automerge as a semver-minor). Policy from retired
+        renovate.json: Python 3.11, Node 22 LTS — upgrades are deliberate."""
+        docker = next(u for u in config["updates"] if u["package-ecosystem"] == "docker")
+        ignored = {i["dependency-name"] for i in docker.get("ignore", [])}
+        assert {"python", "node"} <= ignored, (
+            "docker ecosystem must ignore python/node runtime bumps"
+        )
+        npm = next(u for u in config["updates"] if u["package-ecosystem"] == "npm")
+        npm_ignored = {i["dependency-name"] for i in npm.get("ignore", [])}
+        assert "@types/node" in npm_ignored, "@types/node majors must track the pinned Node runtime"
+
+    def test_dockerfile_runtime_is_python_311(self):
+        """The runtime base image tracks the project's pinned Python."""
+        dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert "FROM python:3.11-slim AS runtime" in dockerfile, (
+            "Runtime image must stay on python:3.11-slim until the deliberate "
+            "upgrade ticket (G-1289) lands"
+        )
+
 
 class TestAutomergeWorkflow:
     """Validate the Dependabot automerge workflow policy (G-1277)."""


### PR DESCRIPTION
## Summary

Dependabot PR #418 (python:3.11-slim → 3.14-slim) auto-merged via the new G-1277 workflow — Python 3.x bumps are semver-minor to fetch-metadata but de-facto runtime majors. The retired renovate.json had a `<3.12` guard that the Dependabot port dropped.

- Dockerfile runtime back on **python:3.11-slim**
- dependabot.yml ignores: `python >=3.12`, `node >=23` (docker), `@types/node >=26` (npm)
- Policy-as-test: guards asserted in `tests/test_dependency_config.py` so no future config port can drop them silently

Deliberate Python upgrade evaluation: G-1289. Release v0.17.0 (#416) held until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf5DaBVx7GXBx2ZL8RqEVP