### PR TITLE
feat(G-1282): port tiered application model + SmartRecruiters/Personio scrapers (PII-stripped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: reviewdog/action-actionlint@v1
+      # Run actionlint directly (pinned official image) instead of the reviewdog
+      # wrapper. reviewdog fetches the PR diff via the GitHub API to scope
+      # findings; with this repo's read-only token it can 403 ("Resource not
+      # accessible by integration") on large PRs, failing the job for reasons
+      # unrelated to workflow lint. A direct run needs no diff, token, or extra
+      # permissions and fails only on real lint errors.
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.7
         with:
-          reporter: github-pr-check
+          args: -color
+        env:
+          # Only fail on shellcheck error/warning, not "style"/"info" nits
+          # (e.g. SC2126/SC2129). Keeps real enforcement without blocking on style.
+          SHELLCHECK_OPTS: --severity=warning
 
   frontend:
     name: Frontend (React)

--- a/tools/job_scorer.py
+++ b/tools/job_scorer.py
@@ -677,5 +677,129 @@ def is_api_submittable(job: dict) -> bool:
     return _is_ats_host(job.get("url"))
 
 
+# --------------------------------------------------------------------------
+# Dream-tier floor (never bury a top target on a sparse JD)
+# --------------------------------------------------------------------------
+
+# Top-tier targets that must never vanish from the digest because an empty/sparse
+# JD made the AI under-score them. These are FICTIONAL example slugs -- replace the
+# tuple (or load it from your own config) with the companies you never want buried.
+DREAM_TIER_COMPANIES: tuple[str, ...] = (
+    "zephyrx",
+    "aspirational labs",
+    "fictional ai systems",
+    "sample target corp",
+)
+DREAM_TIER_FLOOR = 8
+
+# Word-boundary match (not substring): short slugs are not distinctive enough for a
+# substring match (it would floor "Nonlinear ..." or "Linear Technology"). Floored
+# roles are review-flagged anyway, so a rare whole-word collision surfaces for human
+# review rather than being silently applied.
+_DREAM_TIER_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(d) for d in DREAM_TIER_COMPANIES) + r")\b",
+    re.IGNORECASE,
+) if DREAM_TIER_COMPANIES else None
+
+
+def is_dream_tier(company: str | None) -> bool:
+    """True if ``company`` matches a configured dream-tier target (word-boundary)."""
+    if _DREAM_TIER_RE is None:
+        return False
+    return bool(_DREAM_TIER_RE.search(company or ""))
+
+
+def apply_floors(jobs: list[dict]) -> list[dict]:
+    """Raise dream-tier company roles to a score floor so they are never buried.
+
+    A dream-tier role that the AI under-scored is floored and flagged for review.
+    Geo is respected: a geo-ineligible dream role is NOT floored into the digest but
+    is force-flagged for review so it is never lost. A role a hard-cap deliberately
+    buried (wrong function/sales/HR) is likewise not resurrected. Pre-filtered /
+    blocked rows (score<=0) are never resurrected.
+    """
+    for job in jobs:
+        if job.get("fit_score", 0) <= 0:
+            continue  # pre-filtered / blocked -- do not resurrect
+        if not is_dream_tier(job.get("company")):
+            continue
+
+        geo_foreign = job.get("geo_class") == "foreign"
+        # A hard-cap (sales/HR/wrong-function) deliberately buried this role -- the
+        # floor must NOT resurrect it. geo_ineligible caps are handled by the
+        # geo_foreign branch below, not treated as a "wrong function" cap.
+        wrong_function_cap = (
+            bool(job.get("cap_applied")) and job.get("cap_reason") != "geo_ineligible"
+        )
+
+        if geo_foreign or wrong_function_cap:
+            # Don't floor into the digest: geo-ineligible or deliberately buried by
+            # function. Keep it visible in the review queue only -- never lost, never
+            # promoted to a top gem.
+            reason = "geo-ineligible" if geo_foreign else job.get("cap_reason")
+            job["review_flag"] = True
+            job.setdefault(
+                "review_reason",
+                f"Dream-tier company not auto-floored ({reason}, "
+                f"{job.get('location', '')}) -- review",
+            )
+            continue
+
+        if job.get("fit_score", 0) < DREAM_TIER_FLOOR:
+            orig = job.get("fit_score", 0)
+            job["fit_score"] = DREAM_TIER_FLOOR
+            job["floor_applied"] = True
+            job["review_flag"] = True
+            job["review_reason"] = (
+                f"Dream-tier company floored {orig}->{DREAM_TIER_FLOOR}; "
+                "verify the role actually fits"
+            )
+            job["fit_reasoning"] = (
+                f"Floored from {orig} to {DREAM_TIER_FLOOR} (dream-tier company): "
+                + (job.get("fit_reasoning") or "")
+            )
+    return jobs
+
+
+# --------------------------------------------------------------------------
+# Tier classifier — routes each scored gem to its operating-model lane
+# --------------------------------------------------------------------------
+
+def classify_tier(job: dict) -> str | None:
+    """Assign the tiered operating-model lane for a scored job.
+
+    - T1 (dream / high-touch): dream-tier company, OR fit_score >= 8, OR a warm
+      intro. These are written by hand.
+    - T2 (strong / rapid-fire kit): fit_score 6-7.
+    - T3 (volume / auto-fill + 1-click confirm): fit_score >= 5, geo-eligible, and
+      on an auto-fillable ATS. The actual no-open-Q check happens in the T3 lane
+      before anything is prefilled.
+    - None: below the bar (or pre-filtered/blocked) -> not routed to any lane.
+
+    Geo-foreign roles are typically score-capped low upstream, so they fall out
+    naturally here (except dream companies, which stay T1 and are review-flagged by
+    ``apply_floors``).
+    """
+    score = job.get("fit_score", 0) or 0
+    if score <= 0:
+        return None
+    if is_dream_tier(job.get("company")) or score >= 8 or job.get("warm_intro"):
+        return "T1"
+    if score >= 6:
+        return "T2"
+    if score >= 5 and job.get("geo_class") != "foreign" and is_api_submittable(job):
+        return "T3"
+    return None
+
+
+def assign_tiers(jobs: list[dict]) -> list[dict]:
+    """Tag each job with its tier + auto_fillable flag (mutates in place)."""
+    for job in jobs:
+        tier = classify_tier(job)
+        job["tier"] = tier
+        job["auto_fillable"] = tier == "T3"
+    return jobs
+
+
 if __name__ == "__main__":
     main()

