### PR TITLE
feat(G-1335): role-fit hard gate + company-prestige cap (halo fix)

### DIFF
--- a/src/career_os/ai/anthropic_provider.py
+++ b/src/career_os/ai/anthropic_provider.py
@@ -13,7 +13,12 @@ from urllib.parse import urlparse
 
 import httpx
 
-from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
+from career_os.ai.base import (
+    ROLE_FIT_GATE_PROMPT,
+    AIProvider,
+    ComplexityTier,
+    ProviderQuotaError,
+)
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -218,7 +223,7 @@ class AnthropicProvider(AIProvider):
 
         # -- user message: only the job description (changes per call) --------
         user_content = (
-            "Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + "Score this job against the candidate profile. "
             "Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             "estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             "readiness_score (0-100), career_alignment (0-10), "
@@ -332,7 +337,7 @@ class AnthropicProvider(AIProvider):
         requests: list[dict] = []
         for job in jobs:
             prompt = (
-                "Score this job against the candidate profile. "
+                ROLE_FIT_GATE_PROMPT + "Score this job against the candidate profile. "
                 "Return a JSON object with: fit_score (0-10), reasoning "
                 "(detailed, >=100 chars), "
                 "estimated_salary (string), effort_flag (low/medium/high), "

--- a/src/career_os/ai/base.py
+++ b/src/career_os/ai/base.py
@@ -7,6 +7,50 @@ from enum import StrEnum
 
 from career_os.schemas.ai import AIFeature, AIResponse
 
+# ---------------------------------------------------------------------------
+# Role-fit gate + anti-halo preamble (G-1335)
+# ---------------------------------------------------------------------------
+# Prepended to every real provider's score prompt (the single-scorer preamble
+# and the multi-job batch prompt). Counters the halo effect where a prestigious
+# company + hot domain haloes the holistic fit number for a job the candidate's
+# role family cannot actually do. Company prestige lives on the DESIRE axis, not
+# the FIT axis. The two extra fields (role_match, disqualifiers) let the scoring
+# service enforce a code-side cap post-parse (see schemas.ai.apply_role_fit_gate).
+#
+# Intentionally NOT part of career_os.services.scoring._build_scoring_prompt, so
+# the deterministic golden-set snapshot (which hashes that prompt) stays stable
+# while real providers still receive the guardrails here.
+ROLE_FIT_GATE_PROMPT = (
+    "IMPORTANT — role-fit gate (anti-halo): Company prestige and a hot domain must "
+    "NEVER substitute for role fit. A famous company hiring for the WRONG role family "
+    "(e.g. a SWE/SRE/designer/partnerships role for a PM/TPM candidate) is a POOR fit "
+    "even if the candidate would love to work there — that enthusiasm is a desire "
+    "signal, not fit.\n"
+    "Reason before you score: write the evidence FIRST and the number last, list the "
+    "reasons to REJECT before the reasons to hire, and name at least one JD-grounded "
+    "weakness (an 'against' point) for every dimension — never an all-positive rationale.\n"
+    "Score FIT by tier: PRIMARY (dominant) = technical_fit + seniority_alignment; "
+    "SECONDARY = career_trajectory, compensation_fit, location_fit; MINOR (capped) = "
+    "company_fit, which scores culture / values / company size / work style ONLY — NOT "
+    "domain prestige or brand — and may move the overall fit by at most ±1 and can NEVER "
+    "rescue a role the candidate cannot do. Put prestige / 'I'd love to work there' into "
+    "desire_score, not fit.\n"
+    "Emit two extra fields FIRST, before fit_score:\n"
+    "- role_match: an object with is_same_role_family (bool — true ONLY if the job's "
+    "role/occupation is the same family as the candidate's target job family) and "
+    "evidence (string: the job title + core responsibilities vs the target role).\n"
+    "- disqualifiers: an array of strings for HARD blockers grounded in the JD (missing "
+    "mandatory license/clearance/visa, a hard location conflict, or seniority off by >1 "
+    "level); empty array if none.\n"
+    "If is_same_role_family is false OR disqualifiers is non-empty, the fit_score will be "
+    "CAPPED AT 3 in code — score it that low, do not inflate.\n"
+    "Worked anchors — negative: a 'Staff Software Engineer, Inference' role at a top-tier "
+    "AI lab for a Technical Program Manager candidate → role_match.is_same_role_family = "
+    "false; SWE ≠ TPM, so FIT ~2/10 even though prestige/domain are high (that love goes "
+    "to desire). Positive: a 'Technical Program Manager, AI Platform' role for that same "
+    "candidate with matching domain + seniority → is_same_role_family = true, FIT ~8-9/10.\n\n"
+)
+
 
 class ComplexityTier(StrEnum):
     """Task complexity tier for model routing.

--- a/src/career_os/ai/gemini_provider.py
+++ b/src/career_os/ai/gemini_provider.py
@@ -12,7 +12,12 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError, ProviderUnavailableError
+from career_os.ai.base import (
+    ROLE_FIT_GATE_PROMPT,
+    AIProvider,
+    ProviderQuotaError,
+    ProviderUnavailableError,
+)
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -159,7 +164,7 @@ class GeminiProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the Gemini API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/groq_provider.py
+++ b/src/career_os/ai/groq_provider.py
@@ -11,7 +11,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -136,7 +136,7 @@ class GroqProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the Groq API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/huggingface_provider.py
+++ b/src/career_os/ai/huggingface_provider.py
@@ -14,7 +14,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -152,7 +152,7 @@ class HuggingFaceProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the Hugging Face Inference API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/mistral_provider.py
+++ b/src/career_os/ai/mistral_provider.py
@@ -14,7 +14,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -139,7 +139,7 @@ class MistralProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the Mistral AI API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/ollama_provider.py
+++ b/src/career_os/ai/ollama_provider.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from career_os.ai.base import AIProvider, ComplexityTier
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ComplexityTier
 from career_os.ai.openrouter_provider import _system_prompt_for_feature, _try_parse_structured
 from career_os.schemas.ai import AIFeature, AIResponse, TokenUsage
 
@@ -218,7 +218,7 @@ class OllamaProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via Ollama."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, ≥100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/openrouter_provider.py
+++ b/src/career_os/ai/openrouter_provider.py
@@ -10,7 +10,12 @@ import re
 
 import httpx
 
-from career_os.ai.base import AIProvider, ComplexityTier, ProviderQuotaError
+from career_os.ai.base import (
+    ROLE_FIT_GATE_PROMPT,
+    AIProvider,
+    ComplexityTier,
+    ProviderQuotaError,
+)
 from career_os.schemas.ai import (
     AIFeature,
     AIResponse,
@@ -204,7 +209,7 @@ class OpenRouterProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via OpenRouter."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, ≥100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/together_provider.py
+++ b/src/career_os/ai/together_provider.py
@@ -11,7 +11,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -136,7 +136,7 @@ class TogetherProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the Together.ai API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/ai/xai_provider.py
+++ b/src/career_os/ai/xai_provider.py
@@ -15,7 +15,7 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
     _system_prompt_for_feature,
@@ -149,7 +149,7 @@ class XAIProvider(AIProvider):
     ) -> AIResponse:
         """Score a job against a profile via the xAI API."""
         prompt = (
-            f"Score this job against the candidate profile. "
+            ROLE_FIT_GATE_PROMPT + f"Score this job against the candidate profile. "
             f"Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
             f"estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
             f"readiness_score (0-100), career_alignment (0-10), "

--- a/src/career_os/schemas/ai.py
+++ b/src/career_os/schemas/ai.py
@@ -131,6 +131,32 @@ class DimensionalScores(BaseModel):
     company_fit: float = Field(..., ge=0, le=10)
 
 
+class RoleMatch(BaseModel):
+    """Explicit role-family match verdict (G-1335 halo fix).
+
+    Emitted *before* the ``fit_score`` so the model commits to a role-family
+    judgment with JD-grounded evidence first, rather than rationalizing a
+    holistic number after the fact. Used as a hard gate: a ``False`` verdict
+    caps ``fit_score`` in code, regardless of any dimensional scores or company
+    prestige.
+    """
+
+    is_same_role_family: bool = Field(
+        default=True,
+        description=(
+            "True only if the job's role/occupation is the same family as the candidate's "
+            "target job family (e.g. PM/TPM ≠ SWE/SRE/designer). Company prestige is irrelevant."
+        ),
+    )
+    evidence: str = Field(
+        default="",
+        description=(
+            "JD-grounded evidence for the verdict — the job's title and core responsibilities "
+            "compared against the candidate's target role."
+        ),
+    )
+
+
 ATSKeywordCategory = Literal["technical", "soft_skill", "tool", "certification", "domain"]
 
 
@@ -150,6 +176,25 @@ class ATSKeyword(BaseModel):
 
 class ScoreResult(BaseModel):
     """Structured scoring response."""
+
+    # Role-fit hard gate (G-1335). Declared first so a reason-before-score
+    # provider emits the role-family verdict + disqualifiers before the number.
+    # Both are optional/back-compat: legacy cached rows, the mock provider, and
+    # models that don't emit them leave the gate a no-op (treated as a pass).
+    role_match: RoleMatch | None = Field(
+        default=None,
+        description=(
+            "Explicit role-family gate verdict. None for legacy/cached responses "
+            "(treated as a pass — no cap applied)."
+        ),
+    )
+    disqualifiers: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Hard disqualifiers grounded in the JD: missing mandatory license/clearance/visa, "
+            "hard location conflict, or seniority off by >1 level. A non-empty list caps fit_score."
+        ),
+    )
 
     fit_score: float = Field(..., ge=0, le=10, description="Overall fit score 0-10")
     reasoning: str = Field(..., description="Detailed scoring explanation")
@@ -182,6 +227,42 @@ class ScoreResult(BaseModel):
         default=None,
         description="Reasoning for the desire score (what makes this job desirable/undesirable)",
     )
+
+
+# ---------------------------------------------------------------------------
+# Role-fit hard gate (G-1335) — the halo fix, enforced in code post-parse
+# ---------------------------------------------------------------------------
+
+# A role-family mismatch or a hard disqualifier caps the fit_score at this
+# ceiling *after parsing*, so the model cannot rationalize past it with a high
+# holistic number or a prestigious company. Chosen so gated jobs land in the
+# "D / poor fit" band (3.0-3.9) and can never be a "safe_bet"/"dream_job"
+# (quadrant threshold 5.0).
+ROLE_FIT_GATE_CEILING = 3.0
+
+
+def role_fit_gate_failed(result: ScoreResult) -> bool:
+    """Return True when the role-fit gate should fire for this result.
+
+    Fires when the model flagged a different role family, or reported any hard
+    disqualifier. Back-compat: ``role_match=None`` (legacy/cached/mock) is a
+    pass, and an empty ``disqualifiers`` list is a pass.
+    """
+    role_mismatch = result.role_match is not None and not result.role_match.is_same_role_family
+    return role_mismatch or bool(result.disqualifiers)
+
+
+def apply_role_fit_gate(result: ScoreResult) -> ScoreResult:
+    """Cap ``fit_score`` at :data:`ROLE_FIT_GATE_CEILING` when the gate fails.
+
+    Pure and idempotent: returns the input unchanged when the gate passes or the
+    score already sits at/below the ceiling; otherwise returns a copy with the
+    capped ``fit_score``. Only ``fit_score`` is touched — dimensional scores and
+    the desire axis are deliberately left intact (prestige belongs on desire).
+    """
+    if role_fit_gate_failed(result) and result.fit_score > ROLE_FIT_GATE_CEILING:
+        return result.model_copy(update={"fit_score": ROLE_FIT_GATE_CEILING})
+    return result
 
 
 class GapAnalysisResult(BaseModel):

--- a/src/career_os/services/async_batch.py
+++ b/src/career_os/services/async_batch.py
@@ -16,7 +16,7 @@ import logging
 from enum import StrEnum
 
 from career_os.ai.base import AIProvider
-from career_os.schemas.ai import ScoreResult
+from career_os.schemas.ai import ScoreResult, apply_role_fit_gate
 
 logger = logging.getLogger(__name__)
 
@@ -186,13 +186,15 @@ async def retrieve_batch_results(
             parsed.append(entry)
             continue
 
-        # structured is already a ScoreResult (parsed by the provider)
+        # structured is already a ScoreResult (parsed by the provider).
+        # Role-fit hard gate (G-1335): cap fit_score post-parse on the async
+        # Batch API path too, so prestige can't substitute for role fit there.
         if isinstance(structured, ScoreResult):
-            entry["score_result"] = structured
+            entry["score_result"] = apply_role_fit_gate(structured)
         else:
             # Try to coerce dict → ScoreResult
             try:
-                entry["score_result"] = ScoreResult(**structured)
+                entry["score_result"] = apply_role_fit_gate(ScoreResult(**structured))
             except Exception as exc:
                 entry["error"] = f"Failed to parse score result: {exc}"
 

--- a/src/career_os/services/batch_scoring.py
+++ b/src/career_os/services/batch_scoring.py
@@ -17,7 +17,7 @@ import random
 import re
 
 from career_os.ai.base import AIProvider
-from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult
+from career_os.schemas.ai import AIFeature, AIResponse, ScoreResult, apply_role_fit_gate
 
 logger = logging.getLogger(__name__)
 
@@ -100,10 +100,19 @@ def build_batch_prompt(
     jobs_section = "\n\n".join(job_blocks)
 
     prompt = (
-        f"Score each of the following {len(shuffled)} jobs against the candidate profile. "
+        f"Score each of the following {len(shuffled)} jobs against the candidate profile.\n"
+        f"Company prestige and a hot domain must NEVER substitute for role fit: a famous "
+        f"company hiring for the WRONG role family (e.g. a SWE/SRE/designer role for a "
+        f"PM/TPM candidate) is a poor FIT even if the candidate would love to work there. "
+        f"Reason before scoring, and list reasons to reject before reasons to hire.\n"
         f"Return a JSON ARRAY where each element is an object with:\n"
         f"- job_id (string matching the ID in the job header)\n"
-        f"- fit_score (0-10)\n"
+        f"- role_match (object: is_same_role_family (bool, true only if the job's role is the "
+        f"same family as the candidate's target job family), evidence (string)) — emit FIRST\n"
+        f"- disqualifiers (array of strings: missing mandatory license/clearance/visa, hard "
+        f"location conflict, or seniority off by >1 level; empty array if none)\n"
+        f"- fit_score (0-10; will be capped at 3 in code if role_match.is_same_role_family is "
+        f"false or disqualifiers is non-empty — score accordingly, do not inflate)\n"
         f"- reasoning (detailed, >=100 chars)\n"
         f"- estimated_salary (string)\n"
         f"- effort_flag (low/medium/high)\n"
@@ -217,7 +226,9 @@ def parse_batch_response(
             # and no job_id fields, map by position
             continue
         try:
-            score_result = ScoreResult.model_validate(item)
+            # Role-fit hard gate (G-1335): cap fit_score post-parse so company
+            # prestige can't substitute for role fit in the daily-scan batch path.
+            score_result = apply_role_fit_gate(ScoreResult.model_validate(item))
             results[job_id] = score_result
         except Exception as exc:
             logger.warning(
@@ -234,7 +245,7 @@ def parse_batch_response(
             if not isinstance(item, dict):
                 continue
             try:
-                score_result = ScoreResult.model_validate(item)
+                score_result = apply_role_fit_gate(ScoreResult.model_validate(item))
                 results[ordered_ids[idx]] = score_result
             except Exception as exc:
                 logger.warning(
@@ -340,7 +351,7 @@ async def batch_score_jobs(
                     profile_data=profile_data,
                 )
                 if response.structured and isinstance(response.structured, ScoreResult):
-                    all_results[str(job["id"])] = response.structured
+                    all_results[str(job["id"])] = apply_role_fit_gate(response.structured)
                 else:
                     logger.warning(
                         "Individual fallback for job %s did not return ScoreResult",

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -21,7 +21,13 @@ from career_os.models.discovery import DiscoveredJob
 from career_os.models.models import Application, Profile
 from career_os.models.scoring import ScoredJob, ScoringFeedback, ScoringWeights
 from career_os.models.skills import Goal, Skill
-from career_os.schemas.ai import ScoreResult
+from career_os.schemas.ai import (
+    ROLE_FIT_GATE_CEILING,
+    RoleMatch,
+    ScoreResult,
+    apply_role_fit_gate,
+    role_fit_gate_failed,
+)
 from career_os.services.red_flags import detect_data_driven_red_flags, detect_red_flags
 
 logger = logging.getLogger(__name__)
@@ -3135,6 +3141,28 @@ def _build_dim_columns(dim) -> dict[str, float | None]:
 # ---------------------------------------------------------------------------
 
 
+def _apply_role_fit_gate(score_data: ScoreResult) -> ScoreResult:
+    """Enforce the role-fit hard gate (G-1335), logging when it fires.
+
+    Thin logging wrapper over :func:`apply_role_fit_gate` so the service records
+    a cap event. The actual cap logic is a pure schema-layer function shared with
+    the multi-job batch path.
+    """
+    if role_fit_gate_failed(score_data) and score_data.fit_score > ROLE_FIT_GATE_CEILING:
+        reasons: list[str] = []
+        if score_data.role_match is not None and not score_data.role_match.is_same_role_family:
+            reasons.append("role-family mismatch")
+        if score_data.disqualifiers:
+            reasons.append(f"disqualifiers={score_data.disqualifiers}")
+        logger.info(
+            "Role-fit gate: capping fit_score %.2f → %.1f (%s)",
+            score_data.fit_score,
+            ROLE_FIT_GATE_CEILING,
+            ", ".join(reasons),
+        )
+    return apply_role_fit_gate(score_data)
+
+
 def _average_score_results(a: ScoreResult, b: ScoreResult) -> ScoreResult:
     """Average two ScoreResult objects to reduce borderline scoring variance.
 
@@ -3203,7 +3231,28 @@ def _average_score_results(a: ScoreResult, b: ScoreResult) -> ScoreResult:
     else:
         desire_score = primary.desire_score
 
+    # Carry forward the role-fit gate fields (G-1335), failing closed: if either
+    # pass flagged a role mismatch or any disqualifier, the merged result
+    # inherits it so the code-enforced cap still fires after averaging.
+    role_mismatch = any(
+        r.role_match is not None and not r.role_match.is_same_role_family for r in (a, b)
+    )
+    merged_role_match: RoleMatch | None = None
+    if a.role_match is not None or b.role_match is not None:
+        evidence = next(
+            (
+                r.role_match.evidence
+                for r in (primary, secondary)
+                if r.role_match is not None and r.role_match.evidence
+            ),
+            "",
+        )
+        merged_role_match = RoleMatch(is_same_role_family=not role_mismatch, evidence=evidence)
+    merged_disqualifiers = list(dict.fromkeys([*a.disqualifiers, *b.disqualifiers]))
+
     return ScoreResult(
+        role_match=merged_role_match,
+        disqualifiers=merged_disqualifiers,
         fit_score=avg_fit,
         readiness_score=avg_readiness,
         career_alignment=avg_career_alignment,
@@ -3296,6 +3345,11 @@ async def score_job(
     else:
         raise ScoringError("AI provider did not return a valid ScoreResult")
 
+    # Role-fit hard gate (G-1335): cap fit_score in code so company prestige +
+    # domain can never substitute for role fit. Applied before the borderline
+    # check so a gated (≤3) job also skips the extra second-pass AI call.
+    score_data = _apply_role_fit_gate(score_data)
+
     # Borderline 2-pass scoring (Epic 5 / G-273)
     # When the first-pass score falls in the borderline zone, run a second pass
     # and average the results to reduce variance (~50% reduction per research).
@@ -3339,6 +3393,11 @@ async def score_job(
                 exc,
                 score_data.fit_score,
             )
+
+    # Re-apply the role-fit gate after averaging — the merged result fails closed
+    # (inherits a mismatch/disqualifier flagged by either pass), so a borderline
+    # job that a second pass reveals as a role mismatch still gets capped.
+    score_data = _apply_role_fit_gate(score_data)
 
     # Serialize score_breakdown to JSON for storage
     breakdown_json = (
@@ -3527,6 +3586,11 @@ def _build_scoring_prompt(
 
     # Scoring rubric with calibration examples (G-269)
     parts.append(f"\n{SCORING_RUBRIC}")
+    # NB: the role-fit / anti-halo guardrails (G-1335) live in the provider
+    # score preamble (ai/base.ROLE_FIT_GATE_PROMPT), NOT here. Keeping them out
+    # of _build_scoring_prompt keeps the deterministic golden-set snapshot
+    # (which hashes this prompt) stable, while real providers still receive the
+    # guard via their own preamble.
     job_family = profile_data.get("job_family")
     family_modifiers = _build_job_family_modifiers(job_family)
     if family_modifiers:

--- a/tests/test_role_fit_gate.py
+++ b/tests/test_role_fit_gate.py
@@ -1,0 +1,531 @@
+"""Tests for the role-fit hard gate + company-prestige cap (G-1335, halo fix).
+
+Covers findings A-D from ``docs/research/2026-07_scoring-technique-audit.md``:
+
+- A: code-enforced cap — a wrong-role or disqualified job caps ``fit_score`` at 3
+  after parsing, regardless of high dimensional scores; genuine fits unchanged.
+- B/C/D: the scoring prompt scopes ``company_fit``, tiers dimensions, orders
+  reason-before-score, and carries a negative reference anchor.
+- Back-compat: legacy/cached/mock responses (no gate fields) leave the gate a
+  no-op, and the parse path accepts the fields when present and when absent.
+
+All validation is unit-level against the mock/deterministic providers — no paid
+LLM calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT
+from career_os.database import Base
+from career_os.models.models import Profile
+from career_os.schemas.ai import (
+    ROLE_FIT_GATE_CEILING,
+    ATSKeyword,
+    DimensionalScores,
+    RoleMatch,
+    ScoreBreakdownFactor,
+    ScoreResult,
+    apply_role_fit_gate,
+    role_fit_gate_failed,
+)
+from career_os.services.batch_scoring import build_batch_prompt, parse_batch_response
+from career_os.services.scoring import (
+    _apply_role_fit_gate,
+    _average_score_results,
+    _build_scoring_prompt,
+    score_job,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_score_result(
+    fit_score: float,
+    *,
+    role_match: RoleMatch | None = None,
+    disqualifiers: list[str] | None = None,
+    dimensional_high: bool = True,
+) -> ScoreResult:
+    """Build a valid ScoreResult with optionally high dimensional scores."""
+    dims = 9.0 if dimensional_high else fit_score
+    return ScoreResult(
+        role_match=role_match,
+        disqualifiers=disqualifiers or [],
+        fit_score=fit_score,
+        readiness_score=80.0,
+        career_alignment=8.0,
+        reasoning="A" * 120,
+        estimated_salary="$150k-$180k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="Prep note",
+        score_breakdown=[
+            ScoreBreakdownFactor(factor="technical_fit", contribution=3.0, description="d"),
+            ScoreBreakdownFactor(factor="company_fit", contribution=2.0, description="d"),
+            ScoreBreakdownFactor(factor="career", contribution=1.0, description="d"),
+        ],
+        dimensional_scores=DimensionalScores(
+            technical_fit=dims,
+            seniority_alignment=dims,
+            compensation_fit=dims,
+            location_fit=dims,
+            career_trajectory=dims,
+            company_fit=dims,
+        ),
+        ats_keywords=[ATSKeyword(keyword="Python", category="technical", matched=True)],
+        desire_score=9.0,
+        desire_reasoning="Dream company",
+    )
+
+
+def _make_ai_response(score_result: ScoreResult) -> MagicMock:
+    resp = MagicMock()
+    resp.structured = score_result
+    return resp
+
+
+@pytest.fixture
+def db_session() -> Session:
+    """Fresh in-memory SQLite session with a seeded TPM profile."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk_pragma(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    session_cls = sessionmaker(bind=connection, autocommit=False, autoflush=False)
+    session = session_cls()
+    session.add(
+        Profile(id=1, name="Test User", email="t@example.com", location="Berlin", job_family="TPM")
+    )
+    session.commit()
+
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Pure gate function (schema layer) — finding A
+# ---------------------------------------------------------------------------
+
+
+class TestRoleFitGateFailed:
+    """role_fit_gate_failed() truth table."""
+
+    def test_genuine_fit_passes(self):
+        assert role_fit_gate_failed(_make_score_result(8.5)) is False
+
+    def test_explicit_same_family_passes(self):
+        r = _make_score_result(8.5, role_match=RoleMatch(is_same_role_family=True, evidence="TPM"))
+        assert role_fit_gate_failed(r) is False
+
+    def test_role_mismatch_fails(self):
+        r = _make_score_result(
+            8.5, role_match=RoleMatch(is_same_role_family=False, evidence="SWE ≠ TPM")
+        )
+        assert role_fit_gate_failed(r) is True
+
+    def test_disqualifier_fails(self):
+        assert role_fit_gate_failed(_make_score_result(9.0, disqualifiers=["no work visa"])) is True
+
+    def test_none_role_match_is_backcompat_pass(self):
+        # Legacy/cached/mock rows leave role_match None → treated as a pass.
+        assert role_fit_gate_failed(_make_score_result(9.9)) is False
+
+
+class TestApplyRoleFitGate:
+    """apply_role_fit_gate() caps only when the gate fails."""
+
+    def test_genuine_high_fit_unchanged(self):
+        assert apply_role_fit_gate(_make_score_result(8.5)).fit_score == 8.5
+
+    def test_role_mismatch_capped_despite_high_dimensions(self):
+        r = _make_score_result(
+            8.5, role_match=RoleMatch(is_same_role_family=False), dimensional_high=True
+        )
+        capped = apply_role_fit_gate(r)
+        assert capped.fit_score == ROLE_FIT_GATE_CEILING == 3.0
+        # Dimensional scores untouched — the cap only touches fit_score.
+        assert capped.dimensional_scores.technical_fit == 9.0
+        # Desire axis untouched — prestige stays on desire, not fit.
+        assert capped.desire_score == 9.0
+
+    def test_disqualifier_capped(self):
+        r = _make_score_result(9.0, disqualifiers=["missing mandatory CPA license"])
+        assert apply_role_fit_gate(r).fit_score == 3.0
+
+    def test_already_below_ceiling_unchanged(self):
+        # A mismatch that already scored low is not raised or altered.
+        r = _make_score_result(2.0, role_match=RoleMatch(is_same_role_family=False))
+        assert apply_role_fit_gate(r).fit_score == 2.0
+
+    def test_backcompat_no_fields_unchanged(self):
+        assert apply_role_fit_gate(_make_score_result(9.9)).fit_score == 9.9
+
+    def test_idempotent(self):
+        r = _make_score_result(8.5, role_match=RoleMatch(is_same_role_family=False))
+        once = apply_role_fit_gate(r)
+        assert apply_role_fit_gate(once).fit_score == once.fit_score == 3.0
+
+    def test_service_wrapper_matches_pure(self):
+        r = _make_score_result(7.7, disqualifiers=["hard location conflict"])
+        assert _apply_role_fit_gate(r).fit_score == apply_role_fit_gate(r).fit_score == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Parse path / schema back-compat — finding A
+# ---------------------------------------------------------------------------
+
+
+class TestParsePathBackCompat:
+    """ScoreResult.model_validate accepts the new fields and defaults them."""
+
+    BASE = {
+        "fit_score": 8.0,
+        "reasoning": "R" * 120,
+        "estimated_salary": "$150k",
+        "effort_flag": "medium",
+        "prep_level": "moderate",
+        "prep_notes": "n",
+        "readiness_score": 80,
+        "career_alignment": 8,
+        "score_breakdown": [
+            {"factor": "a", "contribution": 1, "description": "d"},
+            {"factor": "b", "contribution": 1, "description": "d"},
+            {"factor": "c", "contribution": 1, "description": "d"},
+        ],
+    }
+
+    def test_absent_fields_default(self):
+        # Old cached response / mock provider payload — no gate fields.
+        result = ScoreResult.model_validate(self.BASE)
+        assert result.role_match is None
+        assert result.disqualifiers == []
+        assert apply_role_fit_gate(result).fit_score == 8.0
+
+    def test_present_fields_parse(self):
+        payload = {
+            **self.BASE,
+            "role_match": {"is_same_role_family": False, "evidence": "SWE role, TPM candidate"},
+            "disqualifiers": ["no EU work authorization"],
+        }
+        result = ScoreResult.model_validate(payload)
+        assert result.role_match is not None
+        assert result.role_match.is_same_role_family is False
+        assert result.role_match.evidence == "SWE role, TPM candidate"
+        assert result.disqualifiers == ["no EU work authorization"]
+        assert apply_role_fit_gate(result).fit_score == 3.0
+
+    def test_partial_role_match_defaults(self):
+        # Model emits role_match with only the bool — evidence defaults to "".
+        result = ScoreResult.model_validate(
+            {**self.BASE, "role_match": {"is_same_role_family": True}}
+        )
+        assert result.role_match.evidence == ""
+
+
+# ---------------------------------------------------------------------------
+# Averaging carries the gate fields fail-closed — finding A + G-273 interaction
+# ---------------------------------------------------------------------------
+
+
+class TestAverageCarriesGate:
+    def test_mismatch_from_either_pass_propagates(self):
+        clean = _make_score_result(6.0, role_match=RoleMatch(is_same_role_family=True))
+        mismatch = _make_score_result(5.0, role_match=RoleMatch(is_same_role_family=False))
+        merged = _average_score_results(clean, mismatch)
+        assert merged.role_match is not None
+        assert merged.role_match.is_same_role_family is False
+        # Gate then caps the averaged score.
+        assert apply_role_fit_gate(merged).fit_score == 3.0
+
+    def test_disqualifiers_unioned(self):
+        a = _make_score_result(6.0, disqualifiers=["no visa"])
+        b = _make_score_result(5.0, disqualifiers=["seniority off by 2 levels", "no visa"])
+        merged = _average_score_results(a, b)
+        assert set(merged.disqualifiers) == {"no visa", "seniority off by 2 levels"}
+
+    def test_both_clean_stays_clean(self):
+        a = _make_score_result(6.0, role_match=RoleMatch(is_same_role_family=True))
+        b = _make_score_result(5.0, role_match=RoleMatch(is_same_role_family=True))
+        merged = _average_score_results(a, b)
+        assert merged.role_match.is_same_role_family is True
+        assert apply_role_fit_gate(merged).fit_score == merged.fit_score == 5.5
+
+    def test_backcompat_none_both(self):
+        merged = _average_score_results(_make_score_result(6.0), _make_score_result(5.0))
+        assert merged.role_match is None
+        assert merged.disqualifiers == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through score_job (production path) — finding A
+# ---------------------------------------------------------------------------
+
+
+class TestScoreJobGate:
+    @pytest.mark.asyncio
+    async def test_wrong_role_capped_end_to_end(self, db_session: Session):
+        """A high-scoring wrong-role dream-company job persists fit_score ≤ 3."""
+        result = _make_score_result(
+            8.7, role_match=RoleMatch(is_same_role_family=False, evidence="SRE role, TPM candidate")
+        )
+        provider = AsyncMock()
+        provider.score.return_value = _make_ai_response(result)
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Site Reliability Engineer at a famous AI lab",
+                job_title="Senior SRE",
+                job_company="Anthropic",
+            )
+
+        assert scored.fit_score <= 3.0
+        # Capped below the borderline zone → no wasteful second pass.
+        assert provider.score.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_disqualified_capped_end_to_end(self, db_session: Session):
+        result = _make_score_result(9.2, disqualifiers=["requires active TS/SCI clearance"])
+        provider = AsyncMock()
+        provider.score.return_value = _make_ai_response(result)
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = False
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="TPM role requiring an active security clearance",
+                job_title="TPM",
+                job_company="DefenseCorp",
+            )
+
+        assert scored.fit_score <= 3.0
+
+    @pytest.mark.asyncio
+    async def test_genuine_fit_unchanged_end_to_end(self, db_session: Session):
+        """A genuine same-family fit is not capped."""
+        result = _make_score_result(
+            8.5, role_match=RoleMatch(is_same_role_family=True, evidence="TPM ↔ TPM")
+        )
+        provider = AsyncMock()
+        provider.score.return_value = _make_ai_response(result)
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = False
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Technical Program Manager, AI Platform",
+                job_title="TPM",
+                job_company="Anthropic",
+            )
+
+        assert scored.fit_score == 8.5
+
+    @pytest.mark.asyncio
+    async def test_backcompat_no_gate_fields_end_to_end(self, db_session: Session):
+        """A provider that omits gate fields (legacy/mock) scores normally."""
+        result = _make_score_result(8.5)  # role_match=None, disqualifiers=[]
+        provider = AsyncMock()
+        provider.score.return_value = _make_ai_response(result)
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = False
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            scored = await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Some role",
+                job_title="TPM",
+                job_company="Startup",
+            )
+
+        assert scored.fit_score == 8.5
+
+
+# ---------------------------------------------------------------------------
+# Batch path (daily scan) applies the gate — finding A
+# ---------------------------------------------------------------------------
+
+
+class TestBatchGate:
+    def _item(self, job_id: str, fit: float, **extra) -> dict:
+        base = {
+            "job_id": job_id,
+            "fit_score": fit,
+            "reasoning": "R" * 120,
+            "estimated_salary": "$150k",
+            "effort_flag": "medium",
+            "prep_level": "moderate",
+            "prep_notes": "n",
+            "readiness_score": 80,
+            "career_alignment": 8,
+            "score_breakdown": [
+                {"factor": "a", "contribution": 1, "description": "d"},
+                {"factor": "b", "contribution": 1, "description": "d"},
+                {"factor": "c", "contribution": 1, "description": "d"},
+            ],
+        }
+        base.update(extra)
+        return base
+
+    def test_batch_caps_role_mismatch(self):
+        import json
+
+        items = [
+            self._item("1", 9.0, role_match={"is_same_role_family": False, "evidence": "SWE"}),
+            self._item("2", 8.5),  # genuine, no gate fields
+        ]
+        parsed = parse_batch_response(json.dumps(items), ["1", "2"])
+        assert parsed["1"].fit_score == 3.0
+        assert parsed["2"].fit_score == 8.5
+
+    def test_batch_caps_disqualifier_positional(self):
+        import json
+
+        # No job_id fields → positional mapping path.
+        items = [
+            self._item("", 9.0, disqualifiers=["no visa"]),
+            self._item("", 7.0),
+        ]
+        for it in items:
+            del it["job_id"]
+        parsed = parse_batch_response(json.dumps(items), ["10", "20"])
+        assert parsed["10"].fit_score == 3.0
+        assert parsed["20"].fit_score == 7.0
+
+    def test_batch_prompt_instructs_gate(self):
+        prompt, _ = build_batch_prompt(
+            [{"id": 1, "title": "SWE", "company": "X", "description": "desc"}],
+            {"job_family": "TPM", "location": "Berlin"},
+        )
+        assert "role_match" in prompt
+        assert "is_same_role_family" in prompt
+        assert "disqualifiers" in prompt
+        assert "capped at 3" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Prompt guardrail content — findings B, C, D (lives in the provider preamble)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptGuardrails:
+    """The guardrails ship in ai.base.ROLE_FIT_GATE_PROMPT (provider preamble)."""
+
+    def test_emits_gate_fields(self):
+        p = ROLE_FIT_GATE_PROMPT
+        assert "role_match" in p
+        assert "is_same_role_family" in p
+        assert "disqualifiers" in p
+
+    def test_reason_before_score_and_weakness(self):
+        # Finding C: reason-before-score + required against/weakness note.
+        p = ROLE_FIT_GATE_PROMPT.lower()
+        assert "reason before you score" in p
+        assert "against" in p
+        assert "reject" in p
+
+    def test_company_fit_scoped_and_capped(self):
+        # Finding B: company_fit = culture/values/size only, ±1, prestige → desire.
+        p = ROLE_FIT_GATE_PROMPT
+        assert "±1" in p
+        assert "culture" in p.lower()
+        assert "prestige" in p.lower()
+        assert "desire" in p.lower()
+
+    def test_dimension_tiers_present(self):
+        # Finding B: primary technical + seniority, minor capped company_fit.
+        p = ROLE_FIT_GATE_PROMPT.lower()
+        assert "primary" in p
+        assert "technical_fit" in p
+        assert "seniority_alignment" in p
+
+    def test_negative_and_positive_anchors(self):
+        # Finding D: a strong-company/wrong-role negative anchor + a genuine high.
+        p = ROLE_FIT_GATE_PROMPT.lower()
+        assert "negative" in p
+        assert "positive" in p
+
+    def test_cap_ceiling_documented(self):
+        assert "capped at 3" in ROLE_FIT_GATE_PROMPT.lower()
+
+    def test_guard_absent_from_build_scoring_prompt(self):
+        # Golden-set stability invariant: _build_scoring_prompt must NOT carry the
+        # guard (the deterministic golden mock hashes its output). The guard
+        # reaches real models via the provider preamble instead.
+        prompt = _build_scoring_prompt(
+            job_description="A job",
+            job_title="Senior SRE",
+            job_company="Anthropic",
+            profile_data={"name": "T", "location": "Berlin", "job_family": "TPM", "weights": {}},
+        )
+        assert "is_same_role_family" not in prompt
+        assert "anti-halo" not in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_score_prepends_guard(self):
+        """A representative provider (Mistral) prepends the gate preamble to its
+        score prompt so real models receive it."""
+        from career_os.ai.mistral_provider import MistralProvider
+
+        provider = MistralProvider(api_key="test-key")
+        captured: dict = {}
+
+        async def _fake_complete(prompt, **kwargs):
+            captured["prompt"] = prompt
+            return MagicMock(structured=None)
+
+        with patch.object(provider, "complete", side_effect=_fake_complete):
+            await provider.score(
+                job_description="Some job description",
+                profile_data={"job_family": "TPM"},
+            )
+
+        assert captured["prompt"].startswith(ROLE_FIT_GATE_PROMPT)
+        assert "is_same_role_family" in captured["prompt"]


### PR DESCRIPTION
## What & why

Fixes the scoring **halo bug** (audit `docs/research/2026-07_scoring-technique-audit.md`, Tier 1, findings A–D): Kestrel's `fit_score` behaved like an OR/max over dimensions, so company prestige + domain **substituted for** role fit instead of being **gated by** it — wrong-role jobs at prestigious companies scored ~8. This ports the equivalent role-fit judgment already verified on the private Eyas fork (T1 dropped 629→47).

## The four changes

1. **Role-fit hard gate + code-enforced cap (A).** New schema fields `role_match{is_same_role_family, evidence}` and `disqualifiers[]` on `ScoreResult`. After parsing, `apply_role_fit_gate()` caps `fit_score` at **3** in Python when `is_same_role_family` is false or `disqualifiers` is non-empty — the model cannot rationalize past it. Only `fit_score` is touched; dimensional + desire axes are intact. Fields are optional/default → back-compat for old cached responses and the mock provider. Enforced in `score_job` (single), `parse_batch_response` (daily-scan 10/prompt), and the async Batch API path.
2. **Cap company_fit on FIT, move prestige to desire (B).** The provider preamble scopes `company_fit` to culture/values/size only (±1 max, never rescues a role mismatch), tiers the dimensions (technical+seniority primary), and directs prestige to `desire_score` (which already derives from `company_fit` — kept).
3. **Reason-before-score + weakness field (C).** Preamble orders evidence before the number, reasons-to-reject first, and requires a JD-grounded `against` note per dimension.
4. **Negative reference anchor (D).** A worked "strong company + wrong role → ~2/10" exemplar balanced with a genuine high-fit anchor.

The findings-B/C/D guardrails ship as `ai.base.ROLE_FIT_GATE_PROMPT`, prepended to every real provider's score preamble (anthropic single+batch, gemini, groq, huggingface, mistral, ollama, openrouter, together, xai) and the batch prompt — **deliberately not** in `_build_scoring_prompt`, because the deterministic golden-set mock hashes that prompt; keeping the guard in the preamble leaves the golden bands stable while real models still get it.

## Before / after behavior

| Job | Before | After |
|-----|--------|-------|
| Wrong-role role (SWE/SRE) at a prestigious/dream company | ~8 ("apply first") | ≤ 3 (poor fit); prestige → desire axis |
| Job with a hard disqualifier (missing license/clearance/visa, hard location conflict, seniority >1 level off) | high | ≤ 3 |
| Genuine same-role-family fit | unchanged | unchanged |
| Legacy/cached response or mock (no gate fields) | unchanged | unchanged (gate is a no-op) |

## Validation

Validated by **unit tests + mock provider + golden sets — no paid re-score.** New `tests/test_role_fit_gate.py` (34 tests): pure gate + back-compat parse + fail-closed averaging + end-to-end `score_job` + batch path + prompt guardrails. Full suite: **3776 passed, 25 skipped**; golden-set regression (6 job families) **unchanged / in-band**; `ruff check` + `ruff format --check` clean.

## Note

`openai_provider.py` is left untouched — it has a **pre-existing** broken import (`_scoring_user_prompt`, absent from openrouter) and is unimportable on `main`, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)