### PR TITLE
refactor(G-1306): round-2 de-personalization — dashboard/worker refs, CV personas, config-loader tests

### DIFF
--- a/.planning/research/cicd_deployment.md
+++ b/.planning/research/cicd_deployment.md
@@ -148,7 +148,7 @@ For a single-server, single-container app like Kestrel:
 3. Removes old containers
 
 **Requirements:**
-- Cannot use `container_name` in compose file (Kestrel's prod compose uses `careeros` -- needs removal)
+- Cannot use `container_name` in compose file (Kestrel's prod compose uses the `kestrel` service -- needs removal)
 - Cannot use `ports` directly (need a reverse proxy like Caddy/Traefik)
 - Health checks must be defined (Kestrel already has `/health`)
 

--- a/.planning/research/cicd_release_strategy.md
+++ b/.planning/research/cicd_release_strategy.md
@@ -212,7 +212,7 @@ release-please generates CHANGELOG.md entries from conventional commits:
 ### Features
 
 * **G-295:** expand golden set with finance and design categories ([4eed038](https://github.com/...))
-* **G-300:** sync CareerOS features to Kestrel platform ([abc1234](https://github.com/...))
+* **G-300:** sync legacy features to Kestrel platform ([abc1234](https://github.com/...))
 
 ### Bug Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # =============================================================================
-# CareerOS — Multi-stage Dockerfile
+# Kestrel — Multi-stage Dockerfile
 # Single container: serves both FastAPI API and React frontend on one port.
 # =============================================================================
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -97,7 +97,7 @@ All config via environment variables:
 | `PIPELINE_MODE` | `api-only` | `api-only` / `api-plus` / `all` |
 | `PIPELINE_MIN_SCORE` | `5` | Minimum fit score to include in digest |
 | `PIPELINE_HOURS_OLD` | `24` | Max posting age in hours |
-| `PIPELINE_LOCATION` | `Berlin` | Primary search location |
+| `PIPELINE_LOCATION` | `Dublin` | Primary search location |
 | `PIPELINE_DRY_RUN` | `0` | Set to `1` to skip CSV writes |
 
 ### Scraping Modes

--- a/automation/cron_runner.sh
+++ b/automation/cron_runner.sh
@@ -14,7 +14,7 @@
 #   PIPELINE_MODE       — api-only (default) | api-plus | all
 #   PIPELINE_MIN_SCORE  — minimum score threshold (default: 5)
 #   PIPELINE_HOURS_OLD  — max posting age in hours (default: 24)
-#   PIPELINE_LOCATION   — search location (default: Berlin)
+#   PIPELINE_LOCATION   — search location (default: Dublin)
 
 set -euo pipefail
 

--- a/automation/n8n_workflow.json
+++ b/automation/n8n_workflow.json
@@ -116,7 +116,7 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "timezone": "Europe/Berlin"
+    "timezone": "Europe/Dublin"
   },
   "_comment": "Import this into n8n via Settings > Import Workflow. Update all paths and credentials before enabling."
 }

--- a/config/personal.yaml.example
+++ b/config/personal.yaml.example
@@ -86,3 +86,20 @@ role_overlays:
     - ["owned end-to-end delivery of technical programmes", "Yes", false]
     - ["native or C1-level in the local language", "No", false]
     - ["delivered AI/ML into production", "Yes", false]
+
+# Tailored CV persona summaries used by tools/render_tailored_cvs.py.
+# Each key is a role slug; `filename` is the output PDF/HTML basename and
+# `summary` replaces the cv.yaml summary section for that variant.
+# A non-empty cv_personas mapping fully REPLACES the embedded fictional floor.
+# The examples below describe an INVENTED person — replace with your own.
+cv_personas:
+  example-platform-engineer:
+    filename: example-platform-engineer-cv
+    summary: >
+      Platform engineer who enjoys turning flaky build pipelines into boring,
+      reliable ones. Comfortable across infrastructure and application code.
+  example-product-manager:
+    filename: example-product-manager-cv
+    summary: >
+      Product manager who prototypes before writing specs and prefers small,
+      shippable increments over big-bang launches.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -16,7 +16,7 @@ npm run dev
 ## Cloudflare Pages Deployment
 
 1. Go to [Cloudflare Dashboard > Pages](https://dash.cloudflare.com/?to=/:account/pages)
-2. Create a project > Connect to Git > Select `job-search-hq` repo
+2. Create a project > Connect to Git > Select your Kestrel repo
 3. Build settings:
    - **Build command:** `cd dashboard && npm install && npm run build`
    - **Build output directory:** `dashboard`

--- a/dashboard/build.js
+++ b/dashboard/build.js
@@ -16,11 +16,12 @@ if (fs.existsSync(envPath)) {
 const { LinearClient } = require("@linear/sdk");
 
 const LINEAR_API_KEY = process.env.LINEAR_API_KEY;
-const PROJECT_ID = "164962c6-01b3-4e8e-99a5-9df574cd4529";
+// Set LINEAR_PROJECT_ID to your own Linear project UUID (no personal default).
+const PROJECT_ID = process.env.LINEAR_PROJECT_ID;
 
 async function fetchLinearData() {
-  if (!LINEAR_API_KEY) {
-    console.warn("LINEAR_API_KEY not set -- using placeholder data");
+  if (!LINEAR_API_KEY || !PROJECT_ID) {
+    console.warn("LINEAR_API_KEY / LINEAR_PROJECT_ID not set -- using placeholder data");
     return generatePlaceholder();
   }
 
@@ -95,7 +96,7 @@ function generatePlaceholder() {
     project: {
       name: "Job Search HQ",
       summary: "Searching for the right role",
-      url: "https://linear.app/abandoned-yachts/project/job-search-hq-9bcd78537fa9",
+      url: process.env.LINEAR_PROJECT_URL || "https://linear.app/your-workspace/project/your-project",
       state: "started",
     },
     milestones: [

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -116,14 +116,15 @@
              class="flex items-center gap-2 text-sm text-white/60 hover:text-accent p-2 rounded-lg hover:bg-white/5 transition">
             <span>GitHub Repo</span>
           </a>
-          <a href="https://linear.app/abandoned-yachts/project/job-search-hq-9bcd78537fa9" target="_blank"
+          <a href="https://linear.app/your-workspace/project/your-project" target="_blank"
              class="flex items-center gap-2 text-sm text-white/60 hover:text-accent p-2 rounded-lg hover:bg-white/5 transition">
             <span>Linear Board</span>
           </a>
+          <a href="https://linkedin.com/in/your-profile" target="_blank"
              class="flex items-center gap-2 text-sm text-white/60 hover:text-accent p-2 rounded-lg hover:bg-white/5 transition">
             <span>LinkedIn Profile</span>
           </a>
-          <a href="https://docs.google.com/document/d/12sVN4KhonG2GvwQkeB65oUukUR27zDTyFLkT8Jp3gfg/edit" target="_blank"
+          <a href="https://docs.google.com/document/d/your-cv-doc-id/edit" target="_blank"
              class="flex items-center gap-2 text-sm text-white/60 hover:text-accent p-2 rounded-lg hover:bg-white/5 transition">
             <span>CV (Google Docs)</span>
           </a>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@
 # by FastAPI from a single container on port 8100.
 
 services:
-  careeros:
+  kestrel:
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/archive/2026-04-14_scoring-evolution.md
+++ b/docs/archive/2026-04-14_scoring-evolution.md
@@ -18,9 +18,9 @@ title: Scoring Evolution
 - Synthesized research into `private/research-scoring-deep-dive-2026-04-14.md`
 - Designed 11-epic roadmap across 5 phases in `docs/scoring-evolution-epics.md`
 - Created 12 Linear tickets (G-268 master + G-269 through G-279)
-- Orchestrated 11 agent executions on Mac Mini via tmux (3 sessions Day 1, 2 sessions Day 2)
+- Orchestrated 11 agent executions via tmux (3 sessions Day 1, 2 sessions Day 2)
 - Reviewed all 7 Day 1 branches with parallel review agents
-- Fixed G-274 calibration injection gap (agent on Mac Mini)
+- Fixed G-274 calibration injection gap (agent execution)
 - Resolved Alembic migration conflicts across 4 branches (revision chain + ID collisions)
 - Merged all 11 PRs (#177-#187) to main
 - Closed all 12 Linear tickets as Done
@@ -41,7 +41,7 @@ title: Scoring Evolution
 
 ## Decisions made
 - Opus for judgment-heavy epics (rubric, embeddings, dual-score, Bayesian), Sonnet for execution
-- Mac Mini + tmux + `--dangerously-skip-permissions` for agent execution
+- Local host + tmux + `--dangerously-skip-permissions` for agent execution
 - Option B (AI-generated) as default desire_score method, Option A (derived) as fallback
 - No sqlite-vec C extension — pure Python cosine similarity for now
 - Feedback calibration gated behind feature flag, requires ≥10 corrections
@@ -52,7 +52,7 @@ title: Scoring Evolution
 - G-283: Consolidate dual Alembic migration directories
 - G-284: Fix pre-existing test_md_to_pdf.py failures
 - Integration testing across all 11 features combined
-- Phase 4 session prompt for Mac Mini still in `private/agent-prompts.md`
+- Phase 4 session prompt still tracked locally (outside the public repo)
 
 ## PRs merged
 - #175: docs(G-268): scoring evolution epic specs

--- a/docs/guides/WRITING-GUIDE.md
+++ b/docs/guides/WRITING-GUIDE.md
@@ -187,7 +187,7 @@ Links between docs use relative paths based on the file's location:
 2. **Check cross-references** when moving or renaming a doc. Grep for the old filename.
 3. **Add archive headers** when superseding a doc. Never delete docs — archive them.
 4. **Fix stale content in place** per D-07. If >50% of a doc is stale, rewrite entirely rather than patching.
-5. **Replace "CareerOS" with "Kestrel"** in prose. Keep `career_os` in code references (Python package name).
+5. **Replace the legacy brand name with "Kestrel"** in prose. Keep `career_os` in code references (Python package name).
 6. **Preserve Jekyll frontmatter** (`permalink`, `layout`, `title`) unchanged when moving files.
 
 ---
@@ -199,5 +199,5 @@ Links between docs use relative paths based on the file's location:
 - [ ] Has at least one Mermaid diagram (guides only)
 - [ ] All cross-references use correct relative paths
 - [ ] Added to `docs/index.md`
-- [ ] No "CareerOS" brand references in prose
+- [ ] No legacy brand references in prose
 - [ ] Tone matches the directory (warm for guides, technical for reference)

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -1280,7 +1280,7 @@ def _fetch_url_content(url: str) -> str | None:
         req = urllib.request.Request(
             url,
             headers={
-                "User-Agent": "Mozilla/5.0 (compatible; CareerOS/1.0)",
+                "User-Agent": "Mozilla/5.0 (compatible; Kestrel/1.0)",
                 "Accept": "text/html,application/xhtml+xml,text/plain",
             },
         )

--- a/tests/test_batch_apply_overlay.py
+++ b/tests/test_batch_apply_overlay.py
@@ -43,9 +43,9 @@ from tools.batch_apply_browser import (  # noqa: E402
 # Greenhouse baseline. Decoupled from production strings so test breaks signal
 # real merge-logic regressions, not copy edits.
 BASELINE: list[tuple[str, str, bool]] = [
-    ("Country", "United Kingdom", False),
+    ("Country", "Ireland", False),
     ("Why Meridian", "baseline-why", False),
-    ("Working address", "London", False),
+    ("Working address", "Dublin", False),
 ]
 
 
@@ -158,7 +158,7 @@ class TestNoCollision:
         # Exactly one Country entry, and it's the baseline value.
         countries = [t for t in result if t[0] == "Country"]
         assert len(countries) == 1
-        assert countries[0] == ("Country", "United Kingdom", False)
+        assert countries[0] == ("Country", "Ireland", False)
         # The non-colliding overlay extra still gets appended.
         assert ("Language C1", "No", False) in result
 

--- a/tests/test_daily_pipeline.py
+++ b/tests/test_daily_pipeline.py
@@ -23,7 +23,7 @@ class TestPipelineConfig:
         assert config.mode == "api-only"
         assert config.min_score == 5
         assert config.hours_old == 24
-        assert config.location == "Berlin"
+        assert config.location == "Dublin"
         assert config.dry_run is False
         assert config.openai_key == ""
 

--- a/tests/test_render_tailored_cvs.py
+++ b/tests/test_render_tailored_cvs.py
@@ -1,11 +1,24 @@
-"""Tests for tools/render_tailored_cvs.py."""
+"""Tests for tools/render_tailored_cvs.py.
+
+ROLES loads from config/personal.yaml `cv_personas:` (gitignored) and falls
+back to an embedded fictional floor, so structural tests here assert shape,
+not contents or count. Loader behaviour (absent/present/malformed/validation)
+is covered in TestLoadCvPersonas; TestFloorHygiene pins the floor as fictional.
+"""
 
 import copy
+import logging
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 import yaml
-from render_tailored_cvs import ROLES, load_base_yaml, render_variant
+from render_tailored_cvs import (
+    _FLOOR_CV_PERSONAS,
+    ROLES,
+    _load_cv_personas,
+    load_base_yaml,
+    render_variant,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -39,7 +52,9 @@ def base_data():
 
 class TestRolesDict:
     def test_roles_has_entries(self):
-        assert len(ROLES) == 14
+        # Count depends on config/personal.yaml (or the floor) — assert non-empty,
+        # not a hardcoded number.
+        assert len(ROLES) >= 1
 
     def test_all_entries_have_required_keys(self):
         for key, cfg in ROLES.items():
@@ -263,3 +278,130 @@ class TestRenderVariant:
         _result, _ = self._run_render(tmp_path, base_data)
         dst_dir = tmp_path / "applications" / self.ROLE_KEY
         assert dst_dir.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# _load_cv_personas — gitignored-config loader (G-1306)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCvPersonas:
+    """Loader merges/falls back per the G-1303 gitignored-config pattern."""
+
+    def test_absent_uses_floor_silently(self, tmp_path, monkeypatch, caplog):
+        import render_tailored_cvs as mod
+
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", tmp_path / "personal.yaml")
+        with caplog.at_level(logging.WARNING, logger="render_tailored_cvs"):
+            personas = _load_cv_personas()
+        assert personas == _FLOOR_CV_PERSONAS
+        assert not caplog.records  # absent config is the normal case
+
+    def test_present_replaces_floor(self, tmp_path, monkeypatch):
+        import render_tailored_cvs as mod
+
+        cfg = tmp_path / "personal.yaml"
+        cfg.write_text(
+            "cv_personas:\n  my-role:\n    filename: my-role-cv\n    summary: My own summary.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", cfg)
+        personas = _load_cv_personas()
+        assert personas == {"my-role": {"filename": "my-role-cv", "summary": "My own summary."}}
+        # Config fully replaces the floor — no fictional personas rendered.
+        assert "example-platform-engineer" not in personas
+
+    def test_invalid_entries_skipped(self, tmp_path, monkeypatch):
+        import render_tailored_cvs as mod
+
+        cfg = tmp_path / "personal.yaml"
+        cfg.write_text(
+            "cv_personas:\n"
+            "  good:\n"
+            "    filename: good-cv\n"
+            "    summary: Fine.\n"
+            "  no-summary:\n"
+            "    filename: broken-cv\n"
+            "  not-a-mapping: just a string\n"
+            "  blank-filename:\n"
+            "    filename: '  '\n"
+            "    summary: Text.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", cfg)
+        personas = _load_cv_personas()
+        assert personas == {"good": {"filename": "good-cv", "summary": "Fine."}}
+
+    def test_all_entries_invalid_keeps_floor(self, tmp_path, monkeypatch):
+        import render_tailored_cvs as mod
+
+        cfg = tmp_path / "personal.yaml"
+        cfg.write_text("cv_personas:\n  broken: just a string\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", cfg)
+        assert _load_cv_personas() == _FLOOR_CV_PERSONAS
+
+    def test_missing_key_keeps_floor(self, tmp_path, monkeypatch):
+        import render_tailored_cvs as mod
+
+        cfg = tmp_path / "personal.yaml"
+        cfg.write_text("answers:\n  why_company: hello\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", cfg)
+        assert _load_cv_personas() == _FLOOR_CV_PERSONAS
+
+    def test_malformed_falls_back_with_warning(self, tmp_path, monkeypatch, caplog):
+        import render_tailored_cvs as mod
+
+        cfg = tmp_path / "personal.yaml"
+        cfg.write_text("cv_personas: [unterminated\n", encoding="utf-8")
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", cfg)
+        with caplog.at_level(logging.WARNING, logger="render_tailored_cvs"):
+            personas = _load_cv_personas()
+        assert personas == _FLOOR_CV_PERSONAS
+        assert any("cv_personas" in r.message for r in caplog.records)
+
+    def test_floor_copy_is_not_shared(self, tmp_path, monkeypatch):
+        # Mutating the returned dict must not leak into the floor constant.
+        import render_tailored_cvs as mod
+
+        monkeypatch.setattr(mod, "PERSONAL_CONFIG", tmp_path / "personal.yaml")
+        personas = _load_cv_personas()
+        first = next(iter(personas))
+        personas[first]["summary"] = "mutated"
+        assert _FLOOR_CV_PERSONAS[first]["summary"] != "mutated"
+
+
+# ---------------------------------------------------------------------------
+# Floor hygiene — the embedded defaults must stay fictional (G-1306)
+# ---------------------------------------------------------------------------
+
+
+class TestFloorHygiene:
+    """The committed floor must never carry the maintainer's real CV markers."""
+
+    # Personal-narrative markers from the pre-G-1306 hardcoded summaries.
+    REAL_MARKERS = [
+        "berlin",
+        "clifton",
+        "since 2016",
+        "$1m",
+        "1m+",
+        "sovereignty",
+        "salesforce",
+        "pipedrive",
+        "200+ live",
+        "bigtech",
+        "3 continents",
+    ]
+
+    def test_floor_summaries_carry_no_real_markers(self):
+        blob = " ".join(
+            f"{slug} {cfg['filename']} {cfg['summary']}" for slug, cfg in _FLOOR_CV_PERSONAS.items()
+        ).lower()
+        for marker in self.REAL_MARKERS:
+            assert marker not in blob, f"real personal marker '{marker}' found in floor"
+
+    def test_floor_summaries_are_marked_fictional(self):
+        for slug, cfg in _FLOOR_CV_PERSONAS.items():
+            assert "fictional example" in cfg["summary"].lower(), (
+                f"floor persona '{slug}' must self-identify as fictional"
+            )

--- a/tools/batch_apply_browser.py
+++ b/tools/batch_apply_browser.py
@@ -17,6 +17,7 @@ Usage:
 import argparse
 import asyncio
 import contextlib
+import logging
 import os
 import re
 import sqlite3
@@ -26,6 +27,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
+
+logger = logging.getLogger("batch_apply_browser")
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCREENSHOTS_DIR = PROJECT_ROOT / "screenshots" / "batch"
@@ -532,8 +535,8 @@ def _load_answers() -> dict[str, str]:
         cfg = _read_personal_yaml()
         for key, val in (cfg.get("answers") or {}).items():
             answers[str(key)] = str(val)
-    except (OSError, yaml.YAMLError):
-        pass
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/personal.yaml answers unreadable (%s); using floor", exc)
     return answers
 
 
@@ -544,8 +547,8 @@ def _load_role_overlays() -> dict[str, list[tuple[str, str, bool]]]:
         cfg = _read_personal_yaml()
         for slug, fields in (cfg.get("role_overlays") or {}).items():
             overlays[str(slug).lower()] = [tuple(f) for f in fields]
-    except (OSError, yaml.YAMLError):
-        pass
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/personal.yaml role_overlays unreadable (%s); using floor", exc)
     return overlays
 
 
@@ -565,8 +568,8 @@ def _load_custom_questions() -> list[dict]:
         cfg = _read_personal_yaml()
         for entry in cfg.get("custom_questions") or []:
             merged[_key(entry)] = entry
-    except (OSError, yaml.YAMLError):
-        pass
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/personal.yaml custom_questions unreadable (%s); using floor", exc)
     return list(merged.values())
 
 

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -28,7 +28,7 @@ Environment variables:
   PIPELINE_MODE           — api-only | api-plus | all (default: api-only)
   PIPELINE_MIN_SCORE      — Minimum score to include in digest (default: 5)
   PIPELINE_HOURS_OLD      — Max posting age in hours (default: 24)
-  PIPELINE_LOCATION       — Search location (default: Berlin)
+  PIPELINE_LOCATION       — Search location (default: Dublin)
   PIPELINE_DRY_RUN        — Set to "1" to skip CSV writes (default: 0)
   GITHUB_STEP_SUMMARY     — GitHub Actions summary file (auto-set in Actions)
 
@@ -71,7 +71,7 @@ class PipelineConfig:
         self.mode = os.getenv("PIPELINE_MODE", "api-only")
         self.min_score = int(os.getenv("PIPELINE_MIN_SCORE", "5"))
         self.hours_old = int(os.getenv("PIPELINE_HOURS_OLD", "24"))
-        self.location = os.getenv("PIPELINE_LOCATION", "Berlin")
+        self.location = os.getenv("PIPELINE_LOCATION", "Dublin")
         self.dry_run = os.getenv("PIPELINE_DRY_RUN", "0") == "1"
         self.openai_key = os.getenv("OPENAI_API_KEY", "")
         self.date = datetime.now().strftime("%Y-%m-%d")

--- a/tools/daily_pipeline.py
+++ b/tools/daily_pipeline.py
@@ -467,7 +467,7 @@ def _fallback_score(jobs: list[dict]) -> list[dict]:
 
 
 def step_dedup_against_tracking(config: PipelineConfig, jobs: list[dict]) -> list[dict]:
-    """Remove jobs that are already tracked in CareerOS DB."""
+    """Remove jobs that are already tracked in the Kestrel DB."""
     logger.info("=" * 60)
     logger.info("STEP 3: DEDUP AGAINST TRACKING")
     logger.info("=" * 60)
@@ -479,7 +479,7 @@ def step_dedup_against_tracking(config: PipelineConfig, jobs: list[dict]) -> lis
 
     tracked_keys: set[tuple[str, str]] = set()
 
-    # Check CareerOS DB (primary)
+    # Check Kestrel DB (primary)
     try:
         sys.path.insert(0, str(PROJECT_ROOT / "src"))
         from career_os.database import SessionLocal
@@ -490,9 +490,9 @@ def step_dedup_against_tracking(config: PipelineConfig, jobs: list[dict]) -> lis
         for app in apps:
             tracked_keys.add(job_key(app.company, app.role))
         db.close()
-        logger.info(f"Loaded {len(tracked_keys)} tracked jobs from CareerOS DB")
+        logger.info(f"Loaded {len(tracked_keys)} tracked jobs from Kestrel DB")
     except Exception as e:
-        logger.warning(f"Could not read CareerOS DB: {e}")
+        logger.warning(f"Could not read Kestrel DB: {e}")
 
         # Fallback to CSV
         if config.csv_path.exists():

--- a/tools/render_tailored_cvs.py
+++ b/tools/render_tailored_cvs.py
@@ -1,194 +1,100 @@
 #!/usr/bin/env python3
-"""Generate 5 tailored CV PDFs from cv.yaml using RenderCV.
+"""Generate tailored CV PDFs from cv.yaml using RenderCV.
 
 Creates a temporary YAML variant per role with a tailored summary,
 renders it, and copies the PDF to the application folder.
+
+Persona summaries are NOT hardcoded: they load from config/personal.yaml
+(gitignored) under a ``cv_personas:`` key. The embedded floor below is an
+OBVIOUSLY-FICTIONAL example set that keeps the rendering mechanism testable in
+CI without any real CV content. See config/personal.yaml.example for the schema.
 """
 
 import copy
+import logging
 import shutil
 import subprocess
 from pathlib import Path
 
 import yaml
 
-BASE_DIR = Path(__file__).resolve().parent.parent / "cv"
-APP_DIR = BASE_DIR / "applications"
-RENDERCV = str(Path(__file__).resolve().parent.parent / ".venv" / "bin" / "rendercv")
+logger = logging.getLogger("render_tailored_cvs")
 
-# Tailored summaries per role
-ROLES = {
-    "example-ai-deployment-strategist": {
-        "filename": "user-ai-strategist-cv",
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BASE_DIR = PROJECT_ROOT / "cv"
+APP_DIR = BASE_DIR / "applications"
+RENDERCV = str(PROJECT_ROOT / ".venv" / "bin" / "rendercv")
+PERSONAL_CONFIG = PROJECT_ROOT / "config" / "personal.yaml"
+
+# Fictional floor personas — an invented person ("Alex Example") with generic,
+# obviously-made-up summaries. They (a) keep the render mechanism runnable and
+# testable in CI without real CV content and (b) document the expected shape.
+# Replace via config/personal.yaml `cv_personas:` (see personal.yaml.example).
+_FLOOR_CV_PERSONAS: dict[str, dict] = {
+    "example-platform-engineer": {
+        "filename": "example-platform-engineer-cv",
         "summary": (
-            "10+ years shipping complex technical programs across AI/ML, IoT, and hardware -- "
-            "now focused on bringing AI from prototype to production. Built an AI-augmented "
-            "program system integrating multiple LLMs with enterprise APIs. Ran ML model "
-            "deployment across 3 continents. Shipped consumer hardware product to "
-            "high volume across 10+ teams. Conducted 200+ live AI product "
-            "demos to executives, driving $1M+ contracts. Based in Berlin. "
-            "The pattern: take the ambiguous, cross-functional, hard-to-own problem and find "
-            "the path through it. Builder first, operator by method."
+            "Fictional example — replace via config/personal.yaml `cv_personas:`. "
+            "Platform engineer who enjoys turning flaky build pipelines into boring, "
+            "reliable ones. Comfortable across infrastructure and application code."
         ),
     },
-    "example-sr-product-engineer-ai": {
-        "filename": "user-product-eng-cv",
+    "example-product-manager": {
+        "filename": "example-product-manager-cv",
         "summary": (
-            "Builder who lives at the intersection of AI systems and product thinking. "
-            "Built an AI agent operating system -- 6 LLMs orchestrated through 4 "
-            "enterprise APIs, persistent context, RAG-adjacent document registry indexing "
-            "1,000+ files, AI provenance tracking, write guardrails. Ran ML model deployment "
-            "pipelines at scale. Shipped consumer hardware from sensor research "
-            "to high volume. 15+ production Python tools, real API integration experience, "
-            "end-to-end ownership instinct. The gap is the title -- the muscle is engineering-adjacent "
-            "product building under real constraints."
+            "Fictional example — replace via config/personal.yaml `cv_personas:`. "
+            "Product manager who prototypes before writing specs and prefers small, "
+            "shippable increments over big-bang launches."
         ),
     },
-    "example-pm-developer-tools": {
-        "filename": "user-devtools-pm-cv",
+    "example-developer-advocate": {
+        "filename": "example-developer-advocate-cv",
         "summary": (
-            "Built an AI-powered workflow system -- 4 API keys, a code editor, and a repo "
-            "that became a giant story about the program. Still fighting the context problem daily: "
-            "multi-generation memory architecture, 4 layers, 2 laptops, still not solved. That's the "
-            "product intuition developer tools need -- not from market research, from being the frustrated "
-            "user every day. Shipped consumer hardware from sensor research to high volume. "
-            "Built demo fleet from scratch -- 200+ live demos, $1M+ contracts. Titles are ephemeral. The work is what matters."
-        ),
-    },
-    "example-sr-developer-advocate": {
-        "filename": "user-devrel-cv",
-        "summary": (
-            "I connect people and build things -- usually at the same time. 10 years bridging "
-            "developers, scientists, and business teams across three continents. Built 15+ "
-            "automation pipelines, ran 200+ live demos of automotive AI "
-            "(messy, honest ones -- they worked 5x better than slide decks). I care about open "
-            "source, honest documentation, and keeping engineering work at least 30% fun. "
-            "CliftonStrengths #1: Communication. Working in Europe since 2016, "
-            "currently in Berlin."
-        ),
-    },
-    "example-technical-project-manager": {
-        "filename": "user-tpm-cv",
-        "summary": (
-            "10+ years shipping enterprise-scale technical programs. Not a human calendar -- "
-            "I build tools, automate mechanical work, and ship. Led Salesforce CRM amid "
-            "M&A acquisition chaos, audit logging, SOX compliance, zero "
-            "critical bugs. Split monolithic AWS account into 25 certified services, 30 weeks "
-            "ahead of schedule. Shipped hardware product across 10+ teams in 5 countries. "
-            "ML deployment across 3 continents. I care about sustainable teams and long-term "
-            "relationships. Berlin, available for customer travel."
-        ),
-    },
-    "example-ai-native-tpm": {
-        "filename": "user-ai-tpm-cv",
-        "summary": (
-            "AI-native builder -- four terminal panels, AI coding assistant, voice input, barely touching "
-            "the keyboard. Built an AI-augmented program system from scratch: 6 LLMs, "
-            "4 enterprise APIs, persistent context, 1,000+ documents indexed. No ticket, no budget "
-            "-- just saw the problem and built the solution. Shipped consumer hardware from "
-            "sensor research to high volume. Worked on a continuous-learning "
-            "ML framework that became obsolete when LLMs arrived. I don't speculate about AI disruption; "
-            "I've been disrupted. Not a cultist, not a Luddite -- I build with AI every day because "
-            "it works. Zero-to-one is where I'm best. Working across Europe "
-            "since 2016, currently in Berlin."
-        ),
-    },
-    "example-ai-native-pm": {
-        "filename": "user-ai-pm-cv",
-        "summary": (
-            "Same person, different hat. Also applied for the AI-Native TPM role -- writing "
-            "separately because PM and TPM in a team like this are the same problem-solving "
-            "persona on different days. 10+ years shipping across AI/ML, IoT, and hardware. "
-            "Built AI agent system from scratch, drove 200+ live demos, "
-            "shipped consumer hardware to high volume. I learn tools, frameworks, and measurement "
-            "systems on the fly. The work is the same. Berlin-based, immediately available."
-        ),
-    },
-    "example-sr-technical-pm-ai": {
-        "filename": "user-sr-tpm-ai-cv",
-        "summary": (
-            "I sit between research teams that want to experiment forever and engineering teams "
-            "that need to ship yesterday. Ran ASR deployment across 3 continents -- "
-            "cut release SLA from multi-day to 1 business day. Worked on a continuous-learning "
-            "ML framework made obsolete when LLMs arrived. I don't speculate "
-            "about AI disruption; I've been disrupted. Built AI-augmented program system "
-            "from scratch -- 6 LLMs, 4 enterprise APIs, no ticket, no budget. Shipped consumer "
-            "hardware to high volume. I care about European AI sovereignty -- not as a slogan, "
-            "but as genuine conviction. Working across Europe since 2016, currently "
-            "in Berlin."
-        ),
-    },
-    "example-sr-swe-product-eng": {
-        "filename": "user-swe-product-cv",
-        "summary": (
-            "Builder crossing from TPM into product engineering via AI tools. Built an AI agent "
-            "operating system -- 15+ Python scripts, 6 LLMs, 4 enterprise APIs, persistent "
-            "context, custom enterprise search CLI, AI provenance tracking. End-to-end ownership: "
-            "I research, spec, wireframe, build, and ship. Shipped hardware across 10+ teams in "
-            "5 countries. Built demo fleet from nothing -- 200+ live demos. "
-            "High ownership, minimal process, product thinking built from a decade of shipping."
-        ),
-    },
-    "example-product-engineer": {
-        "filename": "user-product-eng-crm-cv",
-        "summary": (
-            "CRM data platform owner. Led Pipedrive-to-Salesforce migration amid M&A "
-            "acquisition -- custom objects, permissions models, SOX-compliant connectors, "
-            "audit logging. 12+ stakeholders, 3 merging companies, hundreds of millions in revenue "
-            "running blind without proper infrastructure. Built AI agent system in parallel -- 6 LLMs, "
-            "enterprise APIs, 1,000+-file document registry. I think about data models instinctively "
-            "because I've had to build them. Founder mentality. Germany remote."
-        ),
-    },
-    "example-tpm-science-ops": {
-        "filename": "user-tpm-science-cv",
-        "summary": (
-            "Execution engine builder for research-to-production pipelines. Ran ML model "
-            "deployment across 3 continents -- bridging Science and Engineering, cutting "
-            "release SLA from multi-day to 1 business day. Split monolithic AWS account "
-            "into 25 independently certified services -- 30 weeks ahead of schedule, zero downtime. "
-            "Built AI-augmented program system with persistent context, automated synthesis, "
-            "and retrospective-ready data capture. The pattern: structure ambiguity into coordinated "
-            "execution without killing the science."
-        ),
-    },
-    "example-tpm-engineering": {
-        "filename": "user-tpm-eng-cv",
-        "summary": (
-            "10+ years driving cross-functional technical delivery at scale. 7 years at BigTech: "
-            "shipped consumer hardware to high volume across 10+ teams in 5 countries, "
-            "split monolithic AWS account into 25 certified services 30 weeks ahead of schedule, "
-            "ran ML model deployment across 3 continents. Led Salesforce "
-            "CRM migration with 12+ stakeholders, built AI-augmented program system from scratch. "
-            "Development and deployment process ownership. Technical depth to sit in architecture "
-            "reviews and add value."
-        ),
-    },
-    "example-sr-tpm-remote": {
-        "filename": "user-sr-tpm-remote-cv",
-        "summary": (
-            "Async-first TPM who writes documentation because it's how organizations remember "
-            "what they decided and why. 10+ years running cross-functional programs across "
-            "Engineering, Product, Finance, and Legal. Led CRM transformation amid "
-            "M&A acquisition, 12+ stakeholders, built AI system with 1,000+-file "
-            "document registry as a living handbook. Split monolithic AWS into 25 certified "
-            "services, 30 weeks ahead. ML deployment across 3 continents. I build tools, "
-            "automate mechanical work, and care about sustainable teams. Berlin, remote-ready."
-        ),
-    },
-    "example-ai-ml-pm": {
-        "filename": "user-ai-ml-pm-cv",
-        "summary": (
-            "Drove $1M+ partner deals by building things, not slide decks. 5 demo "
-            "cars, 200+ live drives to OEM executives across 3 continents, 5x sales engagement. "
-            "CRM transformation across 3 merging companies, 12+ stakeholders. ML "
-            "deployment across multiple continents. I care about open-source AI and "
-            "European sovereignty -- not as a slogan, as genuine conviction. "
-            "15+ Python tools, AI agent systems, API integrations. I sit in the room with the "
-            "partner's ML team and add value. Berlin, EMEA remote."
+            "Fictional example — replace via config/personal.yaml `cv_personas:`. "
+            "Developer advocate who writes runnable tutorials and treats documentation "
+            "as a first-class product surface."
         ),
     },
 }
+
+
+def _load_cv_personas() -> dict[str, dict]:
+    """Load CV personas from config/personal.yaml, falling back to the floor.
+
+    A valid, non-empty ``cv_personas:`` mapping fully REPLACES the fictional
+    floor (rendering floor personas alongside real ones would only produce
+    junk PDFs). Entries must be mappings with string ``filename`` and
+    ``summary`` keys; invalid entries are skipped. Absent config is the normal
+    case and stays silent; a present-but-malformed file logs a warning.
+    """
+    personas = {k: dict(v) for k, v in _FLOOR_CV_PERSONAS.items()}
+    if not PERSONAL_CONFIG.exists():
+        return personas
+    try:
+        data = yaml.safe_load(PERSONAL_CONFIG.read_text(encoding="utf-8")) or {}
+        cfg = data.get("cv_personas")
+        if isinstance(cfg, dict) and cfg:
+            parsed: dict[str, dict] = {}
+            for slug, spec in cfg.items():
+                if (
+                    isinstance(spec, dict)
+                    and isinstance(spec.get("filename"), str)
+                    and spec["filename"].strip()
+                    and isinstance(spec.get("summary"), str)
+                    and spec["summary"].strip()
+                ):
+                    parsed[str(slug)] = {
+                        "filename": spec["filename"],
+                        "summary": spec["summary"],
+                    }
+            if parsed:
+                personas = parsed
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/personal.yaml cv_personas unreadable (%s); using floor", exc)
+    return personas
+
+
+ROLES: dict[str, dict] = _load_cv_personas()
 
 
 def load_base_yaml():

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -71,14 +71,18 @@ def _load_company_lists() -> dict[str, list[str]]:
         "lever": list(_FLOOR_LEVER_COMPANIES),
         "ashby": list(_FLOOR_ASHBY_COMPANIES),
     }
+    # Absent config is the normal case (users run on the fictional floor) — stay
+    # silent. Only a present-but-unreadable/malformed file warrants a warning.
+    if not _COMPANIES_CONFIG.exists():
+        return defaults
     try:
         data = yaml.safe_load(_COMPANIES_CONFIG.read_text(encoding="utf-8")) or {}
         for key in defaults:
             vals = data.get(key)
             if isinstance(vals, list) and vals:
                 defaults[key] = [str(v).strip() for v in vals if str(v).strip()]
-    except (OSError, yaml.YAMLError):
-        pass
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/companies.yaml unreadable (%s); using example floor", exc)
     return defaults
 
 

--- a/tools/tests/test_config_loaders.py
+++ b/tools/tests/test_config_loaders.py
@@ -1,0 +1,350 @@
+"""Direct unit tests for the G-1303 gitignored-config loaders.
+
+Covers the five loaders that merge a committed, obviously-fictional "floor" with
+an optional gitignored per-user config:
+
+- ``tools/batch_apply_browser.py``: ``_read_personal_yaml``, ``_load_answers``,
+  ``_load_role_overlays``, ``_load_custom_questions`` (config/personal.yaml).
+- ``tools/scrape_new_sources.py``: ``_load_company_lists`` (config/companies.yaml).
+- ``tools/tier0_ats_poller.py``: ``_load_tier0_companies`` (config/companies.yaml).
+
+Each loader is exercised for the four behaviours that matter for a config that
+ships a floor: YAML absent (floor used, silent), present-and-overrides
+(config wins over floor), malformed (fallback to floor + a logged warning), and
+the dedup / config-wins merge semantics.
+
+Follows the tools-test convention of adding ``tools/`` to ``sys.path`` so the
+modules import directly (see ``test_normalize.py``). ``tools.batch_apply_browser``
+loads ``config/personal.yaml`` eagerly at import, so — like
+``tests/test_batch_apply_overlay.py`` — we seed it from the committed example.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_TOOLS_DIR = _REPO_ROOT / "tools"
+sys.path.insert(0, str(_TOOLS_DIR))
+
+# batch_apply_browser eagerly loads config/personal.yaml at import time; seed it
+# from the committed example so this module always imports (CI does the same).
+_personal_config = _REPO_ROOT / "config" / "personal.yaml"
+_personal_example = _REPO_ROOT / "config" / "personal.yaml.example"
+if not _personal_config.exists() and _personal_example.exists():
+    shutil.copy(_personal_example, _personal_config)
+
+if not _personal_config.exists():
+    pytest.skip(
+        "config/personal.yaml{.example} not found — skipping loader tests",
+        allow_module_level=True,
+    )
+
+import batch_apply_browser as bab  # noqa: E402
+import scrape_new_sources as sns  # noqa: E402
+import tier0_ats_poller as t0  # noqa: E402
+
+
+def _write_yaml(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# batch_apply_browser._read_personal_yaml — the raw reader
+# ---------------------------------------------------------------------------
+
+
+class TestReadPersonalYaml:
+    """`_read_personal_yaml` reads config/personal.yaml (relative to PROJECT_ROOT)."""
+
+    def test_absent_returns_empty_dict(self, tmp_path, monkeypatch):
+        # PROJECT_ROOT points at a dir with no config/personal.yaml.
+        monkeypatch.setattr(bab, "PROJECT_ROOT", tmp_path)
+        assert bab._read_personal_yaml() == {}
+
+    def test_present_returns_parsed_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(bab, "PROJECT_ROOT", tmp_path)
+        _write_yaml(tmp_path / "config" / "personal.yaml", "answers:\n  why_company: hello\n")
+        cfg = bab._read_personal_yaml()
+        assert cfg == {"answers": {"why_company": "hello"}}
+
+    def test_empty_file_returns_empty_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(bab, "PROJECT_ROOT", tmp_path)
+        _write_yaml(tmp_path / "config" / "personal.yaml", "")
+        assert bab._read_personal_yaml() == {}
+
+    def test_malformed_raises_yaml_error(self, tmp_path, monkeypatch):
+        # The raw reader does not swallow — callers are responsible for fallback.
+        monkeypatch.setattr(bab, "PROJECT_ROOT", tmp_path)
+        _write_yaml(tmp_path / "config" / "personal.yaml", "answers: [unterminated\n")
+        with pytest.raises(yaml.YAMLError):
+            bab._read_personal_yaml()
+
+
+# ---------------------------------------------------------------------------
+# batch_apply_browser._load_answers
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAnswers:
+    def test_absent_uses_floor(self, monkeypatch):
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {})
+        answers = bab._load_answers()
+        # Every fictional floor answer is present.
+        for key, val in bab._FLOOR_ANSWERS.items():
+            assert answers[key] == val
+        # `@location` is exposed for rule references.
+        assert "location" in answers
+
+    def test_config_overrides_floor(self, monkeypatch):
+        monkeypatch.setattr(
+            bab,
+            "_read_personal_yaml",
+            lambda: {"answers": {"why_company": "custom answer", "new_key": "extra"}},
+        )
+        answers = bab._load_answers()
+        assert answers["why_company"] == "custom answer"  # config wins
+        assert answers["new_key"] == "extra"  # new keys added
+        # Untouched floor keys survive.
+        assert answers["ai_policy"] == bab._FLOOR_ANSWERS["ai_policy"]
+
+    def test_malformed_falls_back_with_warning(self, monkeypatch, caplog):
+        def _boom():
+            raise yaml.YAMLError("bad yaml")
+
+        monkeypatch.setattr(bab, "_read_personal_yaml", _boom)
+        with caplog.at_level(logging.WARNING, logger="batch_apply_browser"):
+            answers = bab._load_answers()
+        assert answers["why_company"] == bab._FLOOR_ANSWERS["why_company"]
+        assert any("answers" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# batch_apply_browser._load_role_overlays
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRoleOverlays:
+    def test_absent_uses_floor(self, monkeypatch):
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {})
+        overlays = bab._load_role_overlays()
+        assert set(overlays) == set(bab._FLOOR_ROLE_OVERLAYS)
+        # Values are normalized to tuples.
+        for fields in overlays.values():
+            assert all(isinstance(f, tuple) and len(f) == 3 for f in fields)
+
+    def test_config_overrides_floor_per_slug(self, monkeypatch):
+        monkeypatch.setattr(
+            bab,
+            "_read_personal_yaml",
+            lambda: {
+                "role_overlays": {
+                    "meridianlabs-senior-engineer": [["Custom question", "Yes", False]],
+                    "acme-new-role": [["Brand new", "No", False]],
+                }
+            },
+        )
+        overlays = bab._load_role_overlays()
+        # Existing floor slug is replaced by config.
+        assert overlays["meridianlabs-senior-engineer"] == [("Custom question", "Yes", False)]
+        # New slug is added (lower-cased key).
+        assert overlays["acme-new-role"] == [("Brand new", "No", False)]
+        # Untouched floor slug survives.
+        assert "meridianlabs-engineering-manager" in overlays
+
+    def test_config_slug_key_is_lowercased(self, monkeypatch):
+        monkeypatch.setattr(
+            bab,
+            "_read_personal_yaml",
+            lambda: {"role_overlays": {"ACME-Mixed-Case": [["Q", "Yes", False]]}},
+        )
+        overlays = bab._load_role_overlays()
+        assert "acme-mixed-case" in overlays
+
+    def test_malformed_falls_back_with_warning(self, monkeypatch, caplog):
+        def _boom():
+            raise yaml.YAMLError("bad yaml")
+
+        monkeypatch.setattr(bab, "_read_personal_yaml", _boom)
+        with caplog.at_level(logging.WARNING, logger="batch_apply_browser"):
+            overlays = bab._load_role_overlays()
+        assert set(overlays) == set(bab._FLOOR_ROLE_OVERLAYS)
+        assert any("role_overlays" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# batch_apply_browser._load_custom_questions
+# ---------------------------------------------------------------------------
+
+
+def _match_keys(rules):
+    return {
+        (r.get("match", {}).get("platform", ""), r.get("match", {}).get("slug_or_url", "").lower())
+        for r in rules
+    }
+
+
+class TestLoadCustomQuestions:
+    def test_absent_uses_floor(self, monkeypatch):
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {})
+        rules = bab._load_custom_questions()
+        assert len(rules) == len(bab._FLOOR_CUSTOM_QUESTIONS)
+        assert _match_keys(rules) == _match_keys(bab._FLOOR_CUSTOM_QUESTIONS)
+
+    def test_config_replaces_matching_floor_rule(self, monkeypatch):
+        # Same (platform, slug_or_url) as a floor rule -> dedup replaces it.
+        override = {
+            "match": {"platform": "greenhouse", "slug_or_url": "meridianlabs"},
+            "text_fields": [{"label": "Only my question", "value": "Yes"}],
+        }
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {"custom_questions": [override]})
+        rules = bab._load_custom_questions()
+        # No duplicate for that match key.
+        gh_meridian = [
+            r
+            for r in rules
+            if r["match"]["platform"] == "greenhouse"
+            and r["match"]["slug_or_url"].lower() == "meridianlabs"
+        ]
+        assert len(gh_meridian) == 1
+        assert gh_meridian[0]["text_fields"] == [{"label": "Only my question", "value": "Yes"}]
+        # Total count unchanged (replaced, not appended).
+        assert len(rules) == len(bab._FLOOR_CUSTOM_QUESTIONS)
+
+    def test_config_appends_new_rule(self, monkeypatch):
+        new_rule = {
+            "match": {"platform": "greenhouse", "slug_or_url": "brand-new-co"},
+            "text_fields": [{"label": "New", "value": "Yes"}],
+        }
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {"custom_questions": [new_rule]})
+        rules = bab._load_custom_questions()
+        assert len(rules) == len(bab._FLOOR_CUSTOM_QUESTIONS) + 1
+        assert ("greenhouse", "brand-new-co") in _match_keys(rules)
+
+    def test_dedup_is_case_insensitive_on_slug(self, monkeypatch):
+        override = {
+            "match": {"platform": "greenhouse", "slug_or_url": "MeridianLabs"},
+            "text_fields": [{"label": "Case", "value": "Yes"}],
+        }
+        monkeypatch.setattr(bab, "_read_personal_yaml", lambda: {"custom_questions": [override]})
+        rules = bab._load_custom_questions()
+        assert len(rules) == len(bab._FLOOR_CUSTOM_QUESTIONS)  # replaced, not added
+
+    def test_malformed_falls_back_with_warning(self, monkeypatch, caplog):
+        def _boom():
+            raise yaml.YAMLError("bad yaml")
+
+        monkeypatch.setattr(bab, "_read_personal_yaml", _boom)
+        with caplog.at_level(logging.WARNING, logger="batch_apply_browser"):
+            rules = bab._load_custom_questions()
+        assert _match_keys(rules) == _match_keys(bab._FLOOR_CUSTOM_QUESTIONS)
+        assert any("custom_questions" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# scrape_new_sources._load_company_lists
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCompanyLists:
+    def test_absent_uses_floor_silently(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(sns, "_COMPANIES_CONFIG", tmp_path / "companies.yaml")
+        with caplog.at_level(logging.WARNING, logger="scrape_new_sources"):
+            lists = sns._load_company_lists()
+        assert lists["greenhouse"] == sns._FLOOR_GREENHOUSE_COMPANIES
+        assert lists["lever"] == sns._FLOOR_LEVER_COMPANIES
+        assert lists["ashby"] == sns._FLOOR_ASHBY_COMPANIES
+        # Absent config is the normal case — no warning.
+        assert not caplog.records
+
+    def test_present_overrides_floor(self, tmp_path, monkeypatch):
+        cfg = _write_yaml(
+            tmp_path / "companies.yaml",
+            "greenhouse:\n  - acme\n  - beta\nlever:\n  - gamma\n",
+        )
+        monkeypatch.setattr(sns, "_COMPANIES_CONFIG", cfg)
+        lists = sns._load_company_lists()
+        assert lists["greenhouse"] == ["acme", "beta"]  # config wins
+        assert lists["lever"] == ["gamma"]
+        # ashby absent from config -> keeps floor.
+        assert lists["ashby"] == sns._FLOOR_ASHBY_COMPANIES
+
+    def test_empty_list_keeps_floor(self, tmp_path, monkeypatch):
+        cfg = _write_yaml(tmp_path / "companies.yaml", "greenhouse: []\n")
+        monkeypatch.setattr(sns, "_COMPANIES_CONFIG", cfg)
+        lists = sns._load_company_lists()
+        assert lists["greenhouse"] == sns._FLOOR_GREENHOUSE_COMPANIES
+
+    def test_entries_are_stripped(self, tmp_path, monkeypatch):
+        cfg = _write_yaml(tmp_path / "companies.yaml", "lever:\n  - '  spaced  '\n  - ''\n")
+        monkeypatch.setattr(sns, "_COMPANIES_CONFIG", cfg)
+        lists = sns._load_company_lists()
+        assert lists["lever"] == ["spaced"]  # trimmed, empties dropped
+
+    def test_malformed_falls_back_with_warning(self, tmp_path, monkeypatch, caplog):
+        cfg = _write_yaml(tmp_path / "companies.yaml", "greenhouse: [unterminated\n")
+        monkeypatch.setattr(sns, "_COMPANIES_CONFIG", cfg)
+        with caplog.at_level(logging.WARNING, logger="scrape_new_sources"):
+            lists = sns._load_company_lists()
+        assert lists["greenhouse"] == sns._FLOOR_GREENHOUSE_COMPANIES
+        assert any("companies.yaml" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# tier0_ats_poller._load_tier0_companies
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTier0Companies:
+    def test_absent_uses_floor_silently(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(t0, "COMPANIES_CONFIG", tmp_path / "companies.yaml")
+        with caplog.at_level(logging.WARNING, logger="tier0_ats_poller"):
+            companies = t0._load_tier0_companies()
+        assert companies == t0._FLOOR_TIER_0_COMPANIES
+        assert not caplog.records
+
+    def test_present_replaces_floor(self, tmp_path, monkeypatch):
+        cfg = _write_yaml(
+            tmp_path / "companies.yaml",
+            "tier0:\n  Acme: [greenhouse, acme-slug]\n  Beta: [lever, beta-slug]\n",
+        )
+        monkeypatch.setattr(t0, "COMPANIES_CONFIG", cfg)
+        companies = t0._load_tier0_companies()
+        assert companies == {
+            "Acme": ("greenhouse", "acme-slug"),
+            "Beta": ("lever", "beta-slug"),
+        }
+        # Config fully replaces the floor when a valid tier0 map is present.
+        assert "example-greenhouse-co" not in companies
+
+    def test_malformed_spec_entries_ignored(self, tmp_path, monkeypatch):
+        # Entries that are not a 2-item list are skipped; a valid one still parses.
+        cfg = _write_yaml(
+            tmp_path / "companies.yaml",
+            "tier0:\n  Good: [ashby, good-slug]\n  Bad: [only-one]\n",
+        )
+        monkeypatch.setattr(t0, "COMPANIES_CONFIG", cfg)
+        companies = t0._load_tier0_companies()
+        assert companies == {"Good": ("ashby", "good-slug")}
+
+    def test_empty_tier0_keeps_floor(self, tmp_path, monkeypatch):
+        cfg = _write_yaml(tmp_path / "companies.yaml", "tier0: {}\n")
+        monkeypatch.setattr(t0, "COMPANIES_CONFIG", cfg)
+        companies = t0._load_tier0_companies()
+        assert companies == t0._FLOOR_TIER_0_COMPANIES
+
+    def test_malformed_falls_back_with_warning(self, tmp_path, monkeypatch, caplog):
+        cfg = _write_yaml(tmp_path / "companies.yaml", "tier0: [unterminated\n")
+        monkeypatch.setattr(t0, "COMPANIES_CONFIG", cfg)
+        with caplog.at_level(logging.WARNING, logger="tier0_ats_poller"):
+            companies = t0._load_tier0_companies()
+        assert companies == t0._FLOOR_TIER_0_COMPANIES
+        assert any("companies.yaml" in r.message for r in caplog.records)

--- a/tools/tier0_ats_poller.py
+++ b/tools/tier0_ats_poller.py
@@ -69,6 +69,10 @@ _FLOOR_TIER_0_COMPANIES: dict[str, tuple[str, str]] = {
 def _load_tier0_companies() -> dict[str, tuple[str, str]]:
     """Load the Tier-0 map from config/companies.yaml, falling back to the floor."""
     companies = dict(_FLOOR_TIER_0_COMPANIES)
+    # Absent config is the normal case (poller runs on the fictional floor) — stay
+    # silent. Only a present-but-unreadable/malformed file warrants a warning.
+    if not COMPANIES_CONFIG.exists():
+        return companies
     try:
         data = yaml.safe_load(COMPANIES_CONFIG.read_text(encoding="utf-8")) or {}
         tier0 = data.get("tier0")
@@ -79,8 +83,8 @@ def _load_tier0_companies() -> dict[str, tuple[str, str]]:
                     parsed[str(name)] = (str(spec[0]), str(spec[1]))
             if parsed:
                 companies = parsed
-    except (OSError, yaml.YAMLError):
-        pass
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("config/companies.yaml tier0 unreadable (%s); using example floor", exc)
     return companies
 
 

--- a/tools/update_sheet.py
+++ b/tools/update_sheet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Update the CareerOS Google Sheet with pipeline data and daily scan log.
+Update the Kestrel pipeline Google Sheet with pipeline data and daily scan log.
 
 Usage:
     # From CI (uses GOOGLE_SERVICE_ACCOUNT_JSON env var):
@@ -15,7 +15,7 @@ Usage:
 Environment:
     GOOGLE_SERVICE_ACCOUNT_JSON  - JSON string of service account creds (CI)
     GOOGLE_SA_FILE               - Path to service account JSON file (local)
-    SHEET_ID                     - Google Sheet ID (default: CareerOS Pipeline)
+    SHEET_ID                     - Google Sheet ID (required; your own spreadsheet)
     CI_RUN_URL                   - GitHub Actions run URL for daily log
 """
 
@@ -35,7 +35,8 @@ except ImportError:
     sys.exit(1)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SHEET_ID = os.getenv("SHEET_ID", "1sAeXWISdlMTk_UdJTYafQToI0G8FZcnLCATGKigjGQM")
+# Target spreadsheet is per-user config — no personal default is committed.
+SHEET_ID = os.getenv("SHEET_ID")
 DB_PATH = PROJECT_ROOT / "data" / "career_os.db"
 
 
@@ -271,12 +272,16 @@ def update_review_queue(sh, scored_path: Path):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Update CareerOS Google Sheet")
+    parser = argparse.ArgumentParser(description="Update Kestrel pipeline Google Sheet")
     parser.add_argument("--log-entry", help="JSON string with daily log data")
     parser.add_argument("--scored-json", help="Path to scored JSON for review queue")
     parser.add_argument("--pipeline-only", action="store_true", help="Only update pipeline tab")
     parser.add_argument("--log-only", action="store_true", help="Only append daily log")
     args = parser.parse_args()
+
+    if not SHEET_ID:
+        print("SHEET_ID env var is required (your own Google Sheet ID).")
+        sys.exit(1)
 
     client = get_client()
     sh = client.open_by_key(SHEET_ID)

--- a/tools/validate_sheet.py
+++ b/tools/validate_sheet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Validate the CareerOS Google Sheet after update.
+Validate the Kestrel pipeline Google Sheet after update.
 
 Checks: row count vs DB, headers, statuses, scores, sort order, daily log.
 Returns exit code 0 on pass, 1 on failure.
@@ -24,7 +24,8 @@ except ImportError:
     sys.exit(1)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SHEET_ID = os.getenv("SHEET_ID", "1sAeXWISdlMTk_UdJTYafQToI0G8FZcnLCATGKigjGQM")
+# Target spreadsheet is per-user config — no personal default is committed.
+SHEET_ID = os.getenv("SHEET_ID")
 DB_PATH = PROJECT_ROOT / "data" / "career_os.db"
 
 EXPECTED_HEADERS = [
@@ -89,6 +90,10 @@ def get_client():
 def validate():
     errors = []
     warnings = []
+
+    if not SHEET_ID:
+        print("SHEET_ID env var is required (your own Google Sheet ID).")
+        return 1
 
     client = get_client()
     sh = client.open_by_key(SHEET_ID)

--- a/worker/README.md
+++ b/worker/README.md
@@ -33,7 +33,7 @@ npx wrangler secret put CF_PAGES_DEPLOY_HOOK
 
 1. Go to Linear > Settings > API > Webhooks
 2. Create webhook:
-   - **URL:** `https://job-search-sync.<your-account>.workers.dev/webhook/linear`
+   - **URL:** `https://kestrel-linear-sync.<your-account>.workers.dev/webhook/linear`
    - **Events:** Issue updates
    - **Secret:** Same value you set for `LINEAR_WEBHOOK_SECRET`
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "job-search-sync-worker",
+  "name": "kestrel-linear-sync-worker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "job-search-sync-worker",
+      "name": "kestrel-linear-sync-worker",
       "version": "1.0.0",
       "devDependencies": {
         "wrangler": "^4.0.0"

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "job-search-sync-worker",
+  "name": "kestrel-linear-sync-worker",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -296,7 +296,7 @@ async function handleCalendarFeed(env: Env): Promise<Response> {
       const status = issue.state?.type === "completed" ? "COMPLETED" : "NEEDS-ACTION";
 
       lines.push("BEGIN:VTODO");
-      lines.push(`UID:${issue.id}@job-search-hq`);
+      lines.push(`UID:${issue.id}@kestrel`);
       lines.push(`DTSTAMP:${dtStamp}`);
       if (due) lines.push(`DUE;VALUE=DATE:${due}`);
       lines.push(`SUMMARY:${escapeICS(summary)}`);
@@ -312,7 +312,7 @@ async function handleCalendarFeed(env: Env): Promise<Response> {
     return new Response(lines.join("\r\n"), {
       headers: {
         "Content-Type": "text/calendar; charset=utf-8",
-        "Content-Disposition": 'attachment; filename="job-search-hq.ics"',
+        "Content-Disposition": 'attachment; filename="kestrel.ics"',
         "Cache-Control": "public, max-age=900",
       },
     });

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,13 +1,15 @@
-name = "job-search-sync"
+name = "kestrel-linear-sync"
 main = "src/index.ts"
 compatibility_date = "2024-12-01"
 
 [triggers]
 crons = ["*/15 * * * *"]
 
+# Replace the placeholders with your own Linear workspace IDs — either edit
+# here, set them as dashboard vars, or use `wrangler secret put <NAME>`.
 [vars]
-LINEAR_TEAM_ID = "d7d390bc-196d-45cc-bbc3-beaf69e342a6"
-LINEAR_PROJECT_ID = "164962c6-01b3-4e8e-99a5-9df574cd4529"
+LINEAR_TEAM_ID = "your-linear-team-id"
+LINEAR_PROJECT_ID = "your-linear-project-id"
 
 # Secrets (set via `wrangler secret put <NAME>`):
 # LINEAR_API_KEY


### PR DESCRIPTION
## What (round 2, follows #442)

- **Dashboard/worker**: real Linear workspace URL and bare UUIDs removed (`build.js` env-driven, `index.html` placeholders, `wrangler.toml` placeholder vars, worker renamed `kestrel-linear-sync`); Sheet updater now requires `SHEET_ID` env (workflow already supplies the secret; forks get a clean error)
- **CV personas**: `tools/render_tailored_cvs.py`'s 14 hardcoded persona summaries moved to the gitignored `config/personal.yaml` (`cv_personas:` schema documented in the `.example` with invented examples); fictional embedded floor; replace-not-merge semantics
- **Locality residue**: automation defaults Berlin→Dublin, `n8n_workflow.json` timezone, test fixtures neutralized
- **Personal-infra refs**: archive doc (Mac Mini, private paths), README quick-links, CV doc link
- **Tests**: +26 direct unit tests for the G-1303 config loaders (absent/override/malformed/dedup) and +9 for the persona loader incl. floor-hygiene negative assertions that CI-guards the personal markers from returning

3742 backend + 263 tools tests green.

## Review trail

- Independent adversarial review round 1: one CRITICAL finding (real Linear UUIDs in `wrangler.toml`) — fixed in 729afcb with tree-wide UUID grep verification; all other dimensions PASS
- Sweep gates clean: `job-search-hq|abandoned-yachts|careeros|mac mini` (excl. CHANGELOG), both UUID literals, `job-search-sync`
- Diff-scoped PII gate over added lines: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxThvPPj8YHPjy4HMM8RnT