### PR TITLE
fix(G-1349): bump setuptools to >=83.0.0 (PYSEC-2026-3447)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.0", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -50,6 +50,11 @@ dev = [
     "pytest-timeout>=2.3.0",
     "ruff>=0.11.0",
     "httpx>=0.28.0",
+    # setuptools>=83.0.0 closes PYSEC-2026-3447 (advisory against <83.0.0). Declared
+    # here (not just build-system.requires) so `pip install -e .[dev]` upgrades it in
+    # the environment the CI `pip-audit` step scans. Remove the floor if a future
+    # advisory forces a different pin.
+    "setuptools>=83.0.0",
     # pandas 3.0 evaluation (G-251): blocked by python-jobspy which pins
     # pandas<3.0.0. Kestrel's own usage is compatible (tested), but the
     # transitive constraint prevents upgrading. Revisit when jobspy relaxes.


### PR DESCRIPTION
## What

A fresh advisory **PYSEC-2026-3447** hit `setuptools <83.0.0` after v0.20.0, so the strict CI `pip-audit` step now fails on **main and every open PR** (surfaced while merging G-1335 #452 — the tests themselves pass; only the security-audit step is red). Fix version **83.0.0** exists.

## Fix

- `[project.optional-dependencies].dev` → add `setuptools>=83.0.0`. `pip-audit` scans the env from `pip install -e .[dev]`, so the constraint must land here (bumping `build-system.requires` alone only affects build isolation, not the audited runtime env).
- `build-system.requires` → `setuptools>=83.0.0` for consistency.

Per the repo's own `.pip-audit-ignore` policy — suppress *only* when no upstream fix exists — a fix is available, so we bump rather than ignore.

## Verified

Locally: setuptools resolves to 83.0.0, `career_os` imports fine, and setuptools no longer appears in `pip-audit` findings. This unblocks main + all in-flight PRs (G-1335 and the rest of the scoring-v2 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)