--- a/tools/kit_builder.py
+++ b/tools/kit_builder.py
@@ -1,0 +1,209 @@
+"""Rapid-fire T2 application-kit generator.
+
+Codifies a manual per-batch apply flow (manifest -> per-app numbered folders ->
+tabs) into a repeatable build. Given a list of scored+tiered job dicts, emits:
+
+    <out>/_batch-<date>-t<tier>/
+        INDEX.md                      # numbered table: company/role/loc/tier/archetype/open-Q/apply
+        apps/NN-<slug>/
+            NN-SUBMIT.txt             # metadata + apply link + form cheats + CV/cover refs
+            NN-cover-<archetype>.pdf  # copied if a source archetype cover exists
+            NN-<cv>.pdf               # copied if a source CV exists
+
+Numbering uses the NN- prefix convention so a number alone identifies the item.
+The kit STRUCTURE is the codified value; CV/cover PDFs are copied in when source
+files are found, otherwise referenced in SUBMIT.txt with a "(missing)" note.
+
+Pure file I/O + deterministic mapping -> unit-testable with a tmp dir; no network.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+# Title -> cover/CV archetype. First match wins; order matters (specific first).
+_ARCHETYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("devrel", ("developer advocate", "devrel", "developer relations", "evangelist", "community")),
+    (
+        "solutions-fde",
+        (
+            "solutions",
+            "forward deployed",
+            "fde",
+            "sales engineer",
+            "solutions architect",
+            "customer engineer",
+        ),
+    ),
+    (
+        "product-eng",
+        (
+            "product engineer",
+            "founding engineer",
+            "ai engineer",
+            "full stack",
+            "fullstack",
+            "software engineer",
+            "swe",
+        ),
+    ),
+    (
+        "pm",
+        (
+            "product manager",
+            "program manager",
+            "tpm",
+            "product lead",
+            "group pm",
+            "bizops",
+            "operations",
+            "strategy",
+        ),
+    ),
+)
+_DEFAULT_ARCHETYPE = "pm"
+
+# Neutral placeholder cheat-sheet. Callers pass their own ``form_cheats`` string with
+# real values; the default carries no personal data (work-auth/salary/pronouns are
+# left as <configure> tokens so nothing personal ships in the module).
+_FORM_CHEATS_DEFAULT = (
+    "work-auth = <configure> · salary = <configure> · "
+    "remote = <configure> · pronouns = <configure> · notice = <configure>"
+)
+
+
+def archetype_for(title: str | None) -> str:
+    t = (title or "").lower()
+    for archetype, kws in _ARCHETYPE_RULES:
+        if any(k in t for k in kws):
+            return archetype
+    return _DEFAULT_ARCHETYPE
+
+
+def _slug(company: str | None) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (company or "company").lower()).strip("-")
+    return s or "company"
+
+
+def _submit_txt(
+    n: int,
+    job: dict,
+    archetype: str,
+    cv_ref: str,
+    cover_ref: str,
+    open_q: dict | None,
+    form_cheats: str,
+) -> str:
+    score = job.get("fit_score", "?")
+    tier = job.get("tier", "?")
+    if open_q is None or not open_q.get("checked"):
+        oq = "unknown (verify on the form)"
+    elif open_q.get("has_open_questions"):
+        oq = "YES -- write the hook: " + "; ".join(open_q.get("essay_labels", []))
+    else:
+        oq = "none (standard fields only)"
+    return (
+        f"#{n:02d}  {job.get('company', '?')} — {job.get('title', '?')}\n"
+        f"Location: {job.get('location', '?')}\n"
+        f"Geo: {job.get('geo_class', '?')}  Tier: {tier}  Score: {score}/10\n"
+        f"Open questions: {oq}\n\n"
+        f"APPLY: {job.get('url', '')}\n\n"
+        f"CV to upload:  {cv_ref}\n"
+        f"Cover ({archetype}):  {cover_ref}\n\n"
+        f"Form cheats: {form_cheats}\n"
+    )
+
+
+def build_kit(
+    jobs: list[dict],
+    out_root: Path | str,
+    *,
+    batch_date: str,
+    tier: str = "T2",
+    cover_dir: Path | str | None = None,
+    cv_path: Path | str | None = None,
+    open_q_results: dict | None = None,
+    form_cheats: str = _FORM_CHEATS_DEFAULT,
+) -> dict:
+    """Generate the kit folder tree. Returns a summary dict.
+
+    ``open_q_results`` maps a job url -> probe dict (so the caller controls whether
+    network probing happens; tests pass canned results or None).
+    ``cover_dir`` holds archetype cover PDFs named ``_<archetype>.pdf``; ``cv_path``
+    is the default CV PDF. Either may be None/missing -> referenced, not copied.
+    ``form_cheats`` is a caller-supplied cheat-sheet string; it defaults to a neutral
+    placeholder that contains no personal data.
+    """
+    out_root = Path(out_root)
+    kit_dir = out_root / f"_batch-{batch_date}-{tier.lower()}"
+    apps_dir = kit_dir / "apps"
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    cover_dir = Path(cover_dir) if cover_dir else None
+    cv_path = Path(cv_path) if cv_path else None
+    open_q_results = open_q_results or {}
+
+    index_rows: list[str] = []
+    for i, job in enumerate(jobs, start=1):
+        archetype = archetype_for(job.get("title"))
+        folder = apps_dir / f"{i:02d}-{_slug(job.get('company'))}"
+        folder.mkdir(parents=True, exist_ok=True)
+
+        # Cover: copy the archetype cover if present, else reference by name.
+        cover_ref = f"{i:02d}-cover-{archetype}.pdf"
+        src_cover = cover_dir / f"_{archetype}.pdf" if cover_dir else None
+        if src_cover and src_cover.exists():
+            shutil.copy2(src_cover, folder / cover_ref)
+        else:
+            cover_ref += "  (missing -- generate/attach archetype cover)"
+
+        # CV: copy the default CV if present, else reference.
+        cv_ref = f"{i:02d}-CV.pdf"
+        if cv_path and cv_path.exists():
+            shutil.copy2(cv_path, folder / cv_ref)
+        else:
+            cv_ref += "  (missing -- attach the right CV variant)"
+
+        oq = open_q_results.get(job.get("url"))
+        (folder / f"{i:02d}-SUBMIT.txt").write_text(
+            _submit_txt(i, job, archetype, cv_ref, cover_ref, oq, form_cheats),
+            encoding="utf-8",
+        )
+
+        oq_cell = (
+            "?"
+            if (oq is None or not oq.get("checked"))
+            else ("essay" if oq.get("has_open_questions") else "none")
+        )
+        url = job.get("url", "") or ""
+        index_rows.append(
+            f"| {i:02d} | {job.get('company', '?')} | {job.get('title', '?')} | "
+            f"{job.get('location', '?')} | {job.get('tier', '?')} | {archetype} | "
+            f"{oq_cell} | {f'[apply]({url})' if url else ''} |"
+        )
+
+    index = [
+        f"# Tier-{tier} rapid-fire kit — {batch_date}",
+        "",
+        f"**{len(jobs)} roles** · geo-filtered + deduped vs DB. "
+        f"Fire ~2 min each: open APPLY, upload CV, fold the hook into the archetype "
+        f"cover, submit.",
+        "",
+        "| # | Company | Role | Location | Tier | Archetype | OpenQ | Apply |",
+        "|---|---------|------|----------|------|-----------|-------|-------|",
+        *index_rows,
+        "",
+        "OpenQ: none = standard fields only (fast); essay = write a hook first; "
+        "? = verify on the form.",
+    ]
+    (kit_dir / "INDEX.md").write_text("\n".join(index), encoding="utf-8")
+
+    return {
+        "kit_dir": str(kit_dir),
+        "count": len(jobs),
+        "tier": tier,
+        "with_essays": sum(
+            1 for j in jobs if (open_q_results.get(j.get("url")) or {}).get("has_open_questions")
+        ),
+    }

--- a/tools/normalize.py
+++ b/tools/normalize.py
@@ -5,15 +5,15 @@ Job-discovery dedup used to compare raw ``(company, title)`` strings exactly,
 so trivial drift ("Hugging Face" vs the Greenhouse slug-derived "Huggingface",
 "Acme GmbH" vs "Acme", "Senior PM" vs "Senior PM (m/f/d)") slipped through and
 the same roles re-surfaced daily. This module centralizes normalization so the
-daily-pipeline tracking dedup (and any future matcher) can agree on what "the
-same job" means. (Intra-scrape dedup in scrape_resilient still keys on the raw
-title/company pair — migrating it is a follow-up.)
+scraper, dedup, and any future matcher all agree on what "the same job" means.
 
 Deliberately conservative: normalization is deterministic and only collapses
-known noise (legal suffixes, punctuation, case, location/gender tags). The
-optional :func:`fuzzy_ratio` helper uses the stdlib (no extra dependency) and
-is intended for high-threshold company matching, never for silently merging
-distinct roles.
+known noise (legal suffixes, punctuation, case, location/gender tags). Parenthetical
+SPECIALIZATIONS are preserved -- "PM (Growth)" and "PM (Platform)" are distinct roles
+and must not collapse to "pm" -- while noise parentheticals (gender/work-time tags,
+recognized locations) are dropped. The optional :func:`fuzzy_ratio` helper uses the
+stdlib (no extra dependency) and is intended for high-threshold company matching,
+never for silently merging distinct roles.
 """
 
 from __future__ import annotations
@@ -60,14 +60,86 @@ _COMPANY_SUFFIXES = {
     "the",
 }
 
-# Noise commonly appended to scraped job titles.
+# Bare (non-parenthetical) noise appended to scraped job titles. Parentheticals are
+# handled separately by the paren filter below so a specialization inside parens is
+# preserved -- do NOT add a blanket ``\(.*?\)`` strip here.
 _TITLE_NOISE = re.compile(
-    r"\(.*?\)"  # parenthetical: (m/f/d), (Remote), (Berlin)
-    r"|\bm/?f/?d\b|\bf/?m/?d\b"  # gender tags without parens
+    r"\bm/?f/?d\b|\bf/?m/?d\b|\bm/?w/?d\b|\bw/?m/?d\b"  # gender tags without parens
     r"|\bremote\b|\bhybrid\b|\bonsite\b|\bon-site\b"
     r"|\bfull[- ]?time\b|\bpart[- ]?time\b",
     re.IGNORECASE,
 )
+
+# Parentheticals are NOT blindly stripped: "PM (Growth)" and "PM (Platform)" are
+# DISTINCT roles and must not collapse to "pm". A parenthetical is dropped only when
+# its content is pure noise -- gender/work-time tags or a recognized location.
+# Anything else (a specialization) is preserved.
+_PAREN_RE = re.compile(r"\(([^)]*)\)")
+_PAREN_NOISE_WORDS = {
+    "m",
+    "f",
+    "d",
+    "w",
+    "x",
+    "gn",
+    "g",
+    "n",
+    "mfd",
+    "fmd",
+    "mwd",
+    "wmd",
+    "dfm",
+    "divers",
+    "gender",
+    "genders",
+    "all",
+    "any",
+    "remote",
+    "hybrid",
+    "onsite",
+    "on",
+    "site",
+    "fulltime",
+    "parttime",
+    "full",
+    "part",
+    "time",
+    "permanent",
+    "contract",
+    "temporary",
+    "freelance",
+}
+
+
+def _segment_is_noise(segment: str) -> bool:
+    """True if a single comma-segment of a parenthetical is pure noise.
+
+    A segment is noise when every token is a known gender/work-time word, or when the
+    whole segment is a recognized location. Location detection reuses the geo gate's
+    ``_classify_token`` (renamed verdict token: "home"/"eu_remote"/"foreign") so we do
+    not duplicate a city list here.
+    """
+    from batch_probe import _classify_token
+
+    toks = [t for t in re.split(r"[\s/&.+-]+", segment.lower().strip()) if t]
+    if not toks:
+        return True
+    if all(t in _PAREN_NOISE_WORDS for t in toks):
+        return True
+    # A whole segment that is a recognized location ("Berlin", "New York", "EU").
+    return _classify_token(segment) in ("home", "eu_remote", "foreign")
+
+
+def _filter_paren(content: str) -> str:
+    """Drop noise comma-segments from a parenthetical, KEEP specializations.
+
+    "Remote, Growth" -> "Growth" (so "Eng (Remote, Growth)" stays distinct from
+    "Eng (Remote, Platform)"); "m/f/d" -> ""; "Berlin" -> ""; "Growth" -> "Growth".
+    Splitting on comma first means multi-word locations ("New York") are classified
+    as a whole segment rather than per-token.
+    """
+    kept = [seg.strip() for seg in content.split(",") if seg.strip() and not _segment_is_noise(seg)]
+    return " ".join(kept)
 
 
 def _collapse(s: str) -> str:
