### PR TITLE
docs(G-1315): explain cost-optimal fallback-chain ordering

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -105,6 +105,9 @@ jobs:
           # variable to enable cross-vendor fallback. Per-provider keys
           # below are read by career_os.ai.factory; missing ones are
           # silently skipped from the chain.
+          # COST: order the chain cheapest-capable first, premium LAST — whatever
+          # sits at the end is what you pay when everything before it is exhausted.
+          # See docs/guides/cost-optimization.md "Fallback Chain Ordering".
           AI_PROVIDER_FALLBACK: ${{ vars.AI_PROVIDER_FALLBACK }}
           AI_PROVIDER: ${{ vars.AI_PROVIDER }}
           SCORING_MAX_FAILURE_RATE: ${{ vars.SCORING_MAX_FAILURE_RATE || '0.50' }}

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Fully isolated — nothing touches your system Python. Requires [OrbStack](https
 | Guide | What you'll learn |
 |-------|-------------------|
 | [How Kestrel Uses AI](docs/guides/ai-providers-guide.md) | The electricity analogy — what AI providers are, what they cost, and which to pick |
+| [AI Costs and Privacy](docs/guides/cost-optimization.md) | What it costs, the tiers, the optimizations — and how to order your provider fallback so a dry-quota day doesn't bill premium |
 | [AI Provider Setup](docs/reference/AI-PROVIDERS.md) | Technical details — API keys, privacy policies, provider comparison tables |
 | [LLM Landscape Research](docs/research/llms-tokens-privacy.md) | Deep dive — 2026 pricing, privacy audits, GDPR, EU sovereignty (for the curious) |
 
@@ -330,6 +331,8 @@ Kestrel works out of the box in Demo Mode — free, offline, no account needed. 
 > | Claude Sonnet (OpenRouter) | $0.02 | $30.00 | **$900** |
 >
 > Kestrel defaults to free-tier models for bulk scanning. Premium models like Claude Sonnet are best reserved for deep analysis of shortlisted roles, not bulk filtering. The optimizations below help keep costs in check regardless of which model you use.
+>
+> **Order your fallback chain cheap-first.** If you chain providers (`AI_PROVIDER_FALLBACK`), whatever sits at the *end* is what you pay when the cheaper ones run out of quota. Put free/cheap models first and premium last — otherwise a busy or exhausted-quota day can bill an entire scan at premium rates (that $900 row, not the $0 one), often 20-50× the norm. [The rule + a worked example →](docs/guides/cost-optimization.md#fallback-chain-ordering-avoids-surprise-bills)
 
 **Quickest path:** Go to Settings → click "Connect to OpenRouter" → log in → done. No API keys to copy. Free-tier models like Llama 3.3 70B handle job scoring at zero cost — add $10 of credits to unlock 1,000 requests/day.
 
@@ -346,7 +349,7 @@ AI APIs charge per token (roughly per word). Scoring 50 jobs a day could get exp
 | **Token-efficient tool use** | When Kestrel calls AI tools, it uses a compact format that cuts output size. | [70% off output tokens](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/token-efficient-tool-use) |
 | **Smart model selection** | Not every task needs the biggest brain. Simple classification uses a smaller model. Deep analysis uses the full thing. | [60-95% on simple tasks](https://github.com/lm-sys/RouteLLM) |
 | **Batch scoring** | Scoring a big backlog overnight? Batch APIs give a flat 50% discount for non-urgent work. | [50% off everything](https://docs.anthropic.com/en/api/creating-message-batches) |
-| **Provider fallback** | If one provider's quota runs out, Kestrel automatically tries the next one. No failed scores, no wasted retries. | Resilience (not cost) |
+| **Provider fallback** | If one provider's quota runs out, Kestrel automatically tries the next one. No failed scores, no wasted retries. **Order matters:** cheap-first, premium-last (see note above). | Resilience — and cost, ordered right |
 
 **Benchmarked on a real profile + real job posting:** Naive approach = ≈$16/month. With all optimizations = **≈$1-5/month** for the same results. [How it works →](docs/guides/how-token-optimization-works.md)
 

--- a/docs/guides/ai-providers-guide.md
+++ b/docs/guides/ai-providers-guide.md
@@ -64,6 +64,8 @@ OpenRouter is like a phone plan for AI. You load credits, Kestrel uses them when
 
 **Setup:** Click "Connect to OpenRouter" in Settings → log in → done. No copying API keys.
 
+**Cheap or premium — your choice.** OpenRouter can serve a free/cheap open model (like Llama 3.3 70B) *or* a premium one (like Claude), and which you get depends entirely on the `OPENROUTER_MODEL` setting. If you're using OpenRouter as an inexpensive catch in a fallback chain, point it at a cheap model; if it's your premium tier, point it at a premium one — and place it in the chain accordingly (see [Fallback Chain Ordering](cost-optimization.md#fallback-chain-ordering-avoids-surprise-bills)).
+
 *Best for:* Most users who want quality AI without complexity.
 
 ### 3. Direct Anthropic (Claude) — Best for Power Users
@@ -169,6 +171,10 @@ AI pricing is measured in "tokens" (roughly 4 characters = 1 token), but you don
 For context: a single coffee costs more than a month of AI-powered job searching.
 
 With prompt caching enabled, discovery sweeps (scoring 50+ jobs at once) cost 88% less because Kestrel reuses your cached profile instead of re-sending it each time.
+
+### Where you put providers changes the bill
+
+If you chain providers with `AI_PROVIDER_FALLBACK`, the *order* decides which one does the work — and which one you pay when the cheaper ones run out of quota. Put cheap and free providers first and a premium one last; whatever sits at the end of the chain is what a busy or exhausted day bills to. Get this backwards and a single day of scoring can cost 20-50× what it should. See [Fallback Chain Ordering](cost-optimization.md#fallback-chain-ordering-avoids-surprise-bills) for the rule and a worked example.
 
 ---
 

--- a/docs/guides/cost-optimization.md
+++ b/docs/guides/cost-optimization.md
@@ -206,6 +206,29 @@ For nightly discovery scoring (not time-sensitive), Kestrel can use Anthropic's 
 
 Not every question needs the smartest model. "Is this job relevant?" is a simple yes/no — a small, fast model handles it perfectly. "Write a compelling cover letter for this specific role" benefits from a larger model that understands nuance. Kestrel matches the model to the task automatically.
 
+### Fallback Chain Ordering (Avoids Surprise Bills)
+
+Kestrel can chain providers so that if one is down or out of quota, scoring automatically falls through to the next. You set this with `AI_PROVIDER_FALLBACK`, a comma-separated list:
+
+```
+AI_PROVIDER_FALLBACK=groq,cerebras,sambanova,openrouter,anthropic
+```
+
+The order is the whole game, and there's one rule worth burning into memory: **whatever sits at the end of your chain is what you pay when everything before it runs out.** A chain tries each provider in turn and stops at the first one that answers. So on a normal day the cheapest provider at the front does all the work. But the day your free providers hit their daily limit, every request marches down the chain to the last entry — and if that last entry is a premium model, you can wake up to a bill for a full day of scoring at premium rates instead of the ~$0 you expected.
+
+The fix is simply to order the chain **cheapest-capable first, premium last** — and to make the premium tail-end a deliberate choice, not an accident:
+
+- **Front of the chain:** the free providers (Groq, Cerebras, SambaNova) or a cheap paid model. This does the everyday work.
+- **Middle:** a cheap paid catch (for example, OpenRouter pointed at an inexpensive open model like Llama 3.3 70B via `OPENROUTER_MODEL`) so an exhausted free tier lands somewhere cheap, not somewhere expensive.
+- **End:** a premium provider (Anthropic direct, or OpenRouter with a premium model) as a genuine last resort. It should fire rarely — only when everything cheaper has failed.
+
+> A worked example of getting this wrong: if your chain is `mistral,together,anthropic` and Mistral and Together both run dry, **100% of that day's scoring bills on premium Claude** — often 20-50× what a cheap model would have cost. Adding one cheap provider before the premium tail (`mistral,together,openrouter,anthropic`, with `OPENROUTER_MODEL` set to a cheap Llama) turns that same failure day from dollars into cents.
+
+Two settings make the tail-end intentional rather than accidental:
+
+- `OPENROUTER_MODEL` — OpenRouter is an aggregator that can serve both cheap open models and premium ones. Set this explicitly. If you want OpenRouter as a *cheap* catch, point it at something like `meta-llama/llama-3.3-70b-instruct`; if you want it as your *premium* unlock, point it at a premium model and put it at the end of the chain.
+- Provider position — the position in `AI_PROVIDER_FALLBACK` decides when each provider is reached, so a premium provider belongs last.
+
 ### All Together
 
 These optimizations stack. Applied together, they reduce the baseline cost of scoring 600 jobs/day from ~$99/month to ~$5.40/month — a 94.5% reduction. On the free tier, the cost is $0.


### PR DESCRIPTION
## What
Documents the cost-optimal **fallback-chain ordering** pattern across the places users read — the cost guide, the AI providers guide, and the README — plus a pointer comment in `daily-scan.yml`.

## Why (the line of events this generalizes)
From a real cost incident in the private fork (COE `docs/coe/2026-07-09_redundant-scoring-run-cost.md`): a provider chain that ended in premium Anthropic, with the cheap catch (OpenRouter) excluded and mis-keyed, spilled **100% of a day's scoring onto premium Claude** once the cheaper providers hit quota — and two full verification runs burned ~$45 (20-50× the cheap-model cost). The lesson is general to any Kestrel user who configures `AI_PROVIDER_FALLBACK`.

## The rule documented
- Whatever sits at the **end** of the chain is what you pay when everything before it is exhausted.
- Order **cheapest-capable first, premium last**; make the premium tail and `OPENROUTER_MODEL` a deliberate choice.
- Worked example + the fix (`mistral,together,anthropic` → `mistral,together,openrouter,anthropic`).

## Files
- `docs/guides/cost-optimization.md` — new **Fallback Chain Ordering** section
- `docs/guides/ai-providers-guide.md` — OpenRouter cheap-vs-premium note + 'where you put providers changes the bill'
- `README.md` — chain-ordering warning in the AI-cost section, fixed the 'Provider fallback = Resilience (not cost)' line, added the cost guide to the docs table
- `.github/workflows/daily-scan.yml` — pointer comment

## Scope
Docs only — **no model-ID / preset / config / code changes**. Model-currency updates ship in the parallel PR (#B), so this stays conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxThvPPj8YHPjy4HMM8RnT