### PR TITLE
docs(G-1281): distill writing system — anti-slop, voice corpus, cover letters, LinkedIn

### DIFF
--- a/.claude/workflows/anti-slop-frontier.js
+++ b/.claude/workflows/anti-slop-frontier.js
@@ -1,0 +1,130 @@
+/*
+ * anti-slop-frontier — a weekly frontier scan for AI-writing tells.
+ *
+ * WHAT THIS IS
+ *   A small agent-workflow harness. It fans out several research agents in
+ *   parallel, each on a distinct angle, against the newest available sources,
+ *   then synthesizes their findings into an updated "anti-slop" guardrail and
+ *   diffs it against your committed baseline. The point is to stay at the
+ *   frontier: the lexical tells of AI prose rot fast (last year's banned-word
+ *   list is stale this year), so a guardrail you wrote once quietly decays.
+ *   Run this weekly, or before any big batch of writing, to refresh it.
+ *
+ * WHY A WORKFLOW AND NOT A PROMPT
+ *   Running the angles in parallel keeps each agent focused on one lens and
+ *   avoids one giant prompt that averages everything into mush. The schema
+ *   forces every agent to return the same shape (findings + concrete rules +
+ *   before/after + sources) so the synthesis step has clean inputs.
+ *
+ * THE FIFTH ANGLE (voice-tailored) — POINT IT AT YOUR OWN CORPUS
+ *   The first four angles are generic craft research. The fifth grounds the
+ *   guardrail in *your* actual writing so the advice protects your register
+ *   instead of flattening it. It reads a voice-corpus file whose path you
+ *   control. By default it looks for `config/voice-corpus.md`; override with
+ *   the VOICE_CORPUS_PATH environment variable. If the file is absent the
+ *   angle degrades gracefully to generic voice-protection advice. See
+ *   docs/guides/voice-corpus-architecture.md for how to build that corpus and
+ *   config/voice-corpus.example.md for a starter template.
+ *
+ * HARNESS CONTRACT
+ *   This file assumes an agent-runner that injects `agent`, `parallel`, and
+ *   `log` into scope and honors the exported `meta`. Adapt the three helper
+ *   calls to whatever runner you use; the shape of the workflow is the reusable
+ *   part.
+ */
+
+export const meta = {
+  name: 'anti-slop-frontier',
+  description:
+    'Weekly frontier scan: AI-slop markers + anti-slop writing craft (5 angles), synthesize a guardrail, highlight what is NEW vs the committed baseline.',
+  whenToUse:
+    'Run weekly (or before a big writing batch) to keep your anti-slop guardrail current. After it returns, save the synthesis alongside your dated frontier notes and fold substantial findings into your baseline guide.',
+  phases: [
+    { title: 'Research', detail: '5 parallel agents, distinct angles, latest sources' },
+    { title: 'Synthesize', detail: 'consolidate + diff against the baseline guardrail' },
+  ],
+}
+
+// Where the voice-tailored (5th) angle reads your real writing samples from.
+// Override with VOICE_CORPUS_PATH; defaults to the repo-relative template target.
+const VOICE_CORPUS_PATH =
+  (typeof process !== 'undefined' && process.env && process.env.VOICE_CORPUS_PATH) ||
+  'config/voice-corpus.md'
+
+// Every research agent returns this exact shape so the synthesis has clean inputs.
+const FINDER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['angle', 'key_findings', 'concrete_rules', 'before_after', 'sources'],
+  properties: {
+    angle: { type: 'string' },
+    key_findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['finding', 'why_it_matters'],
+        properties: { finding: { type: 'string' }, why_it_matters: { type: 'string' } },
+      },
+    },
+    concrete_rules: { type: 'array', items: { type: 'string' } },
+    before_after: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['slop', 'fixed'],
+        properties: { slop: { type: 'string' }, fixed: { type: 'string' } },
+      },
+    },
+    sources: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+// Four fixed generic angles + one voice-tailored angle that reads your corpus.
+const ANGLES = [
+  {
+    key: 'linguistic-markers',
+    prompt: `Research the LINGUISTIC MARKERS that make text detectably AI-generated, newest sources first (search the current year plus the last 12 months: detection research, stylometry, ChatGPT-tell catalogs, "AI slop" journalism). Focus on observable STRUCTURAL tells (low information density, "not just X but Y", rule-of-three, manufactured significance, participial significance-tails, low burstiness, over-signposting) and note which LEXICAL tells have decayed or newly emerged this year. Return findings + mechanical rules + before/after + sources.`,
+  },
+  {
+    key: 'anti-slop-craft',
+    prompt: `Research the WRITING CRAFT that makes prose read human and genuine — anti-slop editing techniques, newest sources first. Subtraction, concrete specifics, burstiness, point of view, cutting openers and closers, voice, show-the-seams honesty. Translate each into a mechanical, executable move. Return findings + rules + before/after + sources.`,
+  },
+  {
+    key: 'cover-letter-tells',
+    prompt: `Research what hiring managers and recruiters flag as AI-written in COVER LETTERS and application open-question answers, newest sources first (recruiter surveys, hiring blogs, ATS and detector usage this year). Generic enthusiasm, job-description mirroring, adjective lists, fit-assertion closers; and what makes a short letter land. Return findings + rules + before/after + sources.`,
+  },
+  {
+    key: 'detectors-and-stylometry',
+    prompt: `Research how AI-text DETECTORS and stylometry work (perplexity, burstiness, n-grams) and what it implies for human-reading prose, newest sources first. Be honest about detector unreliability and false-positive rates; extract the structural signal and turn it into writing guidance, not detector-gaming. Return findings + rules + before/after + sources.`,
+  },
+  {
+    key: 'voice-tailored',
+    prompt: `Produce a TAILORED anti-slop guardrail grounded in the writer's REAL voice. Read the voice corpus at "${VOICE_CORPUS_PATH}" (and any GOLD sample files it points to). If that file does not exist, say so and fall back to generic voice-protection advice. From the corpus, identify what PROTECTS the author's register (for example: parentheticals, doubt sitting beside competence, deflating closers, jagged sentence rhythm, concrete vignettes over adjectives) and describe exactly how an AI draft betrays that register (smoother, more evenly enthusiastic, flatter rhythm). Return findings + rules + before/after + sources (the corpus files count as sources).`,
+  },
+]
+
+const finds = (
+  await parallel(
+    ANGLES.map((a) => () =>
+      agent(a.prompt, {
+        label: `research:${a.key}`,
+        phase: 'Research',
+        schema: FINDER_SCHEMA,
+      }).catch(() => null)
+    )
+  )
+).filter(Boolean)
+log(`${finds.length}/${ANGLES.length} research angles returned`)
+
+const synthesis = await agent(
+  `Synthesize these anti-slop research angles into an updated guardrail. Bias hard toward SUBTRACTION (shorter, plainer, more specific).\n\nNEW RESEARCH (JSON):\n${JSON.stringify(
+    finds,
+    null,
+    2
+  )}\n\nReturn markdown with:\n1. WHAT'S NEW THIS WEEK — bullets for any new tell, decayed tell, or rule that a standard baseline would not already contain. If nothing material changed, say so plainly.\n2. The full updated guardrail: ranked slop tells, mechanical passes, application-specific rules, a voice-protection section grounded in the corpus findings, and an editing protocol.\nKeep it tight. Return ONLY markdown.`,
+  { label: 'synthesize', phase: 'Synthesize' }
+)
+
+return { synthesis, angles_returned: finds.length }