@@ -100,10 +172,17 @@ def normalize_company(name: str | None) -> str:
 
 
 def normalize_title(title: str | None) -> str:
-    """Normalize a job title: strip location/gender/remote noise, punctuation, case."""
+    """Normalize a job title for dedup.
+
+    Strips noise parentheticals (gender/work-time tags, locations) and bare noise
+    words, but PRESERVES specialization parentheticals so "PM (Growth)" and
+    "PM (Platform)" stay distinct. Accents are ASCII-folded via ``_collapse``.
+    """
     if not title:
         return ""
-    cleaned = _TITLE_NOISE.sub(" ", title)
+    # Drop noise segments inside each parenthetical; keep specialization content.
+    cleaned = _PAREN_RE.sub(lambda m: f" {_filter_paren(m.group(1))} ", title)
+    cleaned = _TITLE_NOISE.sub(" ", cleaned)
     return _collapse(cleaned)
 
 

--- a/tools/open_question_probe.py
+++ b/tools/open_question_probe.py
@@ -1,0 +1,145 @@
+"""Detect free-text "open questions" on an ATS apply form.
+
+The tiered operating model routes a role to the T3 auto-fill lane only when it is
+"no-open-Q" -- i.e. the apply form asks nothing beyond standard fields the pipeline
+can populate (name/email/phone/CV/cover/LinkedIn/standard selects). A required free
+essay ("Why do you want to work here?") or a custom required textarea means a human
+must write something, so it stays in the T2 rapid-fire kit.
+
+This probe is AUTHORITATIVE for Greenhouse (the questions API exposes label +
+required + field types). For other ATSes it returns checked=False (unknown); the
+T3 browser-fill detects an unfilled required textarea live as the real backstop.
+"""
+
+from __future__ import annotations
+
+import httpx
+from batch_probe import parse_greenhouse_url
+
+# Standard fields the pipeline can auto-populate (substring match on the lowercased
+# question label). A required textarea whose label hits one of these is NOT an essay.
+_STANDARD_LABELS: tuple[str, ...] = (
+    "first name",
+    "last name",
+    "full name",
+    "name",
+    "email",
+    "phone",
+    "resume",
+    "cv",
+    "cover letter",
+    "linkedin",
+    "github",
+    "portfolio",
+    "website",
+    "location",
+    "city",
+    "country",
+    "address",
+    "pronoun",
+    "how did you hear",
+    "where did you hear",
+    "referr",
+    "salary",
+    "compensation",
+    "notice period",
+    "start date",
+    "availability",
+    "work authoriz",
+    "authorized to work",
+    "visa",
+    "sponsor",
+    "relocat",
+    # EEO / demographic selects (optional, not essays)
+    "gender",
+    "race",
+    "ethnicit",
+    "veteran",
+    "disab",
+    "hispanic",
+    "lgbt",
+)
+
+_FILLABLE_FIELD_TYPES: frozenset[str] = frozenset(
+    {"input_text", "input_file", "multi_value_single_select", "multi_value_multi_select", "boolean"}
+)
+
+# The ONLY free-text (textarea) questions that are standard, not essays. Everything
+# else with a required textarea is a human-writes-it essay. Matching textareas
+# specifically (rather than any label substring) avoids false negatives where an
+# essay prompt merely contains a standard word -- "Name a project you're proud of"
+# (has "name"), "your favorite website?" (has "website").
+_TEXTAREA_STANDARD_LABELS: tuple[str, ...] = (
+    "resume",
+    "cv",
+    "cover letter",
+    "how did you hear",
+    "where did you hear",
+    "referr",
+    "anything else",
+    "additional info",
+)
+
+
+def _is_essay_question(q: dict) -> bool:
+    """A required free-text question that is NOT a standard field => an essay."""
+    if not q.get("required"):
+        return False
+    label = (q.get("label") or "").lower()
+    field_types = {f.get("type") for f in q.get("fields", [])}
+    if "textarea" in field_types:
+        # A required free textarea is an essay unless it's one of the known-standard
+        # textareas (resume/cover/how-did-you-hear/...).
+        return not any(s in label for s in _TEXTAREA_STANDARD_LABELS)
+    # No textarea: an essay only if there's no structured field type we can fill
+    # (a standard input_text / select / file / boolean is fine).
+    return not (field_types & _FILLABLE_FIELD_TYPES)
+
+
+def probe_greenhouse(slug: str, job_id: str, client: httpx.Client | None = None) -> dict:
+    url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs/{job_id}?questions=true"
+    owns = client is None
+    client = client or httpx.Client(timeout=15, follow_redirects=True)
+    try:
+        r = client.get(url)
+        r.raise_for_status()
+        questions = r.json().get("questions", [])
+    except (httpx.HTTPError, ValueError) as exc:  # pragma: no cover - network
+        return {
+            "checked": False,
+            "has_open_questions": False,
+            "essay_labels": [],
+            "reason": f"greenhouse questions fetch failed: {exc}",
+        }
+    finally:
+        if owns:
+            client.close()
+    essays = [q.get("label", "?") for q in questions if _is_essay_question(q)]
+    return {
+        "checked": True,
+        "has_open_questions": bool(essays),
+        "essay_labels": essays,
+        "reason": (
+            f"{len(essays)} required free-text question(s)" if essays else "no open questions"
+        ),
+    }
+
+
+def probe_open_questions(url: str, source: str, client: httpx.Client | None = None) -> dict:
+    """Best-effort open-question probe for an apply URL.
+
+    Returns {checked, has_open_questions, essay_labels, reason}. checked=False means
+    we could not authoritatively determine it (caller decides; the T3 browser-fill
+    detects live required textareas as the backstop).
+    """
+    src = (source or "").lower().strip()
+    if src == "greenhouse" or "greenhouse.io" in (url or ""):
+        parsed = parse_greenhouse_url(url or "")
+        if parsed:
+            return probe_greenhouse(parsed[0], parsed[1], client=client)
+    return {
+        "checked": False,
+        "has_open_questions": False,
+        "essay_labels": [],
+        "reason": f"open-question probe not implemented for source={src!r}",
+    }

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -960,6 +960,186 @@ def scrape_remotely_de(
 
 
 # ---------------------------------------------------------------------------
+# SmartRecruiters public postings API (no auth, per-company)
+# https://api.smartrecruiters.com/v1/companies/{slug}/postings
+# ---------------------------------------------------------------------------
+
+SMARTRECRUITERS_API = "https://api.smartrecruiters.com/v1/companies/{slug}/postings"
+SMARTRECRUITERS_JOB_URL = "https://jobs.smartrecruiters.com/{slug}/{job_id}"
+
+# EXAMPLE company slugs only — replace with the SmartRecruiters account slugs you
+# want to track (the slug is the path segment on jobs.smartrecruiters.com/<slug>).
+SMARTRECRUITERS_COMPANIES: list[str] = ["example-company-slug"]
+
+# Relevance queries run server-side (q=) against big-corp boards. q= is fuzzy, so a
+# client-side title keyword_filter then trims the noise. This keeps a several-thousand
+# role board down to the handful of target-shaped roles instead of paging it all.
+_SR_QUERIES: tuple[str, ...] = (
+    "product manager",
+    "program manager",
+    "technical program manager",
+    "developer advocate",
+    "solutions architect",
+    "ai engineer",
+    "founding engineer",
+)
+
+
+def scrape_smartrecruiters(
+    companies: list[str] | None = None,
+    keyword_filter: list[str] | None = None,
+) -> list[ScrapedJob]:
+    """Scrape the SmartRecruiters public postings API for big-corp boards.
+
+    No auth. Runs a small set of relevance queries server-side, dedups by posting id,
+    and (when ``keyword_filter`` is given) keeps only matching titles -- big-corp
+    boards are huge, so unlike curated boards these DO get a title gate. Defaults to
+    an EXAMPLE company list; pass your own slugs.
+    """
+    jobs: list[ScrapedJob] = []
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    companies = companies or SMARTRECRUITERS_COMPANIES
+    kw_lower = [k.lower() for k in (keyword_filter or [])]
+
+    for slug in companies:
+        seen: set[str] = set()
+        for query in _SR_QUERIES:
+
+            def _fetch(s=slug, q=query):
+                with httpx.Client(
+                    timeout=20, headers={"User-Agent": _get_user_agent()}, follow_redirects=True
+                ) as client:
+                    r = client.get(
+                        SMARTRECRUITERS_API.format(slug=s),
+                        params={"q": q, "limit": 50},
+                    )
+                    r.raise_for_status()
+                    return r.json()
+
+            data = _retry_with_backoff(_fetch)
+            if not data:
+                continue
+
+            for p in data.get("content", []):
+                job_id = str(p.get("id", ""))
+                if not job_id or job_id in seen:
+                    continue
+                title = p.get("name", "")
+                if kw_lower and not any(k in title.lower() for k in kw_lower):
+                    continue
+                seen.add(job_id)
+
+                loc = p.get("location", {}) or {}
+                location = loc.get("fullLocation") or ", ".join(
+                    part for part in (loc.get("city"), loc.get("country")) if part
+                )
+                dept = (p.get("department", {}) or {}).get("label", "")
+
+                jobs.append(
+                    ScrapedJob(
+                        title=title,
+                        company=slug.replace("-", " ").title(),
+                        location=location,
+                        url=SMARTRECRUITERS_JOB_URL.format(slug=slug, job_id=job_id),
+                        source="smartrecruiters",
+                        description="",
+                        posted=p.get("releasedDate", ""),
+                        remote=bool(loc.get("remote")),
+                        tags=[dept] if dept else [],
+                        scraped_at=now,
+                    )
+                )
+        _random_delay()
+
+    logger.info(f"SmartRecruiters: {len(jobs)} jobs from {len(companies)} companies")
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# Personio Job Board XML feed (public, per-company, no auth)
+# https://{slug}.jobs.personio.de/xml
+# ---------------------------------------------------------------------------
+
+PERSONIO_XML = "https://{slug}.jobs.personio.de/xml"
+PERSONIO_JOB_URL = "https://{slug}.jobs.personio.de/job/{job_id}"
+
+# EXAMPLE company slugs only — replace with the Personio subdomain slugs you want to
+# track (the slug is the subdomain on <slug>.jobs.personio.de).
+PERSONIO_COMPANIES: list[str] = ["example-company-slug"]
+
+
+def scrape_personio(
+    companies: list[str] | None = None,
+    keyword_filter: list[str] | None = None,
+) -> list[ScrapedJob]:
+    """Scrape Personio public XML job feeds. No auth.
+
+    Personio boards are small (EU mid-market), so the full feed is fetched and
+    title-filtered client-side. Defaults to an EXAMPLE company list; pass your own.
+    """
+    import xml.etree.ElementTree as ET
+
+    jobs: list[ScrapedJob] = []
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    companies = companies or PERSONIO_COMPANIES
+    kw_lower = [k.lower() for k in (keyword_filter or [])]
+
+    for slug in companies:
+
+        def _fetch(s=slug):
+            with httpx.Client(
+                timeout=20, headers={"User-Agent": _get_user_agent()}, follow_redirects=True
+            ) as client:
+                r = client.get(PERSONIO_XML.format(slug=s))
+                r.raise_for_status()
+                return r.text
+
+        raw = _retry_with_backoff(_fetch)
+        if not raw:
+            continue
+        try:
+            root = ET.fromstring(raw)
+        except ET.ParseError as exc:
+            logger.warning("Personio: XML parse failed for '%s': %s", slug, exc)
+            continue
+
+        for pos in root.findall(".//position"):
+            title = (pos.findtext("name") or "").strip()
+            if not title:
+                continue
+            if kw_lower and not any(k in title.lower() for k in kw_lower):
+                continue
+            job_id = (pos.findtext("id") or "").strip()
+            primary = (pos.findtext("office") or "").strip()
+            offices = [primary] if primary else []
+            offices += [
+                o.text.strip()
+                for o in pos.findall("./additionalOffices/office")
+                if o.text and o.text.strip()
+            ]
+            dept = (pos.findtext("department") or "").strip()
+
+            jobs.append(
+                ScrapedJob(
+                    title=title,
+                    company=slug.replace("-", " ").title(),
+                    location=primary or (offices[0] if offices else ""),
+                    url=PERSONIO_JOB_URL.format(slug=slug, job_id=job_id),
+                    source="personio",
+                    description="",
+                    posted=(pos.findtext("createdAt") or ""),
+                    remote="remote" in primary.lower(),
+                    tags=[dept] if dept else [],
+                    scraped_at=now,
+                )
+            )
+        _random_delay()
+
+    logger.info(f"Personio: {len(jobs)} jobs from {len(companies)} companies")
+    return jobs
+
+
+# ---------------------------------------------------------------------------
 # Convenience: scrape all new sources at once
 # ---------------------------------------------------------------------------
 

--- a/tools/t3_lane.py
+++ b/tools/t3_lane.py
@@ -1,0 +1,188 @@
+"""T3 auto-fill + 1-click-confirm lane.
+
+The volume lane: **auto-FILL, human-CONFIRM**. For a role that clears every
+guardrail (geo / blocklist / salary-floor / dedup / no-open-Q / auto-fillable ATS),
+this lane opens the apply form and populates it up to -- but never past -- the submit
+button, then presents a queue. A human skims and clicks submit.
+
+HARD INVARIANT: this module NEVER submits. It reuses only the *fill* helpers from
+``auto_apply`` (``fill_ashby_browser`` / ``fill_lever_browser`` / ... ) and never
+calls ``confirm_and_submit_browser`` / ``submit_lever_api`` / ``submit_greenhouse_api``
+(the three code paths that actually POST). ``tools/tests/test_t3_lane.py`` enforces
+this by poisoning those three functions and asserting the prefill path never trips
+them.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+
+from blocklist import is_blocked
+from job_scorer import geo_eligibility, is_api_submittable
+from normalize import job_key
+from open_question_probe import probe_open_questions
+
+# Functions that ACTUALLY submit. The prefill path must never call these; listed
+# here so the invariant test can poison every one of them.
+FORBIDDEN_SUBMIT_FUNCS: tuple[str, ...] = (
+    "confirm_and_submit_browser",
+    "submit_lever_api",
+    "submit_greenhouse_api",
+)
+
+
+def _salary_below_floor(job: dict, floor: int) -> bool:
+    """True only if the role's salary is KNOWN and its top number is below floor.
+
+    Unknown/absent salary never blocks (most JDs omit it) -- we don't lose a gem
+    over a missing number; the blocklist already kills known lowballers.
+    """
+    text = f"{job.get('estimated_salary', '')} {job.get('salary', '')}".lower()
+    # ">= 40" filters out monthly figures / bonuses ("10k/month", "15k signing") that
+    # would otherwise look like a sub-floor annual salary. Real annual bands are 40k+;
+    # anything below the floor that matters is well above 40k.
+    nums = [int(n) for n in re.findall(r"(\d{2,3})\s*k", text) if int(n) >= 40]
+    if not nums:
+        for raw in re.findall(r"\d[\d,\.]{4,}", text):  # bare digit-only annual, e.g. 95000
+            with contextlib.suppress(ValueError):
+                nums.append(int(re.sub(r"[,\.]", "", raw)) // 1000)
+    return bool(nums) and max(nums) < (floor // 1000)
+
+
+def guardrail_check(
+    job: dict,
+    *,
+    taken_keys: set | None = None,
+    salary_floor: int = 0,
+    probe: bool = True,
+    client=None,
+) -> dict:
+    """Run every T3 guardrail. Returns {eligible, reason, checks}.
+
+    Guardrails (ALL must pass before a role is queued for prefill):
+      blocklist · geo (not foreign) · salary-floor · dedup-vs-DB · auto-fillable ATS
+      · no open questions (essay/custom required free-text).
+
+    ``salary_floor`` is caller-configurable and defaults to 0 (disabled) so no
+    personal compensation figure is baked into the module; pass your own floor to
+    reject known lowball roles.
+    """
+    taken_keys = taken_keys or set()
+    checks: dict = {}
+
+    blocked = is_blocked(job.get("company"))
+    checks["blocklist"] = "blocked" if blocked else "ok"
+
+    # Trust the pipeline's authoritative geo_class (set from per-job offices) when
+    # present; only recompute from the unreliable list-location string as a fallback.
+    # Recomputing would discard the offices override the gate exists for.
+    geo = job.get("geo_class") or geo_eligibility(
+        job.get("location"), job.get("offices"), bool(job.get("remote"))
+    )
+    checks["geo"] = geo
+
+    lowball = _salary_below_floor(job, salary_floor)
+    checks["salary"] = "below_floor" if lowball else "ok"
+
+    is_dup = job_key(job.get("company"), job.get("title")) in taken_keys
+    checks["dedup"] = "duplicate" if is_dup else "ok"
+
+    submittable = is_api_submittable(job)
+    checks["ats"] = "ok" if submittable else "not_auto_fillable"
+
+    open_q = {"checked": False, "has_open_questions": False, "reason": "not probed"}
+    if probe and submittable:
+        open_q = probe_open_questions(job.get("url", ""), job.get("source", ""), client=client)
+    checks["open_questions"] = (
+        "essay"
+        if open_q.get("has_open_questions")
+        else ("none" if open_q.get("checked") else "unknown")
+    )
+
+    # Decide. First failing guardrail wins the skip reason.
+    if blocked:
+        return {"eligible": False, "reason": f"blocklist: {blocked}", "checks": checks}
+    if geo == "foreign":
+        return {
+            "eligible": False,
+            "reason": f"geo-ineligible: {job.get('location')}",
+            "checks": checks,
+        }
+    if lowball:
+        return {"eligible": False, "reason": "salary below floor", "checks": checks}
+    if is_dup:
+        return {"eligible": False, "reason": "already in DB", "checks": checks}
+    if not submittable:
+        return {"eligible": False, "reason": "not on an auto-fillable ATS", "checks": checks}
+    if open_q.get("has_open_questions"):
+        labels = "; ".join(open_q.get("essay_labels", []))
+        return {
+            "eligible": False,
+            "reason": f"open questions ({labels}) -> T2 kit",
+            "checks": checks,
+        }
+
+    return {"eligible": True, "reason": "ready to prefill", "checks": checks}
+
+
+def build_queue(
+    jobs: list[dict],
+    *,
+    taken_keys: set | None = None,
+    salary_floor: int = 0,
+    probe: bool = True,
+    client=None,
+) -> dict:
+    """Partition jobs into a prefill queue + a skip list (with reasons)."""
+    queue: list[dict] = []
+    skipped: list[dict] = []
+    for job in jobs:
+        verdict = guardrail_check(
+            job, taken_keys=taken_keys, salary_floor=salary_floor, probe=probe, client=client
+        )
+        entry = {**job, "_guardrail": verdict}
+        (queue if verdict["eligible"] else skipped).append(entry)
+    return {
+        "queue": queue,
+        "skipped": skipped,
+        "summary": {"prefill_ready": len(queue), "skipped": len(skipped)},
+    }
+
+
+def prefill_application(
+    page, personal: dict, app: dict, *, cv: str = "", cover: str = "", dry_run: bool = True
+) -> dict:
+    """Fill ONE apply form up to the submit button. NEVER submits.
+
+    Reuses auto_apply's per-ATS fill helpers (which open the form + populate fields +
+    upload files) and then STOPS. There is no submit call anywhere on this path.
+    Returns {status, platform}. status="prefilled" means it's parked at the submit
+    button for the human to review and click.
+
+    ``cv`` / ``cover`` are repo-relative paths to the CV + cover PDF to upload. The
+    auto_apply fillers index ``app["cv"]`` / ``app["cover_letter"]`` directly, so we
+    inject them here (defaulting to "" so a missing file degrades to a skipped upload
+    rather than a KeyError).
+    """
+    import auto_apply
+
+    app = {
+        **app,
+        "cv": cv or app.get("cv", ""),
+        "cover_letter": cover or app.get("cover_letter", ""),
+    }
+    platform = auto_apply.detect_platform(app.get("url", ""))
+    filler = {
+        "ashby": auto_apply.fill_ashby_browser,
+        "lever": auto_apply.fill_lever_browser,
+        "greenhouse": auto_apply.fill_greenhouse_browser,
+    }.get(platform, auto_apply.fill_generic_browser)
+
+    try:
+        filler(page, personal, app)
+    except Exception as exc:  # pragma: no cover - live-browser variance
+        return {"status": "fill_error", "platform": platform, "error": str(exc)}
+
+    # Intentionally NO submit. Leave the form parked at the submit button for review.
+    return {"status": "prefilled", "platform": platform}

--- a/tools/tests/test_ats_scrapers.py
+++ b/tools/tests/test_ats_scrapers.py
@@ -1,0 +1,160 @@
+"""Tests for the SmartRecruiters + Personio ATS scrapers.
+
+Exercises the API/XML parse paths with canned fixtures (monkeypatched fetch); no
+live network. Adds tools/ to sys.path (tools-test convention). Fixture company
+names are de-personalized (fictional example slugs only).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scrape_new_sources as sns
+
+# --- SmartRecruiters postings API (JSON) ---
+
+_SR_DATA = {
+    "content": [
+        {
+            "id": "111",
+            "name": "Senior Product Manager",
+            "location": {"city": "Dublin", "country": "Ireland", "fullLocation": "Dublin, Ireland"},
+            "department": {"label": "Product"},
+            "releasedDate": "2026-06-01",
+        },
+        {
+            "id": "222",
+            "name": "Staff Software Engineer",
+            "location": {"city": "Remote", "country": "EU", "remote": True},
+            "department": {"label": "Engineering"},
+            "releasedDate": "2026-06-02",
+        },
+    ]
+}
+
+
+def _run_sr(keyword_filter=None):
+    # _retry_with_backoff is called once per (company, query); return the same canned
+    # payload each time, and rely on per-company dedup by posting id.
+    with (
+        patch.object(sns, "_retry_with_backoff", return_value=_SR_DATA),
+        patch.object(sns, "_random_delay"),
+    ):
+        return sns.scrape_smartrecruiters(companies=["example-co"], keyword_filter=keyword_filter)
+
+
+def test_smartrecruiters_parses_postings():
+    jobs = _run_sr()
+    titles = {j.title for j in jobs}
+    assert "Senior Product Manager" in titles
+    assert "Staff Software Engineer" in titles
+
+
+def test_smartrecruiters_dedups_by_id():
+    # Same payload returned for every query -> each posting appears exactly once.
+    jobs = _run_sr()
+    ids_in_url = [j.url for j in jobs]
+    assert len(ids_in_url) == len(set(ids_in_url))
+
+
+def test_smartrecruiters_normalizes_fields():
+    jobs = _run_sr()
+    pm = next(j for j in jobs if j.title == "Senior Product Manager")
+    assert pm.source == "smartrecruiters"
+    assert pm.location == "Dublin, Ireland"
+    assert pm.url == "https://jobs.smartrecruiters.com/example-co/111"
+    assert "Product" in pm.tags
+
+
+def test_smartrecruiters_keyword_gate():
+    jobs = _run_sr(keyword_filter=["product"])
+    titles = {j.title for j in jobs}
+    assert "Senior Product Manager" in titles
+    assert "Staff Software Engineer" not in titles
+
+
+def test_smartrecruiters_remote_flag():
+    jobs = _run_sr()
+    eng = next(j for j in jobs if j.title == "Staff Software Engineer")
+    assert eng.remote is True
+
+
+# --- Personio XML feed ---
+
+_PERSONIO_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+  <position>
+    <id>901</id>
+    <name>Product Manager</name>
+    <office>Dublin</office>
+    <department>Product</department>
+    <createdAt>2026-06-03</createdAt>
+    <additionalOffices>
+      <office>Cork</office>
+    </additionalOffices>
+  </position>
+  <position>
+    <id>902</id>
+    <name>Account Executive</name>
+    <office>Remote</office>
+    <department>Sales</department>
+    <createdAt>2026-06-04</createdAt>
+  </position>
+</workzag-jobs>
+"""
+
+
+def _run_personio(keyword_filter=None):
+    with (
+        patch.object(sns, "_retry_with_backoff", return_value=_PERSONIO_XML),
+        patch.object(sns, "_random_delay"),
+    ):
+        return sns.scrape_personio(companies=["example-co"], keyword_filter=keyword_filter)
+
+
+def test_personio_parses_positions():
+    jobs = _run_personio()
+    titles = {j.title for j in jobs}
+    assert "Product Manager" in titles
+    assert "Account Executive" in titles
+
+
+def test_personio_normalizes_fields():
+    jobs = _run_personio()
+    pm = next(j for j in jobs if j.title == "Product Manager")
+    assert pm.source == "personio"
+    assert pm.location == "Dublin"
+    assert pm.url == "https://example-co.jobs.personio.de/job/901"
+    assert "Product" in pm.tags
+
+
+def test_personio_keyword_gate():
+    jobs = _run_personio(keyword_filter=["product"])
+    titles = {j.title for j in jobs}
+    assert "Product Manager" in titles
+    assert "Account Executive" not in titles
+
+
+def test_personio_remote_flag():
+    jobs = _run_personio()
+    ae = next(j for j in jobs if j.title == "Account Executive")
+    assert ae.remote is True
+
+
+def test_personio_handles_bad_xml():
+    with (
+        patch.object(sns, "_retry_with_backoff", return_value="<not-valid-xml"),
+        patch.object(sns, "_random_delay"),
+    ):
+        jobs = sns.scrape_personio(companies=["example-co"])
+    assert jobs == []
+
+
+def test_scrapers_default_to_example_company_lists():
+    # The shipped defaults must be EXAMPLE-only placeholders, not real slugs.
+    assert sns.SMARTRECRUITERS_COMPANIES == ["example-company-slug"]
+    assert sns.PERSONIO_COMPANIES == ["example-company-slug"]

--- a/tools/tests/test_job_scorer_tiers.py
+++ b/tools/tests/test_job_scorer_tiers.py
@@ -1,0 +1,176 @@
+"""Tests for the tiered operating-model functions in tools/job_scorer.py.
+
+Covers is_dream_tier / apply_floors / classify_tier / assign_tiers using FICTIONAL
+example dream-tier entries. Adds tools/ to sys.path (tools-test convention).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from job_scorer import apply_floors as _apply_floors
+from job_scorer import (
+    assign_tiers,
+    classify_tier,
+    is_api_submittable,
+    is_dream_tier,
+)
+
+
+class TestDreamTierFloor:
+    def _job(self, company, score, location="Remote, EU", geo_class="eligible_remote"):
+        return {
+            "title": "Product Manager",
+            "company": company,
+            "fit_score": score,
+            "location": location,
+            "geo_class": geo_class,
+            "fit_reasoning": "x",
+        }
+
+    def test_is_dream_tier(self):
+        assert is_dream_tier("Zephyrx")
+        assert is_dream_tier("Aspirational Labs")
+        assert not is_dream_tier("Acme Corp")
+
+    def test_dream_tier_word_boundary_no_false_positive(self):
+        # word-boundary match (not substring): a longer word must NOT match.
+        assert is_dream_tier("Zephyrxian Systems") is False
+        assert is_dream_tier("Zephyrx") is True
+
+    def test_floors_underscored_dream_company(self):
+        jobs = _apply_floors([self._job("Zephyrx", 4)])
+        assert jobs[0]["fit_score"] == 8
+        assert jobs[0]["floor_applied"] is True
+        assert jobs[0]["review_flag"] is True
+
+    def test_does_not_lower_high_dream_score(self):
+        jobs = _apply_floors([self._job("Aspirational Labs", 9)])
+        assert jobs[0]["fit_score"] == 9
+        assert not jobs[0].get("floor_applied")
+
+    def test_does_not_resurrect_blocked(self):
+        # A blocked/pre-filtered dream-tier row (score 0) must stay 0.
+        jobs = _apply_floors([self._job("Zephyrx", 0)])
+        assert jobs[0]["fit_score"] == 0
+
+    def test_geo_foreign_dream_not_floored_into_digest(self):
+        jobs = _apply_floors([self._job("Zephyrx", 3, location="Paris", geo_class="foreign")])
+        assert jobs[0]["fit_score"] == 3
+        assert jobs[0]["review_flag"] is True
+
+    def test_non_dream_untouched(self):
+        jobs = _apply_floors([self._job("Acme Corp", 4)])
+        assert jobs[0]["fit_score"] == 4
+
+    def test_floor_does_not_resurrect_hard_capped(self):
+        # A wrong-function hard-capped dream role must NOT be floored (that would
+        # resurrect a sales/HR role at a dream company); it stays capped but visible.
+        jobs = _apply_floors(
+            [
+                {
+                    "title": "Account Executive",
+                    "company": "Zephyrx",
+                    "fit_score": 2,
+                    "location": "Remote, EU",
+                    "geo_class": "eligible_remote",
+                    "fit_reasoning": "x",
+                    "cap_applied": True,
+                    "cap_reason": "wrong_function",
+                }
+            ]
+        )
+        assert jobs[0]["fit_score"] == 2  # stays capped
+        assert not jobs[0].get("floor_applied")
+        assert jobs[0]["review_flag"] is True  # but visible for review
+
+
+class TestTierClassifier:
+    def _j(
+        self,
+        score,
+        company="Acme",
+        source="greenhouse",
+        url="https://boards.greenhouse.io/acme/jobs/1",
+        geo_class="eligible_remote",
+        **extra,
+    ):
+        d = {
+            "fit_score": score,
+            "company": company,
+            "source": source,
+            "url": url,
+            "geo_class": geo_class,
+        }
+        d.update(extra)
+        return d
+
+    def test_t1_dream_company_even_low_score(self):
+        assert classify_tier(self._j(4, company="Zephyrx")) == "T1"
+
+    def test_t1_high_score(self):
+        assert classify_tier(self._j(9, company="Random Co")) == "T1"
+
+    def test_t1_warm_intro(self):
+        assert classify_tier(self._j(5, warm_intro=True)) == "T1"
+
+    def test_t2_strong_fit(self):
+        assert classify_tier(self._j(6)) == "T2"
+        assert classify_tier(self._j(7)) == "T2"
+
+    def test_t3_acceptable_autofillable(self):
+        assert classify_tier(self._j(5, source="ashby")) == "T3"
+
+    def test_t3_requires_ats_source(self):
+        # score 5 on a non-ATS board is not auto-fillable -> no tier
+        assert classify_tier(self._j(5, source="ai-jobs", url="https://ai-jobs.net/x")) is None
+
+    def test_t3_requires_geo_eligible(self):
+        assert classify_tier(self._j(5, geo_class="foreign")) is None
+
+    def test_below_bar_no_tier(self):
+        assert classify_tier(self._j(4)) is None
+
+    def test_blocked_not_resurrected(self):
+        assert classify_tier(self._j(0, company="Zephyrx")) is None
+
+    def test_is_api_submittable(self):
+        assert (
+            is_api_submittable(
+                self._j(5, source="workable", url="https://apply.workable.com/acme/")
+            )
+            is True
+        )
+        assert is_api_submittable(self._j(5, source="indeed", url="https://indeed.com/x")) is False
+        assert is_api_submittable(self._j(5, source="greenhouse", url="")) is False
+
+    def test_spoofed_non_ats_host_rejected(self):
+        # Security: source says greenhouse but the URL is a foreign host -> NOT
+        # auto-fillable (would otherwise lure PII auto-fill onto an attacker page).
+        assert (
+            is_api_submittable(
+                self._j(5, source="greenhouse", url="https://attacker.example/apply")
+            )
+            is False
+        )
+        assert (
+            classify_tier(self._j(5, source="greenhouse", url="https://attacker.example/apply"))
+            is None
+        )
+        # non-https ATS host also rejected
+        assert (
+            is_api_submittable(
+                self._j(5, source="greenhouse", url="http://boards.greenhouse.io/x/jobs/1")
+            )
+            is False
+        )
+
+    def test_assign_tiers_sets_fields(self):
+        jobs = [self._j(9), self._j(5, source="ashby"), self._j(2)]
+        assign_tiers(jobs)
+        assert jobs[0]["tier"] == "T1" and jobs[0]["auto_fillable"] is False
+        assert jobs[1]["tier"] == "T3" and jobs[1]["auto_fillable"] is True
+        assert jobs[2]["tier"] is None and jobs[2]["auto_fillable"] is False

--- a/tools/tests/test_kit_builder.py
+++ b/tools/tests/test_kit_builder.py
@@ -1,0 +1,98 @@
+"""Tests for tools/kit_builder.py (T2 rapid-fire kit).
+
+Adds tools/ to sys.path so the module imports directly (tools-test convention).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import kit_builder as kb
+
+
+def test_archetype_mapping():
+    assert kb.archetype_for("Senior Developer Advocate") == "devrel"
+    assert kb.archetype_for("Forward Deployed Engineer") == "solutions-fde"
+    assert kb.archetype_for("Founding Product Engineer") == "product-eng"
+    assert kb.archetype_for("Senior Technical Program Manager") == "pm"
+    assert kb.archetype_for("Mystery Role") == "pm"  # default
+
+
+def _jobs():
+    return [
+        {
+            "company": "Acme",
+            "title": "Product Manager AI",
+            "location": "Berlin",
+            "url": "https://job-boards.greenhouse.io/acme/jobs/1",
+            "tier": "T2",
+            "geo_class": "home",
+            "fit_score": 7,
+            "source": "greenhouse",
+        },
+        {
+            "company": "Globex",
+            "title": "Developer Advocate EMEA",
+            "location": "Remote, EU",
+            "url": "https://job-boards.greenhouse.io/globex/jobs/2",
+            "tier": "T2",
+            "geo_class": "eligible_remote",
+            "fit_score": 6,
+            "source": "greenhouse",
+        },
+    ]
+
+
+def test_build_kit_structure(tmp_path):
+    res = kb.build_kit(_jobs(), tmp_path, batch_date="2026-06-30", tier="T2")
+    kit = Path(res["kit_dir"])
+    assert res["count"] == 2
+    assert (kit / "INDEX.md").exists()
+    assert (kit / "apps" / "01-acme" / "01-SUBMIT.txt").exists()
+    assert (kit / "apps" / "02-globex" / "02-SUBMIT.txt").exists()
+    submit = (kit / "apps" / "02-globex" / "02-SUBMIT.txt").read_text()
+    assert "Developer Advocate EMEA" in submit
+    assert "cover-devrel" in submit  # archetype mapped
+    assert "https://job-boards.greenhouse.io/globex/jobs/2" in submit
+    index = (kit / "INDEX.md").read_text()
+    assert "Acme" in index and "Globex" in index
+
+
+def test_build_kit_open_q_annotation(tmp_path):
+    jobs = _jobs()
+    oq = {
+        jobs[0]["url"]: {"checked": True, "has_open_questions": True, "essay_labels": ["Why us?"]},
+        jobs[1]["url"]: {"checked": True, "has_open_questions": False, "essay_labels": []},
+    }
+    res = kb.build_kit(jobs, tmp_path, batch_date="2026-06-30", open_q_results=oq)
+    assert res["with_essays"] == 1
+    s1 = (Path(res["kit_dir"]) / "apps" / "01-acme" / "01-SUBMIT.txt").read_text()
+    assert "Why us?" in s1
+
+
+def test_build_kit_default_form_cheats_has_no_personal_literal(tmp_path):
+    # The default form-cheats string must carry NO personal data (work-auth/salary/
+    # pronouns are <configure> placeholders); callers inject their own.
+    res = kb.build_kit([_jobs()[0]], tmp_path, batch_date="2026-06-30")
+    submit = (Path(res["kit_dir"]) / "apps" / "01-acme" / "01-SUBMIT.txt").read_text()
+    assert "<configure>" in submit
+    lowered = submit.lower()
+    for personal in ("blue card", "he/him", "120-160", "120000"):
+        assert personal not in lowered
+
+
+def test_build_kit_copies_pdfs_when_present(tmp_path):
+    cover_dir = tmp_path / "covers"
+    cover_dir.mkdir()
+    (cover_dir / "_pm.pdf").write_bytes(b"%PDF cover")
+    cv = tmp_path / "cv.pdf"
+    cv.write_bytes(b"%PDF cv")
+    res = kb.build_kit(
+        [_jobs()[0]], tmp_path / "out", batch_date="2026-06-30", cover_dir=cover_dir, cv_path=cv
+    )
+    folder = Path(res["kit_dir"]) / "apps" / "01-acme"
+    assert (folder / "01-cover-pm.pdf").exists()
+    assert (folder / "01-CV.pdf").exists()

--- a/tools/tests/test_normalize.py
+++ b/tools/tests/test_normalize.py
@@ -58,7 +58,10 @@ class TestNormalizeTitle:
         assert normalize_title("Senior PM (m/f/d)") == normalize_title("Senior PM")
 
     def test_strips_parenthetical_location(self):
-        assert normalize_title("Engineer (Berlin)") == normalize_title("Engineer")
+        # Dublin is a home-region city in the shipped config/geo.example.yaml; a
+        # recognized location parenthetical is noise and must collapse.
+        assert normalize_title("Engineer (Dublin)") == normalize_title("Engineer")
+        assert normalize_title("Engineer (New York)") == normalize_title("Engineer")
 
     def test_strips_remote_hybrid(self):
         assert normalize_title("Product Manager - Remote") == normalize_title("Product Manager")
@@ -94,3 +97,63 @@ class TestFuzzyRatio:
     def test_empty(self):
         assert fuzzy_ratio("", "x") == 0.0
         assert fuzzy_ratio(None, "x") == 0.0
+
+
+class TestParentheticalSpecialization:
+    """Specialization parens must NOT collapse; noise parens still do."""
+
+    def test_distinct_specializations_not_merged(self):
+        assert normalize_title("PM (Growth)") != normalize_title("PM (Platform)")
+        assert normalize_title("Engineer (Backend)") != normalize_title("Engineer (Frontend)")
+
+    def test_specialization_preserved_in_key(self):
+        assert job_key("Acme", "PM (Growth)") != job_key("Acme", "PM (Platform)")
+
+    def test_gender_paren_still_merged(self):
+        assert normalize_title("Senior PM (m/f/d)") == normalize_title("Senior PM")
+        assert normalize_title("Senior PM (w/m/d)") == normalize_title("Senior PM")
+
+    def test_location_paren_still_merged(self):
+        # Dublin = home-region city, New York = foreign, Remote/EU = remote noise —
+        # all are recognized location noise and collapse.
+        assert normalize_title("Engineer (Dublin)") == normalize_title("Engineer")
+        assert normalize_title("Engineer (New York)") == normalize_title("Engineer")
+        assert normalize_title("Engineer (Remote)") == normalize_title("Engineer")
+        assert normalize_title("Engineer (EU)") == normalize_title("Engineer")
+
+    def test_specialization_distinct_from_bare(self):
+        assert normalize_title("PM (Growth)") != normalize_title("PM")
+
+
+class TestMixedParenSpecialization:
+    """A paren mixing location/remote + specialization must keep the specialization,
+    not drop the whole paren."""
+
+    def test_remote_plus_specialization_kept_distinct(self):
+        assert normalize_title("Eng (Remote, Growth)") != normalize_title("Eng (Remote, Platform)")
+        assert "growth" in normalize_title("Eng (Remote, Growth)")
+
+    def test_pure_location_paren_still_dropped(self):
+        assert normalize_title("Engineer (New York)") == normalize_title("Engineer")
+        assert normalize_title("Engineer (Remote, EU)") == normalize_title("Engineer")
+
+
+class TestHomeTokenLocationNoise:
+    """The renamed 'home' geo verdict token drives location-noise detection.
+
+    _segment_is_noise checks _classify_token(segment) in ("home", "eu_remote",
+    "foreign"). A home-region city (Dublin in the shipped example config) must be
+    filtered as noise through the "home" verdict specifically.
+    """
+
+    def test_home_city_paren_dropped_via_home_token(self):
+        # "(Dublin)" is a home-region city -> _classify_token == "home" -> noise.
+        # The title normalizes identically to the same title without the paren.
+        assert normalize_title("Product Manager (Dublin)") == normalize_title("Product Manager")
+
+    def test_home_city_does_not_shadow_specialization(self):
+        # A home city mixed with a specialization keeps the specialization.
+        assert "growth" in normalize_title("Product Manager (Dublin, Growth)")
+        assert normalize_title("Product Manager (Dublin, Growth)") != normalize_title(
+            "Product Manager (Dublin, Platform)"
+        )

--- a/tools/tests/test_open_question_probe.py
+++ b/tools/tests/test_open_question_probe.py
@@ -1,0 +1,91 @@
+"""Tests for tools/open_question_probe.py (shared open-Q detection).
+
+Adds tools/ to sys.path so the module imports directly (tools-test convention).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import open_question_probe as oqp
+
+
+def _fake_client(questions):
+    c = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"questions": questions}
+    resp.raise_for_status.return_value = None
+    c.get.return_value = resp
+    return c
+
+
+_STD = [
+    {"label": "First Name", "required": True, "fields": [{"type": "input_text"}]},
+    {"label": "Email", "required": True, "fields": [{"type": "input_text"}]},
+    {
+        "label": "Resume/CV",
+        "required": True,
+        "fields": [{"type": "input_file"}, {"type": "textarea"}],
+    },
+    {
+        "label": "Cover Letter",
+        "required": False,
+        "fields": [{"type": "input_file"}, {"type": "textarea"}],
+    },
+    {"label": "LinkedIn Profile", "required": False, "fields": [{"type": "input_text"}]},
+]
+
+
+def test_standard_form_has_no_open_questions():
+    r = oqp.probe_greenhouse("acme", "1", client=_fake_client(_STD))
+    assert r["checked"] is True
+    assert r["has_open_questions"] is False
+
+
+def test_required_essay_flagged():
+    qs = _STD + [
+        {
+            "label": "Why do you want to work here?",
+            "required": True,
+            "fields": [{"type": "textarea"}],
+        }
+    ]
+    r = oqp.probe_greenhouse("acme", "1", client=_fake_client(qs))
+    assert r["has_open_questions"] is True
+    assert any("Why do you want" in e for e in r["essay_labels"])
+
+
+def test_optional_essay_not_flagged():
+    qs = _STD + [{"label": "Anything else?", "required": False, "fields": [{"type": "textarea"}]}]
+    r = oqp.probe_greenhouse("acme", "1", client=_fake_client(qs))
+    assert r["has_open_questions"] is False
+
+
+def test_standard_textarea_not_essay():
+    # "How did you hear about us" is standard even as a textarea.
+    qs = _STD + [
+        {"label": "How did you hear about us?", "required": True, "fields": [{"type": "textarea"}]}
+    ]
+    r = oqp.probe_greenhouse("acme", "1", client=_fake_client(qs))
+    assert r["has_open_questions"] is False
+
+
+def test_unknown_source_returns_unchecked():
+    r = oqp.probe_open_questions("https://jobs.lever.co/x/123", "lever")
+    assert r["checked"] is False
+
+
+def test_essay_prompt_containing_standard_word_flagged():
+    # "Name a project ..." contains "name" but is a required textarea essay.
+    for label in [
+        "Name a project you're proud of and why",
+        "What's your favorite website and why?",
+        "Describe your ideal work location",
+    ]:
+        qs = _STD + [{"label": label, "required": True, "fields": [{"type": "textarea"}]}]
+        r = oqp.probe_greenhouse("acme", "1", client=_fake_client(qs))
+        assert r["has_open_questions"] is True, f"{label!r} should be an essay"