--- a/.claude/workflows/anti-slop-frontier.js
+++ b/.claude/workflows/anti-slop-frontier.js
@@ -1,3 +1,4 @@
+// NOT a standalone script (`node --check` fails by design): this file runs inside an agent-runner harness that injects `agent`, `parallel`, and `log`.
 /*
  * anti-slop-frontier — a weekly frontier scan for AI-writing tells.
  *

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ credentials.json
 
 # Personal config (generated from examples)
 config/personal.yaml
+# Voice corpus (raw personal writing — never commit)
+config/voice-corpus.md
 
 # Cursor / agent internals
 .cursor/

--- a/config/voice-corpus.example.md
+++ b/config/voice-corpus.example.md
@@ -1,0 +1,92 @@
+<!--
+Kestrel Voice Corpus — starter template.
+
+Copy to config/voice-corpus.md and fill in:
+    cp config/voice-corpus.example.md config/voice-corpus.md
+
+This file is the single source of truth for YOUR writing voice. Tools that
+draft or review prose (including the anti-slop-frontier workflow's 5th angle)
+read it to calibrate against how you actually write, instead of the generic
+AI assistant register.
+
+Organize your material into three layers by how much you trust each one to
+DEFINE your voice. See docs/guides/voice-corpus-architecture.md for the full
+method (the Ground -> Review -> Capture -> Distill flywheel and the
+"outputs are not inputs" firewall).
+
+Two rules that keep this file honest:
+  1. Only genuine writing goes in Layer 1 (GOLD) — things you wrote, dictated,
+     or rewrote substantially in your own words. Never add AI-drafted output.
+  2. Capture new genuine artifacts the SAME DAY you produce them, or they are
+     invisible to your next draft.
+-->
+
+# Voice Corpus
+
+_A curated library of my real writing, so an assistant helps me sound like myself._
+
+---
+
+## Layer 1 — GOLD: my pure, unedited voice (highest calibration weight)
+
+<!--
+The strongest signal. Pieces you wrote or dictated yourself, grammar-cleanup at
+most. Calibrate on these FIRST. Never let a tool rewrite anything here.
+For each entry: a path or link, a one-line note on what it captures, and how
+much editing it received ("grammar-only" or "fully mine").
+List your single strongest sample first and anchor every voice check to it.
+-->
+
+- `path/to/strongest-sample.md` — [what it captures; why it's your anchor] — grammar-only
+- `path/to/voice-memo-YYYY-MM-DD.md` — [topic; a raw unfiltered dictation] — grammar-only
+- `path/to/letter-you-wrote-yourself.md` — [a piece you rewrote entirely in your own words] — fully mine
+- _(add more as you capture them)_
+
+## Layer 2 — IDENTITY & RULES: what the voice IS
+
+<!--
+Explicit rules distilled FROM Layer 1. What you skim before writing when you
+don't have time to re-read all of GOLD. Re-distill these periodically as GOLD
+grows (see the DISTILL stage of the flywheel).
+-->
+
+- **Register:** [describe your baseline tone in one line — e.g. "precise, a little
+  self-deprecating, never salesy"]
+- **Rhythm:** [e.g. "jagged — long run-ons next to short fragments; never uniform"]
+- **Signature moves:** [e.g. "parentheticals that undercut the sentence; a win
+  always ships with its cost attached; deflating closers, never a pitch"]
+- **Hard avoids:** [words/moves that are never you — e.g. "no adjective
+  self-claims, no fit-assertion closers, no three-item lists"]
+- `path/to/voice-rules.md` — [link to a fuller distilled ruleset if you keep one]
+
+## Layer 3 — BACKGROUND FACTS: ground claims (NOT voice samples)
+
+<!--
+Facts and dates only. Answers "is that claim true?" — NEVER "does that sound
+like me?". Do not calibrate tone on anything here (CV phrasing is optimized for
+scanning, not voice).
+-->
+
+- `path/to/facts.yaml` — the source of truth for dates, titles, metrics
+- `path/to/background-notes.md` — roles, projects, and context to ground claims
+- _(assessments, timelines, and other fact sources)_
+
+## NOT corpus — outputs to judge, never inputs
+
+<!--
+The firewall. AI-drafted pieces (even ones you lightly edited and sent) are
+OUTPUTS. They are judged against Layer 1, never calibrated on. Calibrating on
+them launders the assistant register back into your voice over time.
+-->
+
+- `path/to/assistant-drafts/` — treat as outputs to review against GOLD, not inputs
+
+---
+
+## CAPTURE checklist (run at every session end)
+
+- [ ] Did I write or dictate something genuine? → save it under Layer 1 and note the editing level.
+- [ ] Did I rewrite an assistant draft substantially in my own words? → save the parts that are truly mine to Layer 1.
+- [ ] New facts, dates, or assessment results? → Layer 3.
+- [ ] Do the new samples shift my voice rules? → queue a DISTILL pass into Layer 2.
+- [ ] Commit it. Keep the corpus in plain text under version control so it travels across machines and tools.

--- a/docs/guides/anti-slop-writing.md
+++ b/docs/guides/anti-slop-writing.md
@@ -1,0 +1,132 @@
+---
+title: "Writing Without the AI Tells"
+description: "How to catch and remove the patterns that make prose read as AI-generated — a practical, ranked checklist plus an editing protocol"
+---
+
+# Writing Without the AI Tells
+
+A recruiter reading your cover letter has read a hundred others this month, and a good chunk of them were quietly written by a chatbot. They can feel it. Not because of any single word, but because AI prose has a *register* — evenly polished, agreeable, noun-heavy, every sentence pulling the same weight. Think of it like a room where every wall is painted the same shade of beige: nothing is wrong, and that's exactly what's wrong. This guide teaches you to hear that beige in your own drafts and knock it back out. The core move is almost never "rephrase it." It's **delete the tell, then make what's left concrete.**
+
+## The Short Version
+
+- The thing readers detect isn't machine authorship — it's the **smooth assistant register**. Write away from that register and the "AI feel" goes with it.
+- **Structural tells matter more than word choice.** Flat sentence rhythm and vague claims survive a thesaurus pass; that's why they're ranked first.
+- **Fix by subtraction.** Delete the slop and restore one concrete specific per paragraph. Rephrasing slop just produces different slop.
+- **Read it aloud.** It's the highest-yield check there is. Anywhere it sounds like a press release, cut.
+- Don't trust AI-detector scores in either direction — they're unreliable and measure the wrong thing. The real judge is a human who reads AI text all day.
+
+## How It Actually Works
+
+### Why "AI-sounding" is a register, not a fingerprint
+
+When people say a piece "reads like AI," they rarely mean a specific banned word. They mean the whole thing sits in one flat, over-helpful tone: balanced hedges, tidy transitions, every paragraph the same shape, a confident summary at the end. That register comes from how assistant models are tuned to be agreeable and complete. The good news is that your own natural writing — jagged, opinionated, occasionally blunt — is already the antidote. The job is mostly to *protect* that jaggedness, not to add polish on top of it.
+
+This also means the lexical tricks age fast. The buzzwords everyone flagged two years ago (*delve*, *tapestry*, *meticulous*) are already fading, because writers learned to avoid them and models drifted too. Structural tells — rhythm, density, paragraph shape — don't decay that way. Chase those first.
+
+### The tells, ranked
+
+Work top to bottom. The structural tells at the top survive paraphrasing and matter most; the lexical smoke list at the bottom rots every few months and is the weakest layer. Each row names the tell and the fix.
+
+| # | Tell | Fix |
+|---|------|-----|
+| 1 | **Flat cadence (low burstiness)** — three or more sentences in a row within about five words of each other's length | Read your sentence lengths as a sequence. Force one under 8 words or over 30. Let one be a fragment. A flat line fails even if every word is clean. |
+| 2 | **Low information density** — asserts a lot, specifies nothing | One number, name, date, or place per paragraph, or the paragraph *is* the slop. Cut it. |
+| 3 | **Swap-test failure** — the sentence would work unchanged in a competitor's letter (or, in a form answer, in another candidate's) | Cut it, or rebuild it around a fact true only of *this* company or *this* writer. |
+| 4 | **Contrast-reframe** — "not just X, but Y," "it's not about X, it's about Y," "no fluff, no filler, just results" | Delete the X clause. Keep Y only with evidence attached. One real contrast per piece, maximum. |
+| 5 | **Uniform paragraph arc** — every paragraph runs claim → elaboration → tidy mini-conclusion | Merge, split, and reorder until paragraph shapes vary. End on the last concrete point, not a zoom-out. |
+| 6 | **Claim with no incident** — "detail-oriented," "proven track record," "passionate about quality" | Replace the adjective with the incident that would prove it, or with nothing. |
+| 7 | **Participial tails and openers** — "…, ensuring seamless delivery," "…, highlighting my impact"; "Leveraging my background…" | Cut the tail; end on the fact. Kill "-ing" openers. This is one of the strongest syntactic tells — such clauses run several times the human rate. |
+| 8 | **Manufactured significance** — "stands as a testament to," "marks a pivotal moment," "boasts a rich history" | Restore a plain "is" or "has," or delete the sentence. The repair is delete-and-concretize, never a synonym. |
+| 9 | **Nominalizations and passive voice** — "the optimization of the pipeline resulted in a reduction of costs" | Use verbs with a person as the subject: "I rewrote the pipeline and the bill halved." |
+| 10 | **Rule-of-three triads** — "robust, scalable, and flexible"; three-item bold-header lists | Keep the most specific item, drop the other two. Use lists of two or four, or fold them into a sentence. |
+| 11 | **Throat-clearing openers** — "In today's fast-paced landscape," "Furthermore," "Here's the thing" | Delete the first ten percent. The real opening is usually your second paragraph. Connect by logic, not signpost. |
+| 12 | **Fit-assertion closers** — "I'm confident my skills align," "I look forward to the opportunity to contribute" | End on a plain next step or a concrete offer. Never recapitulate. |
+| 13 | **Job-description mirroring** — the posting's own language handed back to it | Answer one requirement with proof. Cite something that isn't on the careers page. |
+| 14 | **No opinion, no accidental detail** — every sentence safe and load-bearing | Plant one defensible stance and one oddly specific detail that doesn't serve the argument. Humanizer tools can fake rhythm; they can't fake a position. |
+| 15 | **Weasel attribution** — "studies show," "observers have noted," "it is widely believed" | Name the source or delete the claim. |
+| 16 | **Punctuation density** — a dash in every paragraph, long semicolon chains | Judge punctuation by density and function, never by presence (see the note on dashes below). |
+| 17 | **Lexical smoke list** (weakest layer, rotates every few months) — *emphasizing, enhance, showcasing, fostering, foster, align with, robust, comprehensive, seamless, leverage, harness, elevate* | Dense hits mean the *structure* is slop — fix that, don't swap synonyms. Swapping just lands on the next slop word. |
+
+**A note on the em dash.** For a while the em dash was treated as a human signal, and then as an AI signal, and by now it's neither — it has decayed into a false-positive trap. Don't add dashes to sound human, and never "fix" someone's writing by stripping the dashes they chose; that itself is a humanizer artifact. Judge punctuation by density and function, not by whether a mark is present. If your prose has a dash in every line, thin them out. If it doesn't, leave it alone.
+
+**On detector scores.** No reliable AI detector exists. Their verdicts drift day to day, they flag non-native English as "AI" at high rates, and they're really measuring the assistant register rather than authorship. Never edit toward a detector score in either direction. The gate that matters is a human read against your own genuine writing.
+
+### The mechanical passes
+
+Once you know the tells, run these ten moves over a draft. They're deliberately mechanical — things you can do without agonizing.
+
+1. **Delete-the-opener.** Cut the throat-clearing in paragraph one. Paragraph two is usually the real start.
+2. **Delete-the-closer.** Cut any ending that widens out to "the bigger picture." End on your last concrete point.
+3. **Fence-post pass.** Find three same-length sentences in a row and break the run: force one very short or very long, and keep at least one fragment.
+4. **Structure pass.** After you've fixed the words, vary the paragraph *shapes*. De-slopped prose still reads as AI when every paragraph runs the same arc.
+5. **De-noun pass.** Turn nominalizations back into verbs with agents. Kill "-ing" openers and tails. Restore "is" and "has."
+6. **Concrete over abstract.** One specific per paragraph, plus one non-load-bearing detail per piece — the small true thing that doesn't advance the argument but proves a person was there. If you don't have a real one, leave a placeholder and fill it later. Never invent it.
+7. **Span/collision test.** For every surviving sentence, ask: could this be pasted, unchanged, into someone else's application? If yes, cut it.
+8. **One opinion.** Add a single stance or reservation you'd defend out loud.
+9. **Show the seams.** State the real constraint, the thing that went wrong, the trade-off you actually made. Plainly.
+10. **Read aloud.** The highest-yield check. Re-cut anywhere it sounds like a press release.
+
+```mermaid
+flowchart TD
+    A[Draft] --> B[Read aloud, whole]
+    B --> C[Mark every tell inline<br/>tag, don't fix yet]
+    C --> D[Cut — delete before rewriting]
+    D --> E[Collision test<br/>every surviving sentence]
+    E --> F[Restore one specific<br/>per paragraph]
+    F --> G[Structure pass<br/>vary paragraph shapes]
+    G --> H[Fence-post check<br/>break flat rhythm]
+    H --> I[Smoke check the<br/>lexical list]
+    I --> J{Shorter than the draft?<br/>Every claim has evidence?<br/>One opinion, one odd detail?}
+    J -->|No| D
+    J -->|Yes| K[Done]
+```
+
+### The editing protocol
+
+Here's the whole thing as one pass, top to bottom. Notice how much of it is *cutting* and *tagging* rather than writing.
+
+1. **Register gate.** Before touching individual words, read the draft aloud next to a piece of your own real writing — something you wrote unassisted and were happy with. If the draft is smoother or more enthusiastic than your genuine voice, reject it wholesale and start closer to your own samples. Don't patch a register problem word by word. (Keeping a small library of your own real samples is worth doing on its own — see the [voice corpus guide](voice-corpus-architecture.md).)
+2. **Read aloud, whole.** Note the press-release spots and any flat, fence-post rhythm.
+3. **Mark every tell** inline, like `[SLOP: contrast-reframe]`. Tag, don't fix yet.
+4. **Cut, don't rewrite.** Your first action on every tag is to delete it and see if the sentence survives.
+5. **Collision test** every surviving sentence: swappable to another company or another writer? Cut it.
+6. **Restore specificity.** One concrete per paragraph, plus one accidental detail per piece. Leave a `[TODO: real detail]` slot if you have none — never fabricate.
+7. **Structure pass.** Vary paragraph arcs and lengths. Kill the zoom-out closer.
+8. **Fence-post check.** Break uniform sentence runs. Keep a fragment.
+9. **Log old → new** for every change, so you can see what you cut and undo a step that went too far.
+10. **Flag, don't guess.** For anything you can't verify — a number, a claim, a stance only the author can take — mark it and surface it rather than inventing something plausible.
+11. **Smoke check** the lexical list. Dense hits mean fix the structure, not the vocabulary.
+
+**Stop when** the piece is shorter than the draft, every claim has evidence or a flag, no sentence survives the collision test, and there's at least one opinion and one accidental detail.
+
+## Examples
+
+**Before (slop):** "As a detail-oriented professional with a proven track record, I am excited to leverage my comprehensive skill set to drive impactful results and foster seamless collaboration across cross-functional teams."
+
+**After:** "I once spent a week tracing a billing bug at Northwind Data that turned out to be a timezone off by one. It shipped in the fix that halved our support tickets that quarter. That's the kind of problem I like."
+
+The rewrite is shorter, carries a real incident, states a preference, and could not be pasted into anyone else's letter. Nothing was rephrased; the slop was deleted and one concrete thing was restored.
+
+**Before (flat cadence):** "I built the reporting service. I tested the reporting service. I deployed the reporting service. It worked well in production." Four sentences, nearly identical length — the fence-post pattern.
+
+**After:** "I built the reporting service, tested it against a year of replayed traffic, and shipped it. It held. (The one incident was a cache we'd sized for the wrong percentile — very educational.)" The rhythm now varies, and the parenthetical adds the seam that a machine would smooth away.
+
+## FAQ
+
+**Q: Isn't this just "write well"?**
+Partly. But the tells give you a checklist, which is faster and more reliable than a vague sense that something is off. When you're editing at 11pm before a deadline, "flag three same-length sentences and break the run" is a move you can actually execute.
+
+**Q: Should I run my writing through an AI detector before sending it?**
+No. Detectors are unreliable and flag plenty of genuine human writing, especially from non-native English speakers. Edit against your own real samples and read the piece aloud instead.
+
+**Q: If I delete all the polish, won't the writing feel rough?**
+A little rough beats a little robotic. The reader trained on AI text is scanning for the smooth assistant register, and slightly uneven, specific, opinionated prose reads as *a person wrote this* — which is the whole point.
+
+**Q: Does this apply to everything I write?**
+It applies to prose meant to persuade or represent you: cover letters, outreach, application answers, posts. It does **not** apply to CVs, which are keyword-driven documents optimized for scanning. See the [cover letter guide](cover-letter-writing.md) for why the two diverge.
+
+## Further Reading
+
+- [Building a Voice Corpus](voice-corpus-architecture.md) — how to collect the real writing samples the register gate depends on
+- [Writing Cover Letters That Don't Read as AI](cover-letter-writing.md) — the full 14-category taxonomy and pre-send checklist
+- [Optimizing a LinkedIn Profile](linkedin-profile-optimization.md) — where distinctive voice helps and where keyword discipline wins instead

--- a/docs/guides/anti-slop-writing.md
+++ b/docs/guides/anti-slop-writing.md
@@ -19,7 +19,7 @@ A recruiter reading your cover letter has read a hundred others this month, and 
 
 ### Why "AI-sounding" is a register, not a fingerprint
 
-When people say a piece "reads like AI," they rarely mean a specific banned word. They mean the whole thing sits in one flat, over-helpful tone: balanced hedges, tidy transitions, every paragraph the same shape, a confident summary at the end. That register comes from how assistant models are tuned to be agreeable and complete. The good news is that your own natural writing — jagged, opinionated, occasionally blunt — is already the antidote. The job is mostly to *protect* that jaggedness, not to add polish on top of it.
+When people say a piece "reads like AI," they rarely mean a specific banned word. They mean the whole thing sits in one flat, over-helpful tone: balanced hedges, tidy transitions, every paragraph the same shape, a confident summary at the end. That register comes from how assistant models are tuned to be agreeable and complete. The good news is that your own natural writing — jagged and opinionated — is already the antidote. The job is mostly to *protect* that jaggedness, not to add polish on top of it.
 
 This also means the lexical tricks age fast. The buzzwords everyone flagged two years ago (*delve*, *tapestry*, *meticulous*) are already fading, because writers learned to avoid them and models drifted too. Structural tells — rhythm, density, paragraph shape — don't decay that way. Chase those first.
 

--- a/docs/guides/cover-letter-writing.md
+++ b/docs/guides/cover-letter-writing.md
@@ -1,0 +1,142 @@
+---
+title: "Writing Cover Letters That Don't Read as AI"
+description: "A 14-category taxonomy of what experts flag as AI-written, a pre-send checklist, and why none of it applies to your CV"
+---
+
+# Writing Cover Letters That Don't Read as AI
+
+A recruiter at an AI-literate company is, by now, an expert AI-text detector — not because they run your letter through a tool, but because they read the assistant register all day and their ear is tuned to it. A letter that pings that ear is worse than a slightly rough human one: it signals both a lack of effort *and* a lack of judgment about how your reader reads. Think of it like sending a form email that opens "Dear Sir or Madam" — the problem isn't any single word, it's that the whole thing announces you didn't really show up. This guide breaks down the specific patterns those readers flag, gives you a checklist to catch them before you send, and explains why you should throw all of it out the moment you touch your CV.
+
+## The Short Version
+
+- Frequent AI users are startlingly good at spotting AI prose — better than any detector tool — so your real audience is the toughest possible judge.
+- Experts flag **14 recurring categories**, led by vocabulary, sentence structure, and grammar. The fix for almost all of them is *cut and make concrete*, not rephrase.
+- Some tells are **discourse-level** — how a story handles cause, agency, and time — and survive even when you scrub the vocabulary.
+- A **12-item pre-send checklist** catches most of it in a few minutes.
+- **Do not apply any of this to your CV.** A CV is a keyword-scannable document; distinctive voice actively hurts it.
+
+## How It Actually Works
+
+### Why this is worth the effort
+
+Three findings from recent research set the stakes:
+
+1. **People who use LLMs daily are near-perfect at spotting AI prose.** In a controlled study (Russell, Karpinska & Iyyer, ACL 2025, arXiv:2501.15654), a five-expert majority vote of frequent LLM users misclassified only 1 of 300 articles — beating every detector tool, even against paraphrasing and "humanization" attacks. Recruiters at AI-adjacent companies are exactly this cohort.
+
+2. **AI prose is everywhere in professional writing.** A follow-up (arXiv:2510.18774) found a meaningful share of 2025 newspaper articles were AI-generated, with opinion pieces far more likely than news to contain AI content. The pool of readers trained on real AI submissions is enormous and growing.
+
+3. **Discourse-level tells persist even when surface tells are scrubbed.** The StoryScope work (arXiv:2604.03136) shows AI text is distinguishable at the structural level — narrative arc, agency, chronology — not just word choice. Polishing vocabulary alone does not solve the problem.
+
+The implication: a letter that reads as AI to your reader is a worse outcome than a plainer, human-sounding one. Effort and judgment are the things you're actually signaling.
+
+### The 14-category taxonomy
+
+Descending by how often experts cited each category. For each: what AI tends to do, and what to do instead. Every example here is invented.
+
+**1. Vocabulary.** *AI overuses:* delve, testament, crucial, vibrant, harness, foster, robust, comprehensive, multifaceted, leverage, intricate, showcase, demonstrate, "serves as a testament to." *Do instead:* your actual working vocabulary — "the obvious move was," "what bit me last time was," "the architecture I'd reach for." Precise domain terms used correctly are signal, not noise.
+
+**2. Sentence structure.** *AI patterns:* "not only X, but also Y"; three-item lists ("robust, scalable, and flexible"); sentences of uniform length forming even blocks. *Do instead:* vary length aggressively — three short clipped sentences, then one long one with an aside. List two items or four, never three. Cut every "not only … but also."
+
+**3. Grammar and punctuation.** *AI:* grammatically flawless, avoids parentheticals, identical comma rhythm throughout. *Do instead:* use parentheses (like this) and the occasional colon. One comma splice per letter is fine. Judge punctuation by density and function rather than by presence — including dashes, which have decayed into a false-positive tell: don't add them to sound human, and don't strip a writer's chosen dashes to sound less like AI.
+
+**4. Originality.** *AI:* safe, no surprises, no humor, no specific imagery. *Do instead:* one concrete, unexpected detail per letter. "I shipped the checkout rewrite at Northwind Data the week our payment provider changed their API — that was a long week." Specifics that couldn't appear in anyone else's letter are the strongest human-authorship signal.
+
+**5. Quotes and cited claims.** *AI:* smooths all cited material into the surrounding voice. *Do instead:* let it sit jagged. "My lead at Meridian Labs used to say 'ship it and watch the graphs' — that's the loop I want back."
+
+**6. Clarity.** *AI:* over-explains, adds connective tissue, tells rather than shows. *Do instead:* trust the reader. Cut every "in order to," "it is worth noting that," "what this means is." State the result and let them infer the process.
+
+**7. Formatting.** *AI:* uniform headings, even paragraphs, bulleted lists. *Do instead:* no bullets, no headings in a cover letter. Vary paragraph length — one paragraph can be a single sentence.
+
+**8. Conclusions.** *AI:* cheerful summary closings ("I would welcome the opportunity to contribute," "I look forward to discussing"). *Do instead:* end abruptly on a concrete next step. "Happy to walk you through the pipeline if it helps." / "If the role's still open in two weeks, I'll follow up." Never recapitulate.
+
+**9. Formality.** *AI (un-humanized):* no contractions, no fillers, uniformly polished. *Do instead:* use contractions naturally (I'd, I'm, didn't). One mild filler is fine (honestly, frankly). Don't over-correct into breezy informality either — precise is not the same as casual.
+
+**10. Names, titles, and entities.** *AI:* generic placeholder names, the same job title for everyone, avoids specific brands. *Do instead:* name real things. "Atlas Robotics' warehouse SDK," not "a major logistics platform." Concrete named entities are hard for a generic draft to produce.
+
+**11. Tone.** *AI:* consistently neutral-positive, no critique, no edge. *Do instead:* one moment of genuine opinion or honest reservation. "I'm wary of platform roles that turn into ticket triage — what I want is to own a surface end to end again."
+
+**12. Introductions.** *AI:* generic scenic openers. "In today's rapidly evolving landscape…" *Do instead:* open with something specific to *this* company or role that couldn't appear elsewhere — a reference to a real release note, a product you actually used and what happened. Never "I'm writing to express my interest in…"
+
+**13. Factuality (critical).** Never invent numbers, dates, project names, or company facts. Every metric must trace to something real, or be flagged for you to verify. Hallucinated specifics are catastrophic — both a detection signal *and* a credibility-killer if the reader checks. If unsure, leave it out or mark `[VERIFY: X]` and resolve it before sending.
+
+**14. Topics.** *AI:* avoids critique and smooths over career discontinuities. *Do instead:* a real career has gaps and pivots — naming yours tells the reader you're not afraid of the question. "I joined a startup that got acquired and wound down my team six months later; the time since has gone into shipping a project end to end, which is the work I actually want."
+
+### Discourse-level tells (StoryScope)
+
+Beyond words and sentences, AI prose has structural giveaways that survive a vocabulary scrub:
+
+- **Causality.** Real careers have *because*, *which led to*, *which didn't work because*. AI smooths everything into *and then* / *building on this*. Force the causal joints to be explicit.
+- **Agency.** Whose decision was each move? AI drifts into passive arcs ("the opportunity arose to…"). State the agent: "I left because…," "I took the offer because…"
+- **Chronological discontinuity.** Real timelines have gaps, overlaps, and pivots. If your arc reads as one smooth ascending curve, it's wrong.
+
+```mermaid
+flowchart TD
+    A[Draft cover letter] --> B[Run the 14-category scan]
+    B --> C{Surface tells:<br/>vocabulary, structure,<br/>closers, formatting}
+    C --> D[Cut + make concrete]
+    D --> E{Discourse tells:<br/>causality, agency,<br/>chronology}
+    E --> F[Make the joints explicit]
+    F --> G[Run the 12-item<br/>pre-send checklist]
+    G --> H{8+ pass?}
+    H -->|No| D
+    H -->|Yes| I[Send]
+```
+
+### Pre-send checklist
+
+Self-check before you send. If 8+ pass, the letter probably reads as human. Fewer than 6, redraft.
+
+1. **Banned-vocab scan** — delve, testament, crucial, vibrant, harness, foster, leverage, robust, comprehensive, multifaceted, showcase, demonstrate. Replace or cut every hit.
+2. **"Not only / but also"** — search and rewrite.
+3. **Three-item lists** — reduce to two or expand to four.
+4. **Transition openers** — Furthermore, Moreover, Additionally, In conclusion. Rewrite.
+5. **Closing phrases** — "I look forward to," "I would welcome," "Thank you for considering." Replace with a concrete next step.
+6. **Specificity per paragraph** — every paragraph has at least one named entity or real number.
+7. **Punctuation variety** — at least one parenthetical aside; no single mark in every line.
+8. **Opening specificity** — the first sentence couldn't be pasted into another application.
+9. **Paragraph-length variance** — not all the same length.
+10. **Factual provenance** — every metric traces to something real; mark `[VERIFY: X]` for anything uncertain.
+11. **Career honesty** — gaps and pivots named, not smoothed.
+12. **Tonal shift** — at least one sentence carries opinion, edge, or honest reservation.
+
+## What NOT to apply to CVs
+
+**Do not apply this guide to CVs.** A cover letter and a CV are read by different judges with opposite criteria, and the strategy diverges completely.
+
+A CV is a convention-bound, scannable, keyword-driven document read by an applicant tracking system (ATS) first and a human second. Its signal is keyword alignment with the job description and clarity of scope and impact — not human-sounding prose. "Distinctive voice" in a CV actively reduces parseability and hurts your result.
+
+For CVs:
+
+- Keep the template clean and terse.
+- Lead bullets with strong verbs and quantified outcomes — the *opposite* of the "show, don't tell" advice above.
+- Mirror the job description's keywords explicitly; do not paraphrase them into your own words.
+- Avoid parentheticals — they confuse some ATS parsers.
+- Three-item parallel structure is fine in a CV. It isn't, in a cover letter.
+
+The rule of thumb: a CV is judged by systems aligned *with* convention, while a cover letter is judged by humans who read AI text all day. Optimize each for its actual reader.
+
+## FAQ
+
+**Q: If I follow all this, won't my letter sound less polished?**
+Yes, a little — and that's the goal. Your reader is scanning for the smooth assistant register. Specific, opinionated, slightly uneven prose reads as *a person wrote this*, which is exactly the signal you want.
+
+**Q: Can I use an assistant to draft the letter at all?**
+Use it to research the company, check facts, and mark the tells in a draft — but the sentences that carry your voice should be yours. See [Building a Voice Corpus](voice-corpus-architecture.md) for how to give an assistant real samples to work from, and [Writing Without the AI Tells](anti-slop-writing.md) for the editing protocol.
+
+**Q: How long should a cover letter be?**
+Short. One achievement matched to the role, one specific reason you want *this* company, and a plain ask. A tight letter that a reader finishes beats a long one they skim.
+
+**Q: What if I genuinely don't have a specific detail for a company?**
+Then find one before you write — read a real release note, changelog, or product page — or don't send a cover letter at all. A generic letter is worse than none.
+
+## Source papers
+
+- Russell, J., Karpinska, M., & Iyyer, M. (2025). *People who frequently use ChatGPT for writing tasks are accurate and robust detectors of AI-generated text.* ACL 2025. arXiv:2501.15654.
+- Russell, J., Karpinska, M., Akinode, D., Thai, K., Emi, B., Spero, M., & Iyyer, M. (2025). *AI use in American newspapers is widespread, uneven, and rarely disclosed.* arXiv:2510.18774.
+- Russell, J., Rajendhran, R., Pham, C. M., Iyyer, M., & Wieting, J. (2026). *StoryScope: Investigating idiosyncrasies in AI fiction.* arXiv:2604.03136.
+
+## Further Reading
+
+- [Writing Without the AI Tells](anti-slop-writing.md) — the ranked tell checklist and editing protocol behind this guide
+- [Building a Voice Corpus](voice-corpus-architecture.md) — how to give an assistant real samples of your voice to work from
+- [Optimizing a LinkedIn Profile](linkedin-profile-optimization.md) — the keyword-driven counterpart, where CV logic applies instead

--- a/docs/guides/linkedin-profile-optimization.md
+++ b/docs/guides/linkedin-profile-optimization.md
@@ -5,7 +5,7 @@ description: "How recruiter search actually reads your profile, and how to write
 
 # Optimizing a LinkedIn Profile
 
-Your LinkedIn profile has two audiences, and they read it in completely different ways. First comes the machine: recruiter search filters and, increasingly, AI screening assistants that decide whether you even appear in a result. Only if you clear that gate does a human ever read a word you wrote. Most people write only for the human and quietly stay invisible to the machine — a beautifully worded profile that no search ever surfaces. Think of it like a storefront on a street no one drives down: the window display doesn't matter if the map never lists the address. This guide covers both readers: the keyword discipline that gets you found, and the writing that makes a human keep reading once they arrive.
+Recruiters don't browse LinkedIn. They search it. Filters and AI screening assistants decide who appears in a result list at all, and a human reads only the handful of profiles that survive that cut. Which means your profile has two audiences — the machine first, then the person — and most people write for only the second one. The result is a beautifully worded page no search ever surfaces: a storefront on a street nobody drives down. This guide covers both readers in the order they arrive: the keyword discipline that gets you found, then the writing that makes a human keep reading once they do.
 
 ## The Short Version
 

--- a/docs/guides/linkedin-profile-optimization.md
+++ b/docs/guides/linkedin-profile-optimization.md
@@ -1,0 +1,107 @@
+---
+title: "Optimizing a LinkedIn Profile"
+description: "How recruiter search actually reads your profile, and how to write a headline, About section, and skills list that get you found and taken seriously"
+---
+
+# Optimizing a LinkedIn Profile
+
+Your LinkedIn profile has two audiences, and they read it in completely different ways. First comes the machine: recruiter search filters and, increasingly, AI screening assistants that decide whether you even appear in a result. Only if you clear that gate does a human ever read a word you wrote. Most people write only for the human and quietly stay invisible to the machine — a beautifully worded profile that no search ever surfaces. Think of it like a storefront on a street no one drives down: the window display doesn't matter if the map never lists the address. This guide covers both readers: the keyword discipline that gets you found, and the writing that makes a human keep reading once they arrive.
+
+## The Short Version
+
+- A profile is read by **machines first, humans second.** Optimize for both, in that order.
+- The **headline** is your keyword surface and your click-decider — lead with the role terms people actually search, keep any wit to a short clause at the tail, and front-load it so it survives mobile truncation.
+- The **About** section works as an arc: **thesis → proof → stance.** Open with what you do, back it with concrete shipped work, and close with a commitment signal.
+- **Seed recruiter keywords** in plain language and echo your skill terms into your experience descriptions — search scans those too.
+- **Skills:** 15–25 hard, job-description-language terms; pin your top 3; drop stale ones.
+- Featured, Projects, and Recommendations are **trust primitives** — proof that you did the things you claim.
+
+## How It Actually Works
+
+### The two readers
+
+Recruiters rarely browse. They search — filtering by title, seniority, function, skills, and location — and then read only the handful of profiles that surface. Layered on top, AI screening assistants now parse profiles semantically, matching the plain-language way a role is described against the plain-language way you describe yourself. Both readers care about *terms*: the exact words a recruiter types and a screener matches. Miss those terms and the best-written profile in the world never gets read.
+
+The human reader arrives only after the machine passes you through. For them, the job flips: now it's about whether your headline earns a click and whether your About section reads like a real person who shipped real things. The rest of this guide handles each reader in turn.
+
+### The headline formula
+
+Your headline is the single most valuable text real estate you own. It feeds the keyword index that search matches against, it's the line a human uses to decide whether to click, and it's what AI screeners parse to place you. Three rules:
+
+1. **Keyword-first.** Lead with the role terms someone would actually search — the plain job titles for the work you want, not a clever coinage. A headline made entirely of personality is invisible to search.
+2. **Front-load for truncation.** Only the first ~68 characters reliably survive on mobile. Put your most important terms there; anything witty goes at the tail where truncation costs you nothing.
+3. **One wit clause, maximum.** A single sharp phrase at the end makes you memorable to the human without diluting the keywords. More than one and you're back to writing only for the human.
+
+**Invented example.** Instead of a pure-personality headline like *"Turning caffeine into shipped software"* (searchable for nothing), write:
+
+> Backend Engineer · Distributed Systems & Payments · Building Northwind's checkout platform · ex-Meridian Labs
+
+The role terms lead, the concrete work follows, and there's just enough specificity to earn a click — all within the first line a phone will show.
+
+### The About arc: thesis → proof → stance
+
+An About section that reads as a list of adjectives ("passionate, results-driven, collaborative") reads as AI and convinces no one. Structure it as an arc instead.
+
+- **Thesis.** Open with one plain sentence about what you do and how you work. Not a scenic wind-up — the actual claim. "I build payment systems and I learn by shipping them."
+- **Proof.** Back the thesis with receipts: concrete, named, shipped work. This is where you earn belief. "Last year I rewrote Atlas Robotics' billing service — cut reconciliation errors, survived a provider migration — and I've contributed a dozen merged fixes to an open-source scheduling library."
+- **Stance.** Close with a commitment signal: a sentence that says where you're headed and why, which counters any read of you as a flight risk or a dabbler. "The independent stretch was deliberate — I went deep on the stack by building in it. What I want next is a team and a hard problem to point it all at."
+
+The arc gives a human reader a reason to keep going and gives the machine a dense band of role-relevant terms in the proof section. Write the whole thing in your own voice — this is exactly the kind of prose where the [anti-slop tells](anti-slop-writing.md) matter most.
+
+### Seeding recruiter keywords
+
+Semantic search and AI screeners map you to roles stated in **plain language**, so state your target roles plainly somewhere in the profile — the everyday names of the jobs you want, not internal jargon or invented titles. A line like "Open to: Backend Engineer, Platform Engineer, Payments Engineer" is searchable filter data working for you.
+
+Then **echo your skill terms into your experience descriptions.** Search doesn't only scan your skills list; it scans the words in your role descriptions too. If "distributed systems" and "Python" are skills you claim, they should also appear naturally in the bullets describing what you built. A skill that appears only in the list and never in the story reads as a keyword you tacked on.
+
+### Skills: fewer, harder, ordered
+
+- **15–25 skills, in job-description language.** Use the exact terms roles ask for. "Large Language Models (LLM)" if that's what postings say, not a personal shorthand.
+- **Pin your top 3.** The pinned skills are the first a viewer sees — make them the terms most central to the roles you want.
+- **Drop stale ones.** A skill for a tool nobody hires for anymore just dilutes the signal. Prune regularly.
+
+### Trust primitives: Featured, Projects, Recommendations
+
+Once search surfaces you and your writing earns a read, the last question in a reader's mind is *did they actually do this?* Three sections answer it with evidence:
+
+- **Featured** — a small, curated set (three to five outperforms a long dump) of your strongest artifacts, linked directly: a repository, a case study, a well-received post. Link cards beat plain media because they carry a logo and a title.
+- **Projects** — search-indexed, so give entries keyword-rich names and a short problem-to-outcome description each. This is where side work and open-source contributions earn their keywords.
+- **Recommendations** — the trust primitive most people have zero of, and they're read at exactly the late stage where decisions get made. Ask a handful of former colleagues for two or three honest sentences each about specific work you did together; offer to write theirs in return. Specific and modest beats effusive and generic.
+
+```mermaid
+flowchart TD
+    A[Recruiter search / AI screener] -->|keyword + title match| B[Headline + skills + role terms<br/>get you INTO the result set]
+    B --> C[Human opens the profile]
+    C --> D[Headline earns the click]
+    D --> E[About arc: thesis -> proof -> stance]
+    E --> F[Trust primitives:<br/>Featured / Projects / Recommendations]
+    F --> G[Reader believes you did the work]
+```
+
+## Examples
+
+**Headline, before and after.** Before: *"Ideas person | Lifelong learner | Let's connect!"* — searchable for nothing, and the exclamation mark does no work. After: *"Data Engineer · Streaming & ETL · Building Meridian's real-time pipeline · occasional writer on data plumbing"* — role terms first, concrete work, one light clause at the tail.
+
+**About proof paragraph.** Weak: "I am a passionate engineer with a proven track record of delivering high-impact solutions." Strong: "I built the ingestion layer at Meridian Labs that now handles a few billion events a day, and I've written up two of the outages it survived. When something's undefined and messy, that's the work I reach for." The strong version names the system, offers a receipt, and states a preference — all things a generic draft can't produce.
+
+**Skills ordering.** A backend candidate pins *Distributed Systems*, *Python*, and *PostgreSQL* — the three terms most central to their target roles — then lists another dozen (Kafka, gRPC, Kubernetes, observability, and so on) in job-description language, and drops a long-stale framework nobody hires for.
+
+## FAQ
+
+**Q: Should my LinkedIn read like my cover letter?**
+Partly. The About section is prose and benefits from real voice, so the [anti-slop guidance](anti-slop-writing.md) applies. But the headline, skills, and role-term seeding are keyword-driven — closer to CV logic than cover-letter logic. Optimize each section for how it's actually read.
+
+**Q: Isn't keyword-stuffing obvious and off-putting?**
+Stuffing is. Seeding isn't. The goal is that the real terms for your real work appear in the natural places a search looks — headline, skills, and woven into genuine descriptions of what you built. If the words are true and placed naturally, a human reads them as substance, not spam.
+
+**Q: How many Featured items should I have?**
+Three to five, curated. A long list dilutes attention; a tight set of your strongest artifacts, each a direct link to proof, does more work.
+
+**Q: What if I have no recommendations yet?**
+Ask for a few. They're read at the final stages of hiring and most candidates have none, so a handful of specific, honest ones is an outsized advantage. Keep the ask small: two or three sentences about a specific piece of work, with an offer to reciprocate.
+
+## Further Reading
+
+- [Writing Without the AI Tells](anti-slop-writing.md) — for the About section, where distinctive voice earns the read
+- [Building a Voice Corpus](voice-corpus-architecture.md) — how to make an assistant help you write the About section in your own voice
+- [Writing Cover Letters That Don't Read as AI](cover-letter-writing.md) — the cover-letter counterpart, and why CV-style sections here follow the opposite rules

--- a/docs/guides/voice-corpus-architecture.md
+++ b/docs/guides/voice-corpus-architecture.md
@@ -5,7 +5,7 @@ description: "A three-layer system for capturing your real writing voice so an A
 
 # Building a Voice Corpus
 
-When you ask an AI to draft something in your voice, it can't read your mind — it can only pattern-match against whatever you give it. Give it nothing and it hands back the generic assistant register: smooth, agreeable, and detectably not you. Give it a small, well-organized library of things you actually wrote, and it has something real to calibrate against. That library is your **voice corpus**. Think of it like a musician's tuning fork: before you play, you sound a note you *know* is right, and everything else tunes to it. This guide shows you how to build that corpus, keep it honest, and turn it into a system that gets sharper over time instead of just bigger.
+An AI assistant drafting "in your voice" has exactly one source of truth: whatever you've shown it. Show it nothing and you get the generic assistant register back: smooth and agreeable, and not you. A **voice corpus** fixes that. It's a small, organized library of things you actually wrote, kept where your tools can read it, so every draft calibrates against your real register instead of a statistical average of everyone's. Building one takes an afternoon. Keeping it honest takes a system, and the system is what this guide teaches: three layers, one flywheel, one firewall.
 
 ## The Short Version
 

--- a/docs/guides/voice-corpus-architecture.md
+++ b/docs/guides/voice-corpus-architecture.md
@@ -1,0 +1,88 @@
+---
+title: "Building a Voice Corpus"
+description: "A three-layer system for capturing your real writing voice so an AI assistant helps you sound like yourself instead of like everyone else"
+---
+
+# Building a Voice Corpus
+
+When you ask an AI to draft something in your voice, it can't read your mind — it can only pattern-match against whatever you give it. Give it nothing and it hands back the generic assistant register: smooth, agreeable, and detectably not you. Give it a small, well-organized library of things you actually wrote, and it has something real to calibrate against. That library is your **voice corpus**. Think of it like a musician's tuning fork: before you play, you sound a note you *know* is right, and everything else tunes to it. This guide shows you how to build that corpus, keep it honest, and turn it into a system that gets sharper over time instead of just bigger.
+
+## The Short Version
+
+- A voice corpus is a curated set of your **own real writing**, organized into three layers by how much you trust each one to define your voice.
+- **Layer 1 (Gold)** is your unedited writing — the highest-weight calibration signal. **Layer 2 (Identity & Rules)** distills that into explicit voice rules. **Layer 3 (Background Facts)** grounds claims but never sets tone.
+- The corpus improves through a flywheel: **Ground → Review → Capture → Distill.** The loop only closes when you actually capture new genuine writing, ideally the same day you produce it.
+- One firewall keeps the whole thing from rotting: **never calibrate your voice on AI-drafted output.** That launders the assistant register back in and slowly erases you.
+
+## How It Actually Works
+
+### Three layers, ranked by trust
+
+Not every document you've written deserves equal weight when an assistant is learning your voice. A raw voice memo you dictated is pure signal. A résumé bullet is a fact, not a voice sample. Sorting your material into three layers keeps the strong signal from getting diluted by the weak.
+
+**Layer 1 — Gold: your pure, unedited voice.** These are the pieces you wrote (or dictated) yourself, with at most a grammar cleanup — a farewell note, a long unfiltered voice memo, a letter you rewrote entirely in your own words. This layer carries the highest calibration weight. When someone asks "what does it sound like when *you* write?", the answer lives here. Protect it fiercely: never let an assistant rewrite Gold. If it needs a fix, fix the grammar and nothing else.
+
+**Layer 2 — Identity & Rules: the distilled voice.** These are the explicit, written-down rules you've extracted *from* Layer 1 — "uses parentheticals to undercut its own confidence," "ends flat instead of with a pitch," "prefers a concrete vignette to an adjective." Layer 2 is what you skim before writing when you don't have time to re-read all of Gold. It's downstream of Gold, and it's only as good as the Gold it was distilled from.
+
+**Layer 3 — Background Facts: the ground truth.** Dates, job titles, project names, metrics, assessment results. This layer answers "is that claim true?" — never "does that sound like me?" Do not calibrate tone on it. A CV's phrasing is optimized for scanning, not for voice; treat it as a fact-checker, not a style guide.
+
+### The flywheel
+
+A voice corpus isn't a document you write once. It's a loop with four stages, and the whole thing only works if all four keep turning.
+
+```mermaid
+flowchart LR
+    A[GROUND<br/>every draft is grounded<br/>in the corpus, not invented] --> B[REVIEW<br/>check output against<br/>Layer 1 Gold before it ships]
+    B --> C[CAPTURE<br/>save every new genuine<br/>artifact — same day]
+    C --> D[DISTILL<br/>periodically re-distill Gold<br/>into sharper Layer 2 rules]
+    D --> A
+```
+
+1. **Ground.** Every letter, answer, or post you generate starts from the corpus — the real Layer 1 samples and the Layer 2 rules — not from the assistant's imagination. Grounding is what keeps a draft in your register from the first line.
+2. **Review.** Before anything is "ready," a second pass checks the output against Layer 1 Gold. Does it sound smoother or more eager than your real samples? If so, it's not done.
+3. **Capture.** Every time you produce something genuine — a dictation, a letter you wrote yourself, an answer you rewrote in your own words — you add it to Layer 1 **the same day.** This is the stage everyone skips, and skipping it is the failure mode: a great new sample that never gets captured is invisible to the next draft.
+4. **Distill.** Periodically — say, every few new Gold artifacts — re-read Layer 1 and sharpen the Layer 2 rules. This is what makes the system get *better* at your voice over time, not just accumulate more files.
+
+The loop is closed only when Capture actually happens. Outputs become inputs — but only the genuine ones.
+
+### The firewall: outputs are not inputs
+
+Here's the single most important rule, and it's easy to get wrong. **Never calibrate your voice on AI-drafted output — not even output you lightly edited.**
+
+The reasoning is a feedback loop. An assistant drafts something in a slightly flattened version of your voice. You tidy it and send it. If you then fold that piece back into Layer 1 as a "sample of how I write," you've just taught the system that the flattened version is the target. Do that a few times and each new draft calibrates against the last flattened one, and your real edges — the jaggedness, the deflating closers, the odd specific details — quietly wash out. The corpus gets blander every cycle, and you can't feel it happening because each step is small.
+
+So the firewall is absolute: an artifact enters Layer 1 only if *you* wrote it, dictated it, or rewrote it substantially in your own words. An assistant-drafted letter you approved is an **output** — something to be judged against Gold, never a sample to calibrate on. When you're unsure which side of the line a piece falls on, keep it out.
+
+### Capturing without friction
+
+The corpus lives or dies on Capture, so make it cheap. At the end of any session where you wrote something real, ask: did I just produce a genuine artifact? If yes, save it, tag how much editing it got ("grammar-only" vs. "fully mine"), and drop it in the right layer. Voice memos are gold precisely because dictation bypasses the editing brain — you say things in your own rhythm. Store the corpus somewhere durable and portable (plain text under version control travels better than anything locked in an app), so it's available on every machine and to every assistant you point at it.
+
+The starter template at [config/voice-corpus.example.md](../../config/voice-corpus.example.md) gives you empty slots for all three layers plus a capture checklist. Copy it, fill it in, and point your tools at it.
+
+## Examples
+
+**A Gold sample.** You dictate a five-minute voice memo about a project you owned end to end — what worked, what you'd do differently, the metric that turned out to be lying. It's rambling, self-correcting, honest about the parts that went badly. That's Layer 1: unpolished, high-signal, the truest picture of your voice. Save it same-day, grammar-only.
+
+**A Layer 2 rule distilled from it.** Reading three memos like that, you notice you always ship a win with its cost attached in the same breath — "we hit the number, and honestly it barely mattered." You write that down as a rule: *every win carries its shadow in the same paragraph.* Now an assistant reviewing a draft can flag a win that arrives with no cost attached.
+
+**A firewall catch.** An assistant drafts a cover letter that reads well. You send a lightly edited version. Tempting as it is to save that letter as a "voice sample," you don't — it's an output. Instead you save the two sentences you *rewrote from scratch*, because those are genuinely yours.
+
+## FAQ
+
+**Q: How much do I need before this is useful?**
+Even three or four genuine Gold samples beat zero. The corpus compounds — start small and capture consistently rather than waiting for a perfect library.
+
+**Q: Can I include writing an editor heavily reworked?**
+Only if the words are still substantially yours. Heavy external editing pulls a piece toward a house style, which is a different voice than yours. When in doubt, keep it in Background as a fact source, not in Gold.
+
+**Q: Why keep facts separate from voice?**
+Because a CV bullet and a voice memo answer different questions. One tells you *what's true*; the other tells you *how you sound*. Mixing them means an assistant might imitate résumé phrasing — terse, keyword-stuffed — when you wanted your real register.
+
+**Q: How often should I distill?**
+Whenever a few new Gold artifacts have piled up, or whenever you notice the Layer 2 rules no longer capture something you clearly do. Distilling too often is wasted effort; never distilling means the rules drift out of date.
+
+## Further Reading
+
+- [Writing Without the AI Tells](anti-slop-writing.md) — the register gate at the top of the editing protocol depends on having a corpus to compare against
+- [Writing Cover Letters That Don't Read as AI](cover-letter-writing.md) — where the corpus does its most valuable work
+- [config/voice-corpus.example.md](../../config/voice-corpus.example.md) — the starter template for all three layers

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ User-facing explanations and how-tos.
 - [How CI/CD Works](guides/how-cicd-works.md) — The automated pipeline from code push to deployment
 - [How Observability Works](guides/how-observability-works.md) — Monitoring AI calls, costs, and debugging
 - [How Token Optimization Works](guides/how-token-optimization-works.md) — Keeping AI costs under $5/month with 8 stacked techniques
+- [Writing Without the AI Tells](guides/anti-slop-writing.md) — The ranked checklist and editing protocol for prose that doesn't read as AI
+- [Building a Voice Corpus](guides/voice-corpus-architecture.md) — A three-layer system for capturing your real writing voice
+- [Writing Cover Letters That Don't Read as AI](guides/cover-letter-writing.md) — The 14-category taxonomy, pre-send checklist, and why CVs are different
+- [Optimizing a LinkedIn Profile](guides/linkedin-profile-optimization.md) — Headline, About arc, keyword seeding, and skills for recruiter search
 - [Writing Guide](guides/WRITING-GUIDE.md) — How to write documentation for this project
 
 ## Reference


### PR DESCRIPTION
## What

Distills the battle-tested writing system from a private fork into four public, PII-free guides plus supporting artifacts:

- `docs/guides/anti-slop-writing.md` — 17 ranked AI-tells with mechanical fixes, 10 editing passes, an 11-step editing protocol
- `docs/guides/voice-corpus-architecture.md` — three-layer voice-calibration architecture (GOLD corpus / identity rules / background facts) with the Ground→Review→Capture→Distill flywheel
- `docs/guides/cover-letter-writing.md` — 14-category anti-AI-prose taxonomy (ACL-sourced), 12-item pre-send checklist, CV-vs-cover-letter divergence
- `docs/guides/linkedin-profile-optimization.md` — headline formula, About arc (thesis → proof → stance), recruiter-keyword seeding, skills ordering
- `config/voice-corpus.example.md` — empty-slot template (the filled `config/voice-corpus.md` is gitignored)
- `.claude/workflows/anti-slop-frontier.js` — weekly 5-angle research workflow to keep the guardrails current (4 generic angles + configurable voice angle)

## Why

Kestrel generates documents (cover letters, outreach, profiles) but shipped no guidance on making them read human. These guides encode the method: what AI tells look like, how to edit them out, and how to calibrate generation to a user's own voice without laundering AI tone back in.

## PII / review trail

- Distilled, never copied: all personal examples replaced with invented ones; person-specific rules dropped
- Three automated PII gates (regex over names, employers, target companies, ticket refs, local paths) — all clean
- Manual sweep for de-anonymizable career details — clean
- Independent adversarial pre-publication review: 1 blocker found (missing `.gitignore` entry for the filled voice corpus) and fixed in 700e9fc, plus self-consistency fixes (the guides now pass their own tell checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxThvPPj8YHPjy4HMM8RnT