--- a/tools/tests/test_t3_lane.py
+++ b/tools/tests/test_t3_lane.py
@@ -1,0 +1,255 @@
+"""Tests for tools/t3_lane.py — guardrails + the NEVER-SUBMIT invariant.
+
+Adds tools/ to sys.path so the module imports directly (tools-test convention).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import t3_lane
+
+
+def _job(**k):
+    d = {
+        "company": "Acme",
+        "title": "Product Manager AI",
+        "location": "Berlin",
+        "url": "https://job-boards.greenhouse.io/acme/jobs/1",
+        "source": "greenhouse",
+        "geo_class": "home",
+        "fit_score": 5,
+        "estimated_salary": "130-150k EUR",
+    }
+    d.update(k)
+    return d
+
+
+# --- guardrails ---
+
+
+def test_clean_role_eligible(monkeypatch):
+    monkeypatch.setattr(
+        t3_lane,
+        "probe_open_questions",
+        lambda *a, **k: {"checked": True, "has_open_questions": False, "essay_labels": []},
+    )
+    v = t3_lane.guardrail_check(_job())
+    assert v["eligible"] is True
+
+
+def test_blocked_company_rejected():
+    v = t3_lane.guardrail_check(_job(company="Evilcorp"), probe=False)
+    assert v["eligible"] is False and "blocklist" in v["reason"]
+
+
+def test_geo_foreign_rejected():
+    v = t3_lane.guardrail_check(
+        _job(location="San Francisco, CA", geo_class="foreign"), probe=False
+    )
+    assert v["eligible"] is False and "geo" in v["reason"]
+
+
+def test_non_ats_rejected():
+    # Non-ATS source AND a non-ATS host URL -> not auto-fillable.
+    v = t3_lane.guardrail_check(
+        _job(source="indeed", url="https://indeed.com/viewjob?jk=1"), probe=False
+    )
+    assert v["eligible"] is False and "auto-fillable" in v["reason"]
+
+
+def test_dedup_rejected():
+    from normalize import job_key
+
+    taken = {job_key("Acme", "Product Manager AI")}
+    v = t3_lane.guardrail_check(_job(), taken_keys=taken, probe=False)
+    assert v["eligible"] is False and "DB" in v["reason"]
+
+
+def test_essay_rejected(monkeypatch):
+    monkeypatch.setattr(
+        t3_lane,
+        "probe_open_questions",
+        lambda *a, **k: {"checked": True, "has_open_questions": True, "essay_labels": ["Why us?"]},
+    )
+    v = t3_lane.guardrail_check(_job())
+    assert v["eligible"] is False and "open questions" in v["reason"]
+
+
+@pytest.mark.parametrize(
+    "text,floor,expect",
+    [
+        ("90k EUR", 100000, True),
+        ("150k EUR", 100000, False),
+        ("", 100000, False),  # unknown never blocks
+        ("95000 EUR", 100000, True),  # bare digit-only annual parsed as 95k
+    ],
+)
+def test_salary_floor(text, floor, expect):
+    assert t3_lane._salary_below_floor({"estimated_salary": text}, floor) is expect
+
+
+def test_salary_floor_disabled_by_default():
+    # Default salary_floor=0 must never block any role (no personal figure baked in).
+    assert t3_lane._salary_below_floor({"estimated_salary": "50k EUR"}, 0) is False
+
+
+def test_build_queue_partitions(monkeypatch):
+    monkeypatch.setattr(
+        t3_lane,
+        "probe_open_questions",
+        lambda *a, **k: {"checked": True, "has_open_questions": False, "essay_labels": []},
+    )
+    jobs = [_job(), _job(company="Evilcorp")]
+    q = t3_lane.build_queue(jobs)
+    assert q["summary"]["prefill_ready"] == 1
+    assert q["summary"]["skipped"] == 1
+
+
+# --- THE INVARIANT: prefill never submits ---
+
+
+def test_prefill_never_submits(monkeypatch):
+    import auto_apply
+
+    called: list[str] = []
+    for name in t3_lane.FORBIDDEN_SUBMIT_FUNCS:
+        monkeypatch.setattr(auto_apply, name, lambda *a, _n=name, **k: called.append(_n))
+    # Also make the fillers no-ops so we isolate the submit question.
+    for f in (
+        "fill_ashby_browser",
+        "fill_lever_browser",
+        "fill_greenhouse_browser",
+        "fill_generic_browser",
+    ):
+        monkeypatch.setattr(auto_apply, f, lambda *a, **k: None)
+
+    page = MagicMock()
+    res = t3_lane.prefill_application(
+        page, {"first_name": "A", "last_name": "B", "email": "x@y.z"}, _job()
+    )
+
+    assert res["status"] == "prefilled"
+    assert called == [], f"T3 prefill called a submit function: {called}"
+
+
+def test_prefill_uses_correct_filler(monkeypatch):
+    import auto_apply
+
+    used = {}
+    monkeypatch.setattr(
+        auto_apply,
+        "fill_greenhouse_browser",
+        lambda *a, **k: used.setdefault("filler", "greenhouse"),
+    )
+    for name in t3_lane.FORBIDDEN_SUBMIT_FUNCS:
+        monkeypatch.setattr(auto_apply, name, lambda *a, **k: pytest.fail("submitted!"))
+    t3_lane.prefill_application(
+        MagicMock(), {}, _job(url="https://job-boards.greenhouse.io/x/jobs/9")
+    )
+    assert used.get("filler") == "greenhouse"
+
+
+def test_salary_monthly_or_bonus_not_blocked():
+    # "10k/month" / "15k signing bonus" must not look like a sub-floor annual.
+    assert t3_lane._salary_below_floor({"estimated_salary": "10k / month"}, 100000) is False
+    assert t3_lane._salary_below_floor({"salary": "15k signing bonus"}, 100000) is False
+    assert t3_lane._salary_below_floor({"estimated_salary": "90k EUR"}, 100000) is True
+
+
+def test_guardrail_trusts_authoritative_geo_class(monkeypatch):
+    monkeypatch.setattr(
+        t3_lane,
+        "probe_open_questions",
+        lambda *a, **k: {"checked": True, "has_open_questions": False, "essay_labels": []},
+    )
+    # list-location string is a foreign city, but the pipeline-set geo_class is 'home'
+    # (offices override). The guardrail must trust geo_class, not re-derive foreign.
+    v = t3_lane.guardrail_check(_job(location="Paris, France", geo_class="home"))
+    assert v["eligible"] is True
+    assert v["checks"]["geo"] == "home"
+
+
+def test_prefill_injects_cv_cover_keys(monkeypatch):
+    import auto_apply
+
+    captured = {}
+    monkeypatch.setattr(
+        auto_apply, "fill_greenhouse_browser", lambda page, personal, app: captured.update(app)
+    )
+    for n in t3_lane.FORBIDDEN_SUBMIT_FUNCS:
+        monkeypatch.setattr(auto_apply, n, lambda *a, **k: pytest.fail("submitted!"))
+    # job dict has NO cv/cover_letter -> prefill must inject them (avoid KeyError).
+    t3_lane.prefill_application(MagicMock(), {}, _job(), cv="cv/x.pdf", cover="cv/c.pdf")
+    assert captured.get("cv") == "cv/x.pdf"
+    assert captured.get("cover_letter") == "cv/c.pdf"
+
+
+# --- exercise the REAL fillers, assert none click submit ---
+
+
+class _RecLocator:
+    def __init__(self, sel, page):
+        self._sel, self._page = sel, page
+
+    def count(self):
+        return 1
+
+    def nth(self, i):
+        return self
+
+    @property
+    def first(self):
+        return self
+
+    def click(self, *a, **k):
+        import re as _re
+
+        if _re.search(r"submit", self._sel, _re.I):
+            self._page.submits.append(self._sel)
+
+    def __getattr__(self, name):
+        return lambda *a, **k: False if name in ("is_visible", "is_enabled") else None
+
+
+class _RecPage:
+    def __init__(self):
+        self.submits = []
+
+    def locator(self, sel):
+        return _RecLocator(sel, self)
+
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+def test_real_fillers_never_click_submit(monkeypatch):
+    import auto_apply
+
+    monkeypatch.setattr(auto_apply.time, "sleep", lambda *a, **k: None)
+    for n in t3_lane.FORBIDDEN_SUBMIT_FUNCS:
+        monkeypatch.setattr(auto_apply, n, lambda *a, **k: pytest.fail("submit fn called"))
+    personal = {
+        "first_name": "A",
+        "last_name": "B",
+        "email": "a@b.c",
+        "phone": "1",
+        "linkedin": "",
+        "github": "",
+        "location": "Berlin",
+    }
+    for url in [
+        "https://job-boards.greenhouse.io/x/jobs/1",
+        "https://jobs.lever.co/x/1",
+        "https://jobs.ashbyhq.com/x",
+        "https://example.com/generic",
+    ]:
+        page = _RecPage()
+        t3_lane.prefill_application(page, personal, _job(url=url), cv="cv/x.pdf", cover="cv/c.pdf")
+        assert page.submits == [], f"real filler clicked submit for {url}: {page.submits}"


### PR DESCRIPTION
## What (PR B of 2 for G-1282 — follows #436)

Second half of the private-fork pipeline port:

- **Tiered T1/T2/T3 operating model** — `classify_tier`/`assign_tiers`/`apply_hard_caps`/`apply_floors` in `tools/job_scorer.py`, plus:
  - `tools/kit_builder.py` — rapid-fire application-kit folder generator (archetype mappings config-driven, `<configure>` placeholders)
  - `tools/open_question_probe.py` — Greenhouse questions-API essay detection (auto-submittable vs needs-writing)
  - `tools/t3_lane.py` — auto-FILL-never-SUBMIT lane: submit functions are structurally unreachable from the fill path, enforced by two independent invariant tests
- **`scrape_smartrecruiters` + `scrape_personio`** — two new ATS adapters (postings JSON / XML feed), parameterized company lists with example-only defaults, left standalone so examples never leak into aggregate runs
- **`tools/normalize.py`** — parenthetical-specialization dedup layered onto the existing NFKD accent-fold, location-noise via the parameterized "home" geo token
- **CI**: actionlint runs directly (drops reviewdog PR-diff fetch that 403s on read-only tokens), shellcheck at warning+ severity

151 new tests; `tools/tests/` suite: 237 green.

## Scope notes

- CLI surface (`career_os.cli` batch commands) deferred — mechanisms fully usable and tested at tools level
- `salary_floor` defaults to 0 (disabled); all personal defaults replaced with config-driven placeholders

## PII / review trail

- Diff-scoped PII gates (added-lines-only) — clean; negative-assertion tests prove personal literals are absent from generated kit output
- Independent adversarial review vs the private originals: SHIP, no blockers (dream-tier list, form-cheats, salary literals, scraper company lists all verified fictional/parameterized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxThvPPj8YHPjy4HMM8RnT