### PR TITLE
feat(G-1336): scoring eval infrastructure — golden-set κ/NDCG + shadow-mode + drift canary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,21 @@ FEEDBACK_CALIBRATION_ENABLED=false
 # Number of jobs per prompt when using multi-job batch scoring.
 # Higher values save tokens but may slightly reduce quality (<2pp at 25-100).
 BATCH_SCORING_SIZE=10
+
+# -- Scoring Eval Infra (Scoring Engine v2 / G-1336) ----------------------
+# Shadow-mode: score each job a SECOND time with a distinct candidate provider
+# and log it (never surfaced) to compare against the live scorer before
+# promotion. Format: "<provider>" or "<provider>:<model>" (e.g. "mistral",
+# "anthropic:claude-opus-4"). Must differ from AI_PROVIDER (a self-comparison
+# no-ops). Runs fire-and-forget (no added live latency) but costs an extra
+# background LLM call per sampled job. Empty = off (default).
+SCORING_SHADOW_VARIANT=
+# Fraction (0.0–1.0) of scored jobs to shadow — the lever that bounds cost.
+SCORING_SHADOW_SAMPLE=1.0
+
+# Drift canary: nightly check that re-scores the golden set + computes score
+# PSI, alerting via Pushover only on the joint condition (PSI drift AND a κ/NDCG
+# drop). Run with `kestrel scoring drift-canary`. Off by default because
+# re-scoring with a live provider is a (small) paid op — keep AI_PROVIDER=mock
+# for a free, deterministic canary.
+DRIFT_CANARY_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
           alembic upgrade head
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short --cov=src/career_os --cov-report=xml
+        # Exclude the scoring golden-set eval (marker: eval) — it runs as a
+        # separate nightly gate (nightly.yml) so the fast unit run stays lean.
+        run: pytest tests/ -v --tb=short -m "not eval" --cov=src/career_os --cov-report=xml
 
       - name: Run tool-script tests
         # tools/ is dev tooling, not the shipped package, so these run as a

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,16 +9,41 @@ jobs:
   call-smoke:
     uses: ./.github/workflows/smoke.yml
 
+  scoring-eval:
+    name: Scoring golden-set eval (G-1336)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade 'pip>=26.0'
+          pip install -e ".[dev]"
+      - name: Run scoring eval (real score_job, mock provider — no paid LLM calls)
+        env:
+          AI_PROVIDER: mock
+        run: pytest tests/eval/ -v --tb=short -m eval
+
   nightly-status:
     name: Nightly health check
     runs-on: ubuntu-latest
-    needs: [call-smoke]
+    needs: [call-smoke, scoring-eval]
     if: always()
     steps:
       - name: Check results
         run: |
           if [ "${{ needs.call-smoke.result }}" = "failure" ]; then
             echo "::warning::Nightly smoke tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.scoring-eval.result }}" = "failure" ]; then
+            echo "::warning::Nightly scoring eval failed"
             exit 1
           fi
           echo "Nightly status: healthy"

--- a/alembic/versions/s1t2u3v4w5x6_add_shadow_scores_table.py
+++ b/alembic/versions/s1t2u3v4w5x6_add_shadow_scores_table.py
@@ -1,0 +1,63 @@
+"""Add shadow_scores table for scoring shadow-mode (G-1336, finding I).
+
+Revision ID: s1t2u3v4w5x6
+Revises: 18b5326c3da3
+Create Date: 2026-07-15 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "s1t2u3v4w5x6"
+down_revision: str | None = "18b5326c3da3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "shadow_scores",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("profile_id", sa.Integer(), nullable=False),
+        sa.Column("scored_job_id", sa.Integer(), nullable=True),
+        sa.Column("discovered_job_id", sa.Integer(), nullable=True),
+        sa.Column("variant", sa.String(length=100), nullable=False),
+        sa.Column("fit_score", sa.Float(), nullable=False),
+        sa.Column("desire_score", sa.Float(), nullable=True),
+        sa.Column("quadrant", sa.String(length=20), nullable=True),
+        sa.Column("primary_fit_score", sa.Float(), nullable=True),
+        sa.Column("dimensional_scores", sa.Text(), nullable=True),
+        sa.Column("reasoning", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["profile_id"], ["profiles.id"]),
+        sa.ForeignKeyConstraint(
+            ["scored_job_id"], ["scored_jobs.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["discovered_job_id"], ["discovered_jobs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_shadow_scores_profile_id"), "shadow_scores", ["profile_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_shadow_scores_scored_job_id"), "shadow_scores", ["scored_job_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_shadow_scores_discovered_job_id"),
+        "shadow_scores",
+        ["discovered_job_id"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_shadow_scores_variant"), "shadow_scores", ["variant"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_shadow_scores_variant"), table_name="shadow_scores")
+    op.drop_index(op.f("ix_shadow_scores_discovered_job_id"), table_name="shadow_scores")
+    op.drop_index(op.f("ix_shadow_scores_scored_job_id"), table_name="shadow_scores")
+    op.drop_index(op.f("ix_shadow_scores_profile_id"), table_name="shadow_scores")
+    op.drop_table("shadow_scores")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ dev = [
     "pandas>=2.2.0,<4",
     "python-jobspy>=1.1.82,<1.2",
     "fpdf2>=2.8.0",
+    # Dev-only oracle for the scoring eval harness (G-1336): the production
+    # metric math (weighted κ, NDCG, PSI) is pure-Python in
+    # career_os.services.scoring_eval — scikit-learn is used ONLY in
+    # tests/eval to cross-check those implementations against a reference.
+    # Not a runtime dependency; the shipped package never imports it.
+    "scikit-learn>=1.4",
 ]
 
 [project.scripts]
@@ -106,6 +112,12 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 timeout = 30
+markers = [
+    "eval: scoring golden-set agreement eval (G-1336) — runs nightly, excluded from the fast unit run",
+    "regression: golden-set fit-score band regression tests",
+    "property: property-based tests",
+    "fuzz: fuzzing tests",
+]
 
 [tool.coverage.run]
 # relative_files = true makes pytest-cov emit project-relative source paths in

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -129,6 +129,11 @@ from career_os.cli.warn import warn_app  # noqa: E402
 
 app.add_typer(warn_app, name="warn")
 
+# Scoring diagnostics subcommand group (Scoring Engine v2 / G-1336)
+from career_os.cli.scoring import scoring_app  # noqa: E402
+
+app.add_typer(scoring_app, name="scoring")
+
 
 # ---------------------------------------------------------------------------
 # Database helpers

--- a/src/career_os/cli/scoring.py
+++ b/src/career_os/cli/scoring.py
@@ -1,0 +1,133 @@
+"""CLI commands for scoring diagnostics (G-1336).
+
+Usage:
+    DRIFT_CANARY_ENABLED=true kestrel scoring drift-canary
+    DRIFT_CANARY_ENABLED=true kestrel scoring drift-canary --notify
+
+The drift canary re-scores the frozen golden set through the real production
+scorer and compares agreement (κ/NDCG) + score-distribution PSI against a stored
+baseline, alerting via Pushover only on the joint condition. It is gated behind
+``DRIFT_CANARY_ENABLED`` (off by default) and, by default, re-scores with the
+configured ``AI_PROVIDER`` — keep it ``mock`` (the default) for a free,
+deterministic check; point it at a real provider only when you deliberately want
+a live-model canary (a small paid op).
+
+Requires the golden eval harness under ``tests/eval`` (i.e. run from a repo
+checkout, as the nightly job does).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from career_os.database import SessionLocal
+
+console = Console()
+
+scoring_app = typer.Typer(
+    name="scoring",
+    help="Scoring diagnostics — drift canary and related checks.",
+    no_args_is_help=True,
+)
+
+
+@scoring_app.callback()
+def _scoring_main() -> None:
+    """Scoring diagnostics — drift canary and related checks."""
+    # Presence of a callback keeps this a subcommand GROUP (so `drift-canary` is
+    # a named subcommand) even while it has a single command today.
+
+
+def _golden_agreement() -> tuple[float, float, float, float]:
+    """Re-score the golden set (real ``score_job``) and return mean agreement.
+
+    Returns ``(kappa, ndcg, baseline_kappa, baseline_ndcg)`` averaged across the
+    golden families. Imports the eval harness lazily so the rest of the CLI does
+    not depend on ``tests/`` — raises ``ImportError`` when unavailable.
+    """
+    import tests.eval as eval_pkg
+    from tests.eval.harness import compute_agreement
+    from tests.eval.run_scoring import make_memory_session, score_fixture
+
+    baseline = json.loads((Path(eval_pkg.__file__).parent / "baseline_metrics.json").read_text())
+    metrics: dict = baseline["metrics"]
+
+    async def _measure() -> tuple[list[float], list[float]]:
+        kappas: list[float] = []
+        ndcgs: list[float] = []
+        for fixture_name in sorted(metrics):
+            db = make_memory_session()
+            try:
+                scored = await score_fixture(db, fixture_name)
+            finally:
+                db.close()
+            agreement = compute_agreement(fixture_name, scored)
+            kappas.append(agreement["kappa"])
+            ndcgs.append(agreement["ndcg@5"])
+        return kappas, ndcgs
+
+    kappas, ndcgs = asyncio.run(_measure())
+    baseline_kappas = [metrics[f]["kappa"] for f in sorted(metrics)]
+    baseline_ndcgs = [metrics[f]["ndcg@5"] for f in sorted(metrics)]
+
+    def _mean(xs: list[float]) -> float:
+        return sum(xs) / len(xs) if xs else 0.0
+
+    return _mean(kappas), _mean(ndcgs), _mean(baseline_kappas), _mean(baseline_ndcgs)
+
+
+@scoring_app.command("drift-canary")
+def drift_canary(
+    profile_id: int = typer.Option(1, "--profile-id", help="Profile to check PSI for."),
+    notify: bool = typer.Option(
+        False, "--notify", help="Send a Pushover alert on a joint drift trip."
+    ),
+) -> None:
+    """Run the scoring drift canary (gated by DRIFT_CANARY_ENABLED).
+
+    No-ops with a message when the flag is unset, so a scheduled invocation is
+    safe to leave wired. Never runs a live paid re-score unless AI_PROVIDER is
+    deliberately pointed at a real provider.
+    """
+    from career_os.config import settings
+    from career_os.services.drift_canary import drift_canary_check
+
+    if not settings.drift_canary_enabled:
+        console.print("[yellow]Drift canary disabled[/] — set DRIFT_CANARY_ENABLED=true to run it.")
+        raise typer.Exit(0)
+
+    try:
+        agreement_fn = _golden_agreement
+        # Resolve the harness eagerly so a missing checkout fails before scoring.
+        import tests.eval  # noqa: F401
+    except ImportError:
+        console.print(
+            "[red]Golden eval harness unavailable[/] — run the drift canary from a repo "
+            "checkout (tests/eval must be importable)."
+        )
+        raise typer.Exit(1) from None
+
+    db = SessionLocal()
+    try:
+        result = drift_canary_check(db, profile_id, agreement_fn=agreement_fn, notify=notify)
+    finally:
+        db.close()
+
+    psi = result.get("psi")
+    console.print(
+        f"[bold]Drift canary[/]: status={result['status']} "
+        f"alert={result.get('alert')} notified={result.get('notified')}"
+    )
+    console.print(
+        f"  PSI={psi if psi is None else f'{psi:.3f}'} "
+        f"κ={result.get('kappa'):.3f} NDCG@5={result.get('ndcg'):.3f}"
+        if result.get("status") == "ran"
+        else f"  {result.get('reason', '')}"
+    )
+    if result.get("alert"):
+        console.print(f"[red]⚠️  {result['reason']}[/]")

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -83,6 +83,24 @@ class Settings(BaseSettings):
     borderline_low_threshold: float = 4.0
     borderline_high_threshold: float = 6.5
 
+    # Scoring shadow-mode (Scoring Engine v2 / G-1336, finding I) — when set to a
+    # non-empty variant label, every production scoring call ALSO scores the job
+    # with a candidate rubric/model in parallel and logs the result to the
+    # ``shadow_scores`` table. Shadow scores are NEVER surfaced to the user; they
+    # exist only to compare a candidate change against the live scorer on real
+    # production jobs before promotion. Mirrors the G-272 embedding-shadow pattern.
+    # Opt-in and empty by default (a live shadow variant means an extra paid LLM
+    # call per job — see the COST guardrail). The variant string is free-form and
+    # recorded verbatim (e.g. "0to5-scale", "mistral-large", "rubric-v2").
+    scoring_shadow_variant: str = ""
+
+    # Drift canary (Scoring Engine v2 / G-1336, finding J) — nightly-style check
+    # that computes PSI of the score distribution vs a rolling baseline and
+    # re-scores the frozen golden set, alerting via Pushover ONLY on the joint
+    # condition (PSI drift AND a κ/NDCG agreement drop). Opt-in because re-scoring
+    # the golden set with the live provider is a (small) paid op — off by default.
+    drift_canary_enabled: bool = False
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     # Per-provider API key requirements: provider → (settings_attr, expected_prefix).

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -83,16 +83,22 @@ class Settings(BaseSettings):
     borderline_low_threshold: float = 4.0
     borderline_high_threshold: float = 6.5
 
-    # Scoring shadow-mode (Scoring Engine v2 / G-1336, finding I) — when set to a
-    # non-empty variant label, every production scoring call ALSO scores the job
-    # with a candidate rubric/model in parallel and logs the result to the
-    # ``shadow_scores`` table. Shadow scores are NEVER surfaced to the user; they
-    # exist only to compare a candidate change against the live scorer on real
-    # production jobs before promotion. Mirrors the G-272 embedding-shadow pattern.
-    # Opt-in and empty by default (a live shadow variant means an extra paid LLM
-    # call per job — see the COST guardrail). The variant string is free-form and
-    # recorded verbatim (e.g. "0to5-scale", "mistral-large", "rubric-v2").
+    # Scoring shadow-mode (Scoring Engine v2 / G-1336, finding I) — when set,
+    # production scoring ALSO scores the job with a DISTINCT candidate provider
+    # and logs it to the ``shadow_scores`` table (never surfaced), so a candidate
+    # can be measured against the live scorer on real jobs before promotion.
+    # Format: "<provider>" or "<provider>:<model>" (e.g. "mistral",
+    # "anthropic:claude-opus-4"); it must resolve to a provider DIFFERENT from the
+    # live one (a self-comparison no-ops). The shadow runs fire-and-forget on its
+    # own task/session, so it adds NO latency to the live score — but it DOES cost
+    # an extra background LLM call per sampled job (see the COST guardrail). Empty
+    # (off) by default; bound the spend with SCORING_SHADOW_SAMPLE.
     scoring_shadow_variant: str = ""
+
+    # Fraction (0.0–1.0) of scored jobs to shadow when scoring_shadow_variant is
+    # set. 1.0 = every job (default), 0.1 = ~10% — the lever that bounds shadow
+    # cost on high-volume runs.
+    scoring_shadow_sample: float = 1.0
 
     # Drift canary (Scoring Engine v2 / G-1336, finding J) — nightly-style check
     # that computes PSI of the score distribution vs a rolling baseline and

--- a/src/career_os/models/__init__.py
+++ b/src/career_os/models/__init__.py
@@ -27,6 +27,7 @@ from career_os.models.pushover import NotificationLog, NotificationPreference
 from career_os.models.scoring import (
     ScoredJob,
     ScoringWeights,
+    ShadowScore,
 )
 from career_os.models.skills import (
     CoachingSuggestion,
@@ -68,6 +69,7 @@ __all__ = [
     "Profile",
     "ScoredJob",
     "ScoringWeights",
+    "ShadowScore",
     "SearchProfile",
     "Skill",
     "SkillHistory",

--- a/src/career_os/models/scoring.py
+++ b/src/career_os/models/scoring.py
@@ -144,6 +144,62 @@ class ScoredJob(Base):
         )
 
 
+class ShadowScore(Base):
+    """A candidate-variant score logged in parallel with the live scorer.
+
+    Scoring Engine v2 (G-1336, finding I): when ``SCORING_SHADOW_VARIANT`` is
+    set, every production scoring call ALSO scores the job with a candidate
+    rubric/model and records the result here. Shadow scores are **never**
+    surfaced to the user — they exist only to compare a candidate change against
+    the live scorer on real production jobs before promotion. Mirrors the G-272
+    embedding-shadow pattern ("measure on production, not a proxy").
+
+    ``primary_fit_score`` snapshots the live score at the same instant so the
+    prod-vs-shadow delta needs no join back to ``scored_jobs``.
+    """
+
+    __tablename__ = "shadow_scores"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+    )
+    # Nullable + ondelete SET NULL so pruning a live score never drops the
+    # shadow audit trail, and so a shadow can be logged even when the primary
+    # score is not persisted (e.g. offline comparator runs).
+    scored_job_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("scored_jobs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    discovered_job_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("discovered_jobs.id"), nullable=True, index=True
+    )
+
+    # Free-form variant label (e.g. "0to5-scale", "mistral-large", "rubric-v2").
+    variant: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    # Candidate-variant scores.
+    fit_score: Mapped[float] = mapped_column(Float, nullable=False)
+    desire_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    quadrant: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # Snapshot of the live score at logging time (for a join-free prod-vs-shadow diff).
+    primary_fit_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Full candidate breakdown + reasoning (JSON / text) for later inspection.
+    dimensional_scores: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ShadowScore(id={self.id}, variant='{self.variant}', "
+            f"fit_score={self.fit_score}, profile_id={self.profile_id})>"
+        )
+
+
 class ScoringFeedback(Base):
     """User feedback on an AI-generated score.
 

--- a/src/career_os/services/drift_canary.py
+++ b/src/career_os/services/drift_canary.py
@@ -1,0 +1,207 @@
+"""Scoring drift canary — guard against silent score rot.
+
+Scoring Engine v2 (G-1336, finding J). A provider can swap the model behind an
+OpenRouter slug with zero code change on our side and quietly rot every score.
+The canary catches that by watching two independent signals and paging **only
+when both move together** (so a benign shift in the day's job mix never wakes
+anyone):
+
+1. **PSI** — Population Stability Index of the recent ``fit_score`` distribution
+   vs a rolling baseline window (pure-Python, :mod:`career_os.services.scoring_eval`).
+2. **Agreement** — weighted Cohen's κ and NDCG@5 of a re-score of the frozen
+   golden set vs its labels, compared to a stored baseline.
+
+The alert fires on the JOINT condition: ``PSI > threshold`` **and** a κ/NDCG
+drop beyond tolerance. Alerts reuse the existing Pushover integration.
+
+This module is opt-in (``DRIFT_CANARY_ENABLED``) and is invoked by a nightly job
+or CLI, not an always-on loop — re-scoring the golden set with the live provider
+is a small but real paid op, so it is never triggered implicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from career_os.models.scoring import ScoredJob
+from career_os.services.scoring_eval import (
+    DEFAULT_SCORE_BINS,
+    PSI_SIGNIFICANT_SHIFT,
+    psi_from_scores,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default agreement-drop tolerances (absolute, vs the stored baseline). A drop
+# larger than this — together with PSI drift — trips the canary.
+DEFAULT_KAPPA_DROP_TOLERANCE = 0.10
+DEFAULT_NDCG_DROP_TOLERANCE = 0.05
+
+
+def evaluate_drift(
+    *,
+    psi: float,
+    kappa: float,
+    ndcg: float,
+    baseline_kappa: float,
+    baseline_ndcg: float,
+    psi_threshold: float = PSI_SIGNIFICANT_SHIFT,
+    kappa_drop_tolerance: float = DEFAULT_KAPPA_DROP_TOLERANCE,
+    ndcg_drop_tolerance: float = DEFAULT_NDCG_DROP_TOLERANCE,
+) -> dict:
+    """Decide whether the drift canary should alert (pure decision logic).
+
+    Alerts only on the JOINT condition: a significant distribution shift AND a
+    meaningful agreement drop. Returns a structured verdict dict.
+    """
+    distribution_drift = psi > psi_threshold
+    kappa_drop = kappa < baseline_kappa - kappa_drop_tolerance
+    ndcg_drop = ndcg < baseline_ndcg - ndcg_drop_tolerance
+    agreement_drop = kappa_drop or ndcg_drop
+
+    alert = distribution_drift and agreement_drop
+
+    reasons: list[str] = []
+    if distribution_drift:
+        reasons.append(f"PSI {psi:.3f} > {psi_threshold}")
+    if kappa_drop:
+        reasons.append(f"κ {kappa:.3f} < baseline {baseline_kappa:.3f} − {kappa_drop_tolerance}")
+    if ndcg_drop:
+        reasons.append(f"NDCG@5 {ndcg:.3f} < baseline {baseline_ndcg:.3f} − {ndcg_drop_tolerance}")
+
+    if alert:
+        reason = "JOINT drift+agreement drop: " + "; ".join(reasons)
+    elif distribution_drift:
+        reason = "Distribution shifted but agreement held — not alerting (benign job-mix change)"
+    elif agreement_drop:
+        reason = "Agreement dropped but distribution stable — not alerting (needs joint signal)"
+    else:
+        reason = "Stable"
+
+    return {
+        "psi": psi,
+        "kappa": kappa,
+        "ndcg": ndcg,
+        "distribution_drift": distribution_drift,
+        "agreement_drop": agreement_drop,
+        "alert": alert,
+        "reason": reason,
+    }
+
+
+def compute_score_psi(
+    db: Session,
+    profile_id: int,
+    *,
+    baseline_days: int = 30,
+    recent_days: int = 1,
+    min_samples: int = 20,
+    edges: tuple[float, ...] = DEFAULT_SCORE_BINS,
+    now: datetime | None = None,
+) -> float | None:
+    """PSI of the recent ``fit_score`` distribution vs a rolling baseline window.
+
+    ``recent`` = scores created in the last ``recent_days``; ``baseline`` = scores
+    from the preceding ``baseline_days``. Returns ``None`` when either window has
+    fewer than ``min_samples`` scores (not enough signal to judge drift).
+    """
+    ref_now = now or datetime.now(UTC)
+    recent_start = ref_now - timedelta(days=recent_days)
+    baseline_start = recent_start - timedelta(days=baseline_days)
+
+    def _scores(lo: datetime, hi: datetime) -> list[float]:
+        rows = (
+            db.query(ScoredJob.fit_score)
+            .filter(
+                ScoredJob.profile_id == profile_id,
+                ScoredJob.created_at >= lo,
+                ScoredJob.created_at < hi,
+            )
+            .all()
+        )
+        return [r[0] for r in rows]
+
+    recent = _scores(recent_start, ref_now)
+    baseline = _scores(baseline_start, recent_start)
+
+    if len(recent) < min_samples or len(baseline) < min_samples:
+        logger.info(
+            "Drift canary: insufficient samples (baseline=%d, recent=%d, need %d) — skipping PSI",
+            len(baseline),
+            len(recent),
+            min_samples,
+        )
+        return None
+
+    return psi_from_scores(baseline, recent, edges=edges)
+
+
+def run_drift_canary(
+    db: Session,
+    profile_id: int,
+    *,
+    kappa: float,
+    ndcg: float,
+    baseline_kappa: float,
+    baseline_ndcg: float,
+    psi: float | None = None,
+    notify: bool = True,
+    psi_threshold: float = PSI_SIGNIFICANT_SHIFT,
+    kappa_drop_tolerance: float = DEFAULT_KAPPA_DROP_TOLERANCE,
+    ndcg_drop_tolerance: float = DEFAULT_NDCG_DROP_TOLERANCE,
+) -> dict:
+    """Run the drift canary and (optionally) send a Pushover alert on a joint trip.
+
+    ``kappa``/``ndcg`` are the freshly-measured golden-set agreement metrics (the
+    caller re-scores the frozen golden set through the real production path). If
+    ``psi`` is not supplied it is computed from stored scores via
+    :func:`compute_score_psi`; when there is not enough data to compute PSI, the
+    canary reports ``skipped`` and never alerts (the joint condition needs it).
+    """
+    if psi is None:
+        psi = compute_score_psi(db, profile_id)
+
+    if psi is None:
+        result = {
+            "psi": None,
+            "kappa": kappa,
+            "ndcg": ndcg,
+            "distribution_drift": False,
+            "agreement_drop": False,
+            "alert": False,
+            "reason": "Insufficient score history to compute PSI — skipped",
+            "notified": False,
+        }
+        return result
+
+    result = evaluate_drift(
+        psi=psi,
+        kappa=kappa,
+        ndcg=ndcg,
+        baseline_kappa=baseline_kappa,
+        baseline_ndcg=baseline_ndcg,
+        psi_threshold=psi_threshold,
+        kappa_drop_tolerance=kappa_drop_tolerance,
+        ndcg_drop_tolerance=ndcg_drop_tolerance,
+    )
+
+    notified = False
+    if result["alert"] and notify:
+        from career_os.services.pushover import send_drift_alert
+
+        send_result = send_drift_alert(
+            db,
+            profile_id=profile_id,
+            psi=psi,
+            kappa=kappa,
+            ndcg=ndcg,
+            reason=result["reason"],
+        )
+        notified = send_result.get("status") == "sent"
+        logger.warning("Drift canary ALERT for profile %d: %s", profile_id, result["reason"])
+
+    result["notified"] = notified
+    return result

--- a/src/career_os/services/drift_canary.py
+++ b/src/career_os/services/drift_canary.py
@@ -22,10 +22,12 @@ is a small but real paid op, so it is never triggered implicitly.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
+from career_os.config import settings
 from career_os.models.scoring import ScoredJob
 from career_os.services.scoring_eval import (
     DEFAULT_SCORE_BINS,
@@ -204,4 +206,44 @@ def run_drift_canary(
         logger.warning("Drift canary ALERT for profile %d: %s", profile_id, result["reason"])
 
     result["notified"] = notified
+    return result
+
+
+# Returns (kappa, ndcg, baseline_kappa, baseline_ndcg) — the fresh golden-set
+# agreement plus its stored baseline. Injected so this service never imports the
+# eval harness (which lives under tests/); the CLI supplies the real function.
+AgreementFn = Callable[[], tuple[float, float, float, float]]
+
+
+def drift_canary_check(
+    db: Session,
+    profile_id: int = 1,
+    *,
+    agreement_fn: AgreementFn,
+    notify: bool = True,
+) -> dict:
+    """Flag-gated entrypoint for the nightly/CLI drift canary.
+
+    Returns ``{"status": "disabled", ...}`` and does NO work (``agreement_fn`` is
+    never called → no re-score, no paid op) unless ``DRIFT_CANARY_ENABLED`` is
+    set. When enabled it measures the golden-set agreement via ``agreement_fn``
+    and runs :func:`run_drift_canary`, alerting on a joint trip.
+    """
+    if not settings.drift_canary_enabled:
+        return {
+            "status": "disabled",
+            "reason": "DRIFT_CANARY_ENABLED is false — set it to run the canary",
+        }
+
+    kappa, ndcg, baseline_kappa, baseline_ndcg = agreement_fn()
+    result = run_drift_canary(
+        db,
+        profile_id,
+        kappa=kappa,
+        ndcg=ndcg,
+        baseline_kappa=baseline_kappa,
+        baseline_ndcg=baseline_ndcg,
+        notify=notify,
+    )
+    result["status"] = "ran"
     return result

--- a/src/career_os/services/pushover.py
+++ b/src/career_os/services/pushover.py
@@ -940,6 +940,51 @@ def send_credits_exhausted_alert(
 
 
 # ---------------------------------------------------------------------------
+# Alert: scoring drift canary (G-1336, finding J)
+# ---------------------------------------------------------------------------
+
+
+def send_drift_alert(
+    db: Session,
+    *,
+    profile_id: int,
+    psi: float,
+    kappa: float,
+    ndcg: float,
+    reason: str,
+) -> dict:
+    """Send a high-priority alert when the scoring drift canary trips.
+
+    Fired only on the joint condition (distribution drift AND an agreement drop)
+    so a benign shift in job mix does not page. Gracefully no-ops when Pushover
+    is not configured.
+    """
+    try:
+        client = _get_pushover_client(db)
+    except PushoverNotConfiguredError:
+        return {"status": "skipped", "reason": "pushover not configured"}
+
+    title = "⚠️ Scoring Drift Detected"
+    message = (
+        f"The scoring drift canary tripped.\n"
+        f"PSI: {psi:.3f} (distribution shift)\n"
+        f"Weighted κ: {kappa:.3f} · NDCG@5: {ndcg:.3f}\n"
+        f"{reason}\n\n"
+        f"A model/rubric change may have rotted scores — review before trusting new scores."
+    )
+
+    return _send_and_log(
+        db,
+        client,
+        profile_id=profile_id,
+        category="scoring",
+        title=title,
+        message=message,
+        priority=PRIORITY_HIGH,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test Pushover connection (with actual API call)
 # ---------------------------------------------------------------------------
 

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3497,19 +3497,21 @@ async def score_job(
     db.refresh(scored_job)
 
     # Shadow-mode (G-1336, finding I): when SCORING_SHADOW_VARIANT is set, score
-    # this same job with a candidate variant and log it beside the live score —
-    # never surfaced, fully defensive (a shadow failure never breaks live scoring).
+    # this same job with a DISTINCT candidate provider/model and log it beside the
+    # live score — never surfaced. Fire-and-forget (its own task + DB session) so
+    # it adds no latency to the live score, and fully defensive (a shadow failure
+    # never breaks live scoring). No-ops cleanly if the variant can't resolve.
     if settings.scoring_shadow_variant.strip():
-        from career_os.services.scoring_shadow import maybe_record_shadow_score
+        from career_os.services.scoring_shadow import schedule_shadow_score
 
-        await maybe_record_shadow_score(
-            db,
+        schedule_shadow_score(
             profile_id=profile_id,
             prompt=prompt,
             profile_data=profile_data,
             primary_fit_score=score_data.fit_score,
             scored_job_id=scored_job.id,
             discovered_job_id=discovered_job_id,
+            live_provider_name=provider.name,
         )
 
     return scored_job

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3496,6 +3496,22 @@ async def score_job(
     db.commit()
     db.refresh(scored_job)
 
+    # Shadow-mode (G-1336, finding I): when SCORING_SHADOW_VARIANT is set, score
+    # this same job with a candidate variant and log it beside the live score —
+    # never surfaced, fully defensive (a shadow failure never breaks live scoring).
+    if settings.scoring_shadow_variant.strip():
+        from career_os.services.scoring_shadow import maybe_record_shadow_score
+
+        await maybe_record_shadow_score(
+            db,
+            profile_id=profile_id,
+            prompt=prompt,
+            profile_data=profile_data,
+            primary_fit_score=score_data.fit_score,
+            scored_job_id=scored_job.id,
+            discovered_job_id=discovered_job_id,
+        )
+
     return scored_job
 
 

--- a/src/career_os/services/scoring_eval.py
+++ b/src/career_os/services/scoring_eval.py
@@ -1,0 +1,241 @@
+"""Scoring evaluation metrics — agreement, ranking, and drift primitives.
+
+Job-fit scoring is a *ranking* problem, not a regression problem (see
+``docs/research/2026-07_scoring-technique-audit.md``, finding H). We therefore
+evaluate the production scorer on **rank/quadrant agreement** against labeled
+reference data — never on MAE-to-a-reference-model.
+
+This module holds the pure-Python metric primitives shared by the golden-set
+eval harness (``tests/eval/``), the shadow-mode comparator
+(``scoring_shadow.py``), and the drift canary (``drift_canary.py``):
+
+* :func:`weighted_cohen_kappa` — inter-rater agreement on an ordinal tier
+  (linear weights), matching ``sklearn.metrics.cohen_kappa_score(weights="linear")``.
+* :func:`ndcg_at_k` — ranking quality, matching ``sklearn.metrics.ndcg_score``
+  (linear gains, ``log2`` discount).
+* :func:`population_stability_index` — distribution drift (PSI), the standard
+  ``sum((a - e) * ln(a / e))`` over bins.
+
+They are implemented in the standard library (``math`` only) so nothing in the
+production import path depends on numpy/scikit-learn. ``scikit-learn`` is a
+dev-only test oracle: ``tests/eval`` cross-checks these implementations against
+it on toy data with analytically known values.
+"""
+
+from __future__ import annotations
+
+import math
+
+# ---------------------------------------------------------------------------
+# Ordinal fit tiers — the categorical axis for agreement (κ)
+# ---------------------------------------------------------------------------
+
+# The golden sets label each job with one of these four ordinal categories
+# (weakest → strongest). We compare the production ``fit_score`` against the
+# label by projecting the 0–10 score into the same ordinal tier.
+TIER_ORDER: tuple[str, ...] = ("reject", "mediocre", "strong", "dream")
+_TIER_INDEX: dict[str, int] = {name: i for i, name in enumerate(TIER_ORDER)}
+
+# fit_score → tier bin edges (upper-exclusive except the last). Chosen so the
+# role-fit gate ceiling (3.0) and the quadrant threshold (5.0) fall on natural
+# tier boundaries: gated jobs land in "reject", quadrant-positive jobs in
+# "strong"/"dream".
+_TIER_EDGES: tuple[tuple[float, str], ...] = (
+    (3.5, "reject"),
+    (5.0, "mediocre"),
+    (8.0, "strong"),
+    (10.0001, "dream"),
+)
+
+
+def tier_from_fit_score(fit_score: float) -> str:
+    """Project a 0–10 ``fit_score`` into an ordinal :data:`TIER_ORDER` tier."""
+    for upper, name in _TIER_EDGES:
+        if fit_score < upper:
+            return name
+    return TIER_ORDER[-1]
+
+
+def tier_index(tier: str) -> int:
+    """Return the ordinal index (0–3) of a tier name."""
+    return _TIER_INDEX[tier]
+
+
+# ---------------------------------------------------------------------------
+# Weighted Cohen's kappa (linear weights)
+# ---------------------------------------------------------------------------
+
+
+def weighted_cohen_kappa(
+    y_true: list[int],
+    y_pred: list[int],
+    *,
+    num_classes: int | None = None,
+) -> float:
+    """Linearly-weighted Cohen's κ for ordinal labels.
+
+    Matches ``sklearn.metrics.cohen_kappa_score(y_true, y_pred, weights="linear")``.
+    Labels are 0-based ordinal class indices. Returns 1.0 for the degenerate
+    case where the disagreement weight vanishes (e.g. all raters pick one class),
+    consistent with perfect agreement.
+
+    Raises ``ValueError`` on length mismatch or empty input.
+    """
+    if len(y_true) != len(y_pred):
+        raise ValueError("y_true and y_pred must have equal length")
+    n = len(y_true)
+    if n == 0:
+        raise ValueError("cannot compute kappa on empty input")
+
+    k = num_classes if num_classes is not None else (max(max(y_true), max(y_pred)) + 1)
+    if k <= 1:
+        return 1.0
+
+    # Observed confusion matrix.
+    observed = [[0.0] * k for _ in range(k)]
+    for t, p in zip(y_true, y_pred, strict=True):
+        observed[t][p] += 1.0
+
+    row_totals = [sum(observed[i]) for i in range(k)]
+    col_totals = [sum(observed[i][j] for i in range(k)) for j in range(k)]
+
+    # Linear weight matrix: |i - j| / (k - 1).
+    denom_w = k - 1
+    num = 0.0
+    den = 0.0
+    for i in range(k):
+        for j in range(k):
+            w = abs(i - j) / denom_w
+            expected = row_totals[i] * col_totals[j] / n
+            num += w * observed[i][j]
+            den += w * expected
+
+    if den == 0.0:
+        return 1.0
+    return 1.0 - num / den
+
+
+def kappa_from_tiers(true_tiers: list[str], pred_tiers: list[str]) -> float:
+    """Weighted κ over :data:`TIER_ORDER` tier names."""
+    yt = [tier_index(t) for t in true_tiers]
+    yp = [tier_index(t) for t in pred_tiers]
+    return weighted_cohen_kappa(yt, yp, num_classes=len(TIER_ORDER))
+
+
+# ---------------------------------------------------------------------------
+# NDCG@k
+# ---------------------------------------------------------------------------
+
+
+def _dcg(relevances: list[float], k: int) -> float:
+    """Discounted cumulative gain with linear gains and log2 discount."""
+    total = 0.0
+    for rank, rel in enumerate(relevances[:k], start=1):
+        total += rel / math.log2(rank + 1)
+    return total
+
+
+def ndcg_at_k(
+    relevances: list[float],
+    scores: list[float],
+    *,
+    k: int = 5,
+) -> float:
+    """Normalized DCG@k for a single ranking.
+
+    ``relevances[i]`` is the ground-truth relevance grade of item ``i``;
+    ``scores[i]`` is the model score used to *rank* the items. Items are sorted
+    by descending score; ties break by original index (deterministic). Uses
+    linear gains and a ``log2(rank + 1)`` discount, matching
+    ``sklearn.metrics.ndcg_score([relevances], [scores], k=k)`` when scores are
+    distinct.
+
+    Returns 0.0 when the ideal DCG is 0 (all relevances zero).
+    """
+    if len(relevances) != len(scores):
+        raise ValueError("relevances and scores must have equal length")
+    if not relevances:
+        return 0.0
+
+    order = sorted(range(len(scores)), key=lambda i: (-scores[i], i))
+    ranked_rel = [relevances[i] for i in order]
+    ideal_rel = sorted(relevances, reverse=True)
+
+    idcg = _dcg(ideal_rel, k)
+    if idcg == 0.0:
+        return 0.0
+    return _dcg(ranked_rel, k) / idcg
+
+
+# ---------------------------------------------------------------------------
+# Population Stability Index (drift)
+# ---------------------------------------------------------------------------
+
+# Default score-distribution bins over the 0–10 fit-score range.
+DEFAULT_SCORE_BINS: tuple[float, ...] = (0.0, 2.0, 4.0, 5.0, 6.0, 8.0, 10.0001)
+
+# Standard PSI interpretation thresholds.
+PSI_MODERATE_SHIFT = 0.1
+PSI_SIGNIFICANT_SHIFT = 0.2
+
+
+def bin_counts(values: list[float], edges: tuple[float, ...] = DEFAULT_SCORE_BINS) -> list[int]:
+    """Bucket ``values`` into ``len(edges) - 1`` bins defined by ``edges``.
+
+    Values below the first edge fall in the first bin; values at/above the last
+    edge fall in the last bin.
+    """
+    counts = [0] * (len(edges) - 1)
+    for v in values:
+        placed = False
+        for b in range(len(edges) - 1):
+            if v < edges[b + 1]:
+                counts[b] += 1
+                placed = True
+                break
+        if not placed:
+            counts[-1] += 1
+    return counts
+
+
+def population_stability_index(
+    expected_counts: list[int],
+    actual_counts: list[int],
+    *,
+    epsilon: float = 1e-4,
+) -> float:
+    """Population Stability Index between two binned distributions.
+
+    ``PSI = Σ (a% - e%) * ln(a% / e%)`` over bins, where ``a%``/``e%`` are the
+    proportion of the actual/expected populations in each bin. ``epsilon`` floors
+    each proportion so empty bins do not blow up the logarithm. Rule of thumb:
+    ``< 0.1`` stable, ``0.1–0.2`` moderate shift, ``> 0.2`` significant shift.
+
+    Raises ``ValueError`` on bin-count mismatch or empty populations.
+    """
+    if len(expected_counts) != len(actual_counts):
+        raise ValueError("expected and actual must have the same number of bins")
+    e_total = sum(expected_counts)
+    a_total = sum(actual_counts)
+    if e_total == 0 or a_total == 0:
+        raise ValueError("cannot compute PSI on an empty distribution")
+
+    psi = 0.0
+    for e, a in zip(expected_counts, actual_counts, strict=True):
+        e_pct = max(e / e_total, epsilon)
+        a_pct = max(a / a_total, epsilon)
+        psi += (a_pct - e_pct) * math.log(a_pct / e_pct)
+    return psi
+
+
+def psi_from_scores(
+    baseline_scores: list[float],
+    current_scores: list[float],
+    *,
+    edges: tuple[float, ...] = DEFAULT_SCORE_BINS,
+) -> float:
+    """Convenience: PSI between two raw 0–10 score populations."""
+    return population_stability_index(
+        bin_counts(baseline_scores, edges),
+        bin_counts(current_scores, edges),
+    )

--- a/src/career_os/services/scoring_shadow.py
+++ b/src/career_os/services/scoring_shadow.py
@@ -1,0 +1,175 @@
+"""Scoring shadow-mode — log a candidate variant beside the live scorer.
+
+Scoring Engine v2 (G-1336, finding I). When ``SCORING_SHADOW_VARIANT`` is set,
+:func:`maybe_record_shadow_score` runs a *second*, candidate scoring pass on
+each real production job and writes it to the ``shadow_scores`` table. The
+shadow result is **never** surfaced to the user — it exists only so a candidate
+rubric/model can be measured against the live scorer on production traffic
+before promotion. This makes "measure on production, not a proxy" structurally
+unskippable and mirrors the G-272 embedding-shadow pattern.
+
+The comparator (:func:`compare_primary_vs_shadow`) scores prod-vs-shadow
+agreement against a labeled reference (the golden set) using the shared
+:mod:`career_os.services.scoring_eval` primitives.
+
+Design notes:
+* The hook is defensively wrapped — a shadow failure must never break the live
+  scoring path (it is a diagnostic side-channel).
+* By default the shadow reuses the active provider (a deterministic mock in
+  tests, so the eval stays free). A caller may inject a variant provider to
+  compare a different model/rubric; the variant label is recorded verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy.orm import Session
+
+from career_os.ai.base import AIProvider
+from career_os.ai.factory import get_ai_provider
+from career_os.config import settings
+from career_os.models.scoring import ShadowScore
+from career_os.schemas.ai import ScoreResult
+from career_os.schemas.scoring import classify_quadrant
+
+logger = logging.getLogger(__name__)
+
+
+async def record_shadow_score(
+    db: Session,
+    *,
+    profile_id: int,
+    variant: str,
+    prompt: str,
+    profile_data: dict,
+    primary_fit_score: float | None,
+    scored_job_id: int | None = None,
+    discovered_job_id: int | None = None,
+    provider: AIProvider | None = None,
+) -> ShadowScore | None:
+    """Score a job with a candidate variant and persist it to ``shadow_scores``.
+
+    Returns the persisted :class:`ShadowScore`, or ``None`` if the variant
+    provider did not return a usable structured result. Raises nothing that the
+    live path should care about — the caller wraps this defensively.
+    """
+    prov = provider if provider is not None else get_ai_provider()
+    response = await prov.score(job_description=prompt, profile_data=profile_data)
+
+    if not (response.structured and isinstance(response.structured, ScoreResult)):
+        logger.warning("Shadow variant %s returned no structured score — skipping log", variant)
+        return None
+
+    candidate: ScoreResult = response.structured
+    dims_json = (
+        json.dumps(candidate.dimensional_scores.model_dump())
+        if candidate.dimensional_scores is not None
+        else None
+    )
+    quadrant = classify_quadrant(candidate.fit_score, candidate.desire_score)
+
+    shadow = ShadowScore(
+        profile_id=profile_id,
+        scored_job_id=scored_job_id,
+        discovered_job_id=discovered_job_id,
+        variant=variant,
+        fit_score=candidate.fit_score,
+        desire_score=candidate.desire_score,
+        quadrant=quadrant,
+        primary_fit_score=primary_fit_score,
+        dimensional_scores=dims_json,
+        reasoning=candidate.reasoning,
+    )
+    db.add(shadow)
+    db.commit()
+    db.refresh(shadow)
+    logger.info(
+        "Shadow score logged (variant=%s): shadow=%.2f vs primary=%s",
+        variant,
+        candidate.fit_score,
+        f"{primary_fit_score:.2f}" if primary_fit_score is not None else "n/a",
+    )
+    return shadow
+
+
+async def maybe_record_shadow_score(
+    db: Session,
+    *,
+    profile_id: int,
+    prompt: str,
+    profile_data: dict,
+    primary_fit_score: float,
+    scored_job_id: int | None = None,
+    discovered_job_id: int | None = None,
+    provider: AIProvider | None = None,
+) -> ShadowScore | None:
+    """Log a shadow score iff ``SCORING_SHADOW_VARIANT`` is configured.
+
+    Fully defensive: any failure is logged and swallowed so shadow-mode can
+    never break live scoring. No-op (returns ``None``) when the setting is empty.
+    """
+    variant = settings.scoring_shadow_variant.strip()
+    if not variant:
+        return None
+    try:
+        return await record_shadow_score(
+            db,
+            profile_id=profile_id,
+            variant=variant,
+            prompt=prompt,
+            profile_data=profile_data,
+            primary_fit_score=primary_fit_score,
+            scored_job_id=scored_job_id,
+            discovered_job_id=discovered_job_id,
+            provider=provider,
+        )
+    except Exception:
+        db.rollback()
+        logger.warning(
+            "Shadow scoring failed (variant=%s) — live score unaffected", variant, exc_info=True
+        )
+        return None
+
+
+def compare_primary_vs_shadow(
+    primary_fit_scores: list[float],
+    shadow_fit_scores: list[float],
+    true_tiers: list[str],
+) -> dict:
+    """Compare live-vs-shadow scores against a labeled reference.
+
+    Given aligned primary/shadow fit scores for the same jobs and the reference
+    ``true_tiers`` (the golden-set labels), returns each variant's weighted κ
+    (tier agreement) and NDCG@5 (ranking) plus the deltas, so a candidate can be
+    judged *before* promotion.
+    """
+    from career_os.services.scoring_eval import (
+        kappa_from_tiers,
+        ndcg_at_k,
+        tier_from_fit_score,
+        tier_index,
+    )
+
+    if not (len(primary_fit_scores) == len(shadow_fit_scores) == len(true_tiers)):
+        raise ValueError("primary, shadow, and label lists must be aligned and equal length")
+
+    relevances = [float(tier_index(t)) for t in true_tiers]
+    primary_tiers = [tier_from_fit_score(s) for s in primary_fit_scores]
+    shadow_tiers = [tier_from_fit_score(s) for s in shadow_fit_scores]
+
+    primary_kappa = kappa_from_tiers(true_tiers, primary_tiers)
+    shadow_kappa = kappa_from_tiers(true_tiers, shadow_tiers)
+    primary_ndcg = ndcg_at_k(relevances, primary_fit_scores, k=5)
+    shadow_ndcg = ndcg_at_k(relevances, shadow_fit_scores, k=5)
+
+    return {
+        "n": len(true_tiers),
+        "primary": {"kappa": primary_kappa, "ndcg@5": primary_ndcg},
+        "shadow": {"kappa": shadow_kappa, "ndcg@5": shadow_ndcg},
+        "delta": {
+            "kappa": shadow_kappa - primary_kappa,
+            "ndcg@5": shadow_ndcg - primary_ndcg,
+        },
+    }

--- a/src/career_os/services/scoring_shadow.py
+++ b/src/career_os/services/scoring_shadow.py
@@ -1,40 +1,95 @@
 """Scoring shadow-mode — log a candidate variant beside the live scorer.
 
 Scoring Engine v2 (G-1336, finding I). When ``SCORING_SHADOW_VARIANT`` is set,
-:func:`maybe_record_shadow_score` runs a *second*, candidate scoring pass on
-each real production job and writes it to the ``shadow_scores`` table. The
-shadow result is **never** surfaced to the user — it exists only so a candidate
-rubric/model can be measured against the live scorer on production traffic
-before promotion. This makes "measure on production, not a proxy" structurally
-unskippable and mirrors the G-272 embedding-shadow pattern.
+`score_job` *schedules* a second, candidate scoring pass on the same production
+job and writes it to the ``shadow_scores`` table. The shadow result is **never**
+surfaced to the user — it exists only so a candidate model/rubric can be measured
+against the live scorer on production traffic before promotion. Mirrors the G-272
+embedding-shadow pattern ("measure on production, not a proxy").
 
-The comparator (:func:`compare_primary_vs_shadow`) scores prod-vs-shadow
-agreement against a labeled reference (the golden set) using the shared
-:mod:`career_os.services.scoring_eval` primitives.
+Two properties the review demanded and this module guarantees:
 
-Design notes:
-* The hook is defensively wrapped — a shadow failure must never break the live
-  scoring path (it is a diagnostic side-channel).
-* By default the shadow reuses the active provider (a deterministic mock in
-  tests, so the eval stays free). A caller may inject a variant provider to
-  compare a different model/rubric; the variant label is recorded verbatim.
+* **A real, distinct variant.** ``SCORING_SHADOW_VARIANT`` selects an actual
+  provider (``"mistral"``) or provider+model (``"mistral:mistral-large-latest"``)
+  via the AI factory. If it resolves to the *same* provider+model as the live
+  scorer (a self-comparison) or cannot be built, it **no-ops cleanly** — it never
+  compares the live model to itself.
+* **Zero added live latency.** The shadow runs **fire-and-forget** on its own
+  asyncio task with its own DB session, so enabling it never slows the live
+  score. It DOES cost an extra (background) LLM call per sampled job — bound the
+  spend with ``SCORING_SHADOW_SAMPLE`` (fraction 0–1). Off by default.
+
+Every entry point is fully defensive: a shadow failure is logged and swallowed.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
+import random
 
 from sqlalchemy.orm import Session
 
 from career_os.ai.base import AIProvider
 from career_os.ai.factory import get_ai_provider
 from career_os.config import settings
+from career_os.database import SessionLocal
 from career_os.models.scoring import ShadowScore
 from career_os.schemas.ai import ScoreResult
 from career_os.schemas.scoring import classify_quadrant
 
 logger = logging.getLogger(__name__)
+
+
+def build_shadow_provider(
+    variant: str,
+    *,
+    live_provider_name: str | None = None,
+) -> AIProvider | None:
+    """Resolve ``SCORING_SHADOW_VARIANT`` to a REAL, distinct provider.
+
+    ``variant`` is ``"<provider>"`` or ``"<provider>:<model>"`` (e.g.
+    ``"mistral"``, ``"anthropic:claude-opus-4"``). Returns the built provider, or
+    ``None`` when the variant is empty, names an unknown provider, fails to build
+    (e.g. missing API key), or would merely compare the live scorer to itself
+    (same provider name + no model override). ``None`` means "no shadow" — the
+    caller no-ops.
+    """
+    variant = (variant or "").strip()
+    if not variant:
+        return None
+
+    name, _, model = variant.partition(":")
+    name = name.strip().lower()
+    model = model.strip() or None
+
+    # Self-comparison guard: same provider and no model override → nothing to learn.
+    if live_provider_name and name == live_provider_name.strip().lower() and model is None:
+        logger.info(
+            "Shadow variant %r matches the live provider with no model override — skipping "
+            "(it would compare the model to itself)",
+            variant,
+        )
+        return None
+
+    try:
+        provider = get_ai_provider(name)
+    except Exception:
+        logger.warning("Shadow variant %r could not be resolved to a provider — skipping", variant)
+        return None
+
+    # Providers store the chat model as the private ``_model`` attribute (a
+    # shared convention across all provider classes); fall back to a public
+    # ``model`` for any that expose one.
+    if model is not None:
+        if hasattr(provider, "_model"):
+            provider._model = model
+        elif hasattr(provider, "model"):
+            provider.model = model  # type: ignore[attr-defined]
+
+    return provider
 
 
 async def record_shadow_score(
@@ -45,18 +100,16 @@ async def record_shadow_score(
     prompt: str,
     profile_data: dict,
     primary_fit_score: float | None,
+    provider: AIProvider,
     scored_job_id: int | None = None,
     discovered_job_id: int | None = None,
-    provider: AIProvider | None = None,
 ) -> ShadowScore | None:
-    """Score a job with a candidate variant and persist it to ``shadow_scores``.
+    """Score a job with a candidate ``provider`` and persist it to ``shadow_scores``.
 
     Returns the persisted :class:`ShadowScore`, or ``None`` if the variant
-    provider did not return a usable structured result. Raises nothing that the
-    live path should care about — the caller wraps this defensively.
+    provider did not return a usable structured result.
     """
-    prov = provider if provider is not None else get_ai_provider()
-    response = await prov.score(job_description=prompt, profile_data=profile_data)
+    response = await provider.score(job_description=prompt, profile_data=profile_data)
 
     if not (response.structured and isinstance(response.structured, ScoreResult)):
         logger.warning("Shadow variant %s returned no structured score — skipping log", variant)
@@ -94,25 +147,24 @@ async def record_shadow_score(
     return shadow
 
 
-async def maybe_record_shadow_score(
-    db: Session,
+async def run_shadow_score(
     *,
     profile_id: int,
+    variant: str,
     prompt: str,
     profile_data: dict,
-    primary_fit_score: float,
+    primary_fit_score: float | None,
+    provider: AIProvider,
     scored_job_id: int | None = None,
     discovered_job_id: int | None = None,
-    provider: AIProvider | None = None,
+    session_factory=SessionLocal,
 ) -> ShadowScore | None:
-    """Log a shadow score iff ``SCORING_SHADOW_VARIANT`` is configured.
+    """Background body: score + log a shadow on a fresh, independent DB session.
 
-    Fully defensive: any failure is logged and swallowed so shadow-mode can
-    never break live scoring. No-op (returns ``None``) when the setting is empty.
+    Runs off the live request path (its own session), so it never touches the
+    caller's transaction. Fully defensive — any failure is logged and swallowed.
     """
-    variant = settings.scoring_shadow_variant.strip()
-    if not variant:
-        return None
+    db = session_factory()
     try:
         return await record_shadow_score(
             db,
@@ -121,16 +173,69 @@ async def maybe_record_shadow_score(
             prompt=prompt,
             profile_data=profile_data,
             primary_fit_score=primary_fit_score,
+            provider=provider,
             scored_job_id=scored_job_id,
             discovered_job_id=discovered_job_id,
-            provider=provider,
         )
     except Exception:
-        db.rollback()
-        logger.warning(
-            "Shadow scoring failed (variant=%s) — live score unaffected", variant, exc_info=True
-        )
+        with contextlib.suppress(Exception):
+            db.rollback()
+        logger.warning("Background shadow scoring failed (variant=%s)", variant, exc_info=True)
         return None
+    finally:
+        db.close()
+
+
+def schedule_shadow_score(
+    *,
+    profile_id: int,
+    prompt: str,
+    profile_data: dict,
+    primary_fit_score: float,
+    scored_job_id: int | None = None,
+    discovered_job_id: int | None = None,
+    live_provider_name: str | None = None,
+    session_factory=SessionLocal,
+) -> asyncio.Task | None:
+    """Fire-and-forget a shadow score iff configured. Adds NO latency to the caller.
+
+    Gates on ``SCORING_SHADOW_VARIANT`` (must resolve to a distinct provider) and
+    ``SCORING_SHADOW_SAMPLE`` (fraction of jobs to shadow), then spawns an
+    asyncio task and returns immediately. Returns the scheduled task, or ``None``
+    when shadow-mode is off, this job is not sampled, the variant can't resolve,
+    or there is no running event loop.
+    """
+    variant = settings.scoring_shadow_variant.strip()
+    if not variant:
+        return None
+
+    sample = settings.scoring_shadow_sample
+    if sample < 1.0 and random.random() >= max(sample, 0.0):
+        return None
+
+    provider = build_shadow_provider(variant, live_provider_name=live_provider_name)
+    if provider is None:
+        return None
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("No running event loop — skipping shadow score for variant %s", variant)
+        return None
+
+    return loop.create_task(
+        run_shadow_score(
+            profile_id=profile_id,
+            variant=variant,
+            prompt=prompt,
+            profile_data=profile_data,
+            primary_fit_score=primary_fit_score,
+            provider=provider,
+            scored_job_id=scored_job_id,
+            discovered_job_id=discovered_job_id,
+            session_factory=session_factory,
+        )
+    )
 
 
 def compare_primary_vs_shadow(

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,50 @@
+# Scoring eval harness (G-1336)
+
+Golden-set agreement eval for the job-fit scorer. Implements finding **H** of
+`docs/research/2026-07_scoring-technique-audit.md`.
+
+## The one rule
+
+The eval exercises the **real production scorer** —
+`career_os.services.scoring.score_job` (and `batch_score_discovery`) — never a
+reimplementation. That was the whole lesson: the earlier 18-job MAE benchmark
+misled us because it scored a *proxy path*, not production.
+
+It runs with the deterministic **MockProvider** (`AI_PROVIDER=mock`) so there are
+**zero paid LLM calls** and CI is reproducible. "Production path, mock provider."
+
+## What it measures
+
+Fit scoring is a **ranking** problem, so we evaluate rank/quadrant agreement,
+not MAE-to-a-reference:
+
+- **Weighted Cohen's κ** on the ordinal tier (`reject < mediocre < strong < dream`).
+- **NDCG@5** on the ranking.
+
+Both come from the pure-Python primitives in
+`career_os.services.scoring_eval` (cross-checked against scikit-learn in
+`tests/test_scoring_eval.py`). The eval gates on **deltas vs a frozen baseline**
+(`baseline_metrics.json`) with tolerance bands, so it tracks pipeline behavior
+without flapping.
+
+## Running
+
+```bash
+pytest tests/eval/ -m eval          # nightly gate (excluded from the fast CI run)
+python -m tests.eval.generate_baseline   # regenerate baseline (review the diff!)
+python -m tests.eval.generate_labels     # reseed interim labels after fixture edits
+```
+
+## ⚠️ The remaining step: human labels
+
+The labels in `labels/*.labels.json` are **INTERIM, model-derived** — seeded
+from the golden set's LLM-authored `category` field. With the mock provider κ
+sits near 0 (hash scores are uncorrelated), so today the harness proves the
+**infra + metric math + regression gate**, not real quality.
+
+To make the κ/NDCG gate a real quality signal, a human must label the
+**rank/quadrant** of the ~120 jobs across the 6 families (`tier` + `relevance`
+in each label file). Each label is bound to its job text by an `input_hash`, so
+editing a fixture invalidates its label (the harness flags it) rather than
+silently mislabeling. Once human labels land, run a real reference model once and
+raise the gate toward **weighted κ ≥ 0.60** (per the research).

--- a/tests/eval/baseline_metrics.json
+++ b/tests/eval/baseline_metrics.json
@@ -1,0 +1,36 @@
+{
+  "metrics": {
+    "scoring_golden_set.json": {
+      "kappa": -0.0442,
+      "n": 20,
+      "ndcg@5": 0.6312
+    },
+    "scoring_golden_set_design.json": {
+      "kappa": -0.036,
+      "n": 20,
+      "ndcg@5": 0.44
+    },
+    "scoring_golden_set_finance.json": {
+      "kappa": 0.0244,
+      "n": 20,
+      "ndcg@5": 0.6514
+    },
+    "scoring_golden_set_healthcare.json": {
+      "kappa": -0.0385,
+      "n": 20,
+      "ndcg@5": 0.413
+    },
+    "scoring_golden_set_legal.json": {
+      "kappa": -0.0843,
+      "n": 20,
+      "ndcg@5": 0.3304
+    },
+    "scoring_golden_set_product.json": {
+      "kappa": -0.1765,
+      "n": 20,
+      "ndcg@5": 0.5095
+    }
+  },
+  "note": "Baseline \u03ba/NDCG@5 from the real score_job over the MockProvider. Deltas gate the eval; regenerate deliberately when scoring changes.",
+  "provider": "mock"
+}

--- a/tests/eval/generate_baseline.py
+++ b/tests/eval/generate_baseline.py
@@ -1,0 +1,69 @@
+"""Freeze the golden-set agreement baseline (G-1336, finding H).
+
+Runs the real production scorer (MockProvider) over every golden fixture and
+records the resulting κ / NDCG@5 into ``baseline_metrics.json``. The eval test
+gates future runs on *deltas* vs this baseline (tolerance bands), so the check
+tracks the production scoring pipeline's behavior rather than a brittle absolute
+threshold — and mock nondeterminism never flaps it (the mock is deterministic).
+
+Regenerate deliberately (and review the diff) whenever an intended scoring
+change moves the metrics:
+
+    python -m tests.eval.generate_baseline
+
+NOTE: with the mock provider these numbers reflect the *plumbing*, not real
+quality. They become quality signal once the labels are human and a real
+reference model is run — see label_store.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import json
+from pathlib import Path
+
+from tests.eval.harness import compute_agreement
+from tests.eval.run_scoring import make_memory_session, score_fixture
+
+BASELINE_PATH = Path(__file__).resolve().parent / "baseline_metrics.json"
+
+
+async def _run() -> dict:
+    fixtures_dir = Path(__file__).resolve().parent.parent / "fixtures"
+    metrics: dict[str, dict] = {}
+    for path in sorted(glob.glob(str(fixtures_dir / "scoring_golden_set*.json"))):
+        fixture_name = Path(path).name
+        db = make_memory_session()
+        try:
+            scored = await score_fixture(db, fixture_name)
+        finally:
+            db.close()
+        agreement = compute_agreement(fixture_name, scored)
+        metrics[fixture_name] = {
+            "n": agreement["n"],
+            "kappa": round(agreement["kappa"], 4),
+            "ndcg@5": round(agreement["ndcg@5"], 4),
+        }
+    return {
+        "note": (
+            "Baseline κ/NDCG@5 from the real score_job over the MockProvider. "
+            "Deltas gate the eval; regenerate deliberately when scoring changes."
+        ),
+        "provider": "mock",
+        "metrics": metrics,
+    }
+
+
+def regenerate() -> dict:
+    doc = asyncio.run(_run())
+    with open(BASELINE_PATH, "w") as f:
+        json.dump(doc, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return doc
+
+
+if __name__ == "__main__":
+    doc = regenerate()
+    for fixture, m in sorted(doc["metrics"].items()):
+        print(f"{fixture}: κ={m['kappa']:.4f} NDCG@5={m['ndcg@5']:.4f} (n={m['n']})")

--- a/tests/eval/generate_labels.py
+++ b/tests/eval/generate_labels.py
@@ -1,0 +1,39 @@
+"""Seed / refresh interim golden-set labels (G-1336, finding H).
+
+Run after editing the golden-set fixtures to regenerate the interim label files
+from the ``category`` field:
+
+    python -m tests.eval.generate_labels
+
+This only SEEDS placeholder labels — human rank/quadrant labels are the
+remaining step and should overwrite the generated values.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+from pathlib import Path
+
+from tests.eval.label_store import LABELS_DIR, build_seed_labels
+
+
+def regenerate_all() -> list[Path]:
+    """Regenerate label files for every ``scoring_golden_set*.json`` fixture."""
+    LABELS_DIR.mkdir(parents=True, exist_ok=True)
+    fixtures_dir = Path(__file__).resolve().parent.parent / "fixtures"
+    written: list[Path] = []
+    for path in sorted(glob.glob(str(fixtures_dir / "scoring_golden_set*.json"))):
+        fixture_name = Path(path).name
+        doc = build_seed_labels(fixture_name)
+        out = LABELS_DIR / f"{Path(fixture_name).stem}.labels.json"
+        with open(out, "w") as f:
+            json.dump(doc, f, indent=2, sort_keys=True)
+            f.write("\n")
+        written.append(out)
+    return written
+
+
+if __name__ == "__main__":
+    for p in regenerate_all():
+        print(f"wrote {p}")

--- a/tests/eval/harness.py
+++ b/tests/eval/harness.py
@@ -1,0 +1,76 @@
+"""Golden-set agreement harness (G-1336, finding H).
+
+Turns a set of production ``fit_score`` outputs plus the interim tier/rank labels
+into the two agreement metrics we actually care about for a *ranking* problem:
+
+* weighted Cohen's κ on the ordinal tier (categorical agreement), and
+* NDCG@5 on the ranking (does the scorer put the best jobs on top).
+
+The scores MUST come from the real ``career_os.services.scoring.score_job``
+(driven by the deterministic mock provider) — never a reimplementation. This
+module only does the label alignment + metric aggregation; the async scoring
+loop lives in the test/conftest so the harness stays pure and unit-testable.
+"""
+
+from __future__ import annotations
+
+from career_os.services.scoring_eval import (
+    kappa_from_tiers,
+    ndcg_at_k,
+    tier_from_fit_score,
+    tier_index,
+)
+
+# A changed fixture invalidates its label; the harness reports these so a human
+# knows to re-label rather than trusting a stale reference.
+from tests.eval.label_store import input_hash, load_fixture, load_labels
+
+
+def check_label_freshness(fixture_name: str) -> list[str]:
+    """Return job IDs whose fixture text no longer matches its stored label hash."""
+    fixture = load_fixture(fixture_name)
+    labels = load_labels(fixture_name)["labels"]
+    stale: list[str] = []
+    for job in fixture["jobs"]:
+        jid = job["id"]
+        if jid not in labels:
+            stale.append(jid)
+            continue
+        if labels[jid].get("input_hash") != input_hash(job):
+            stale.append(jid)
+    return stale
+
+
+def compute_agreement(fixture_name: str, scored: dict[str, float]) -> dict:
+    """Compute κ / NDCG@5 for a fixture given ``{job_id: production_fit_score}``.
+
+    Aligns to the label file, projects scores into ordinal tiers, and returns the
+    metric bundle. Raises ``ValueError`` if a labeled job is missing a score.
+    """
+    labels = load_labels(fixture_name)["labels"]
+    job_ids = list(labels.keys())
+
+    missing = [jid for jid in job_ids if jid not in scored]
+    if missing:
+        raise ValueError(f"{fixture_name}: missing production scores for {missing}")
+
+    true_tiers = [labels[jid]["tier"] for jid in job_ids]
+    relevances = [float(labels[jid]["relevance"]) for jid in job_ids]
+    fit_scores = [scored[jid] for jid in job_ids]
+    pred_tiers = [tier_from_fit_score(s) for s in fit_scores]
+
+    kappa = kappa_from_tiers(true_tiers, pred_tiers)
+    ndcg = ndcg_at_k(relevances, fit_scores, k=5)
+
+    return {
+        "fixture": fixture_name,
+        "n": len(job_ids),
+        "kappa": kappa,
+        "ndcg@5": ndcg,
+    }
+
+
+def relevances_from_labels(fixture_name: str, job_ids: list[str]) -> list[float]:
+    """Relevance grades (from labels) for the given job IDs, in order."""
+    labels = load_labels(fixture_name)["labels"]
+    return [float(tier_index(labels[jid]["tier"])) for jid in job_ids]

--- a/tests/eval/label_store.py
+++ b/tests/eval/label_store.py
@@ -1,0 +1,81 @@
+"""Golden-set label store for the scoring eval harness (G-1336, finding H).
+
+Fit scoring is a *ranking* problem — so the reference we evaluate against is an
+ordinal **tier/rank** label per job, not a target number. This module defines
+the label schema and the input-hash that binds a label to the exact job text it
+was assigned to, so a changed fixture invalidates its stale label instead of
+silently mislabeling.
+
+**Labels here are INTERIM, model-derived** — seeded from the existing golden-set
+``category`` field (itself LLM-authored). They are a placeholder so the harness
+runs today; the remaining step is ~60–120 **human** rank/quadrant labels (the
+fixtures hold exactly 120 jobs across 6 families). Regenerate the seed with
+``python -m tests.eval.generate_labels`` after editing fixtures; replace the
+values with human judgments to make the κ/NDCG gate meaningful.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+LABELS_DIR = Path(__file__).resolve().parent / "labels"
+
+LABEL_SOURCE_INTERIM = "interim-model-derived"
+
+# Ordinal tier → relevance grade (weakest → strongest). Mirrors
+# career_os.services.scoring_eval.TIER_ORDER.
+TIER_TO_RELEVANCE: dict[str, int] = {"reject": 0, "mediocre": 1, "strong": 2, "dream": 3}
+
+
+def input_hash(job: dict) -> str:
+    """Stable hash of the load-bearing job text a label was assigned to.
+
+    Binds a label to its exact input so an edited fixture invalidates the label
+    rather than silently mislabeling. Uses title|company|description.
+    """
+    payload = f"{job.get('title', '')}|{job.get('company', '')}|{job.get('description', '')}"
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def labels_path(fixture_name: str) -> Path:
+    """Path to the label file for a given fixture filename."""
+    stem = Path(fixture_name).stem
+    return LABELS_DIR / f"{stem}.labels.json"
+
+
+def load_fixture(fixture_name: str) -> dict:
+    """Load a golden-set fixture by filename."""
+    with open(FIXTURES_DIR / fixture_name) as f:
+        return json.load(f)
+
+
+def load_labels(fixture_name: str) -> dict:
+    """Load the label file for a fixture (raises if it does not exist)."""
+    with open(labels_path(fixture_name)) as f:
+        return json.load(f)
+
+
+def build_seed_labels(fixture_name: str) -> dict:
+    """Build an interim label document from a fixture's ``category`` field."""
+    data = load_fixture(fixture_name)
+    labels: dict[str, dict] = {}
+    for job in data["jobs"]:
+        tier = job["category"]
+        labels[job["id"]] = {
+            "tier": tier,
+            "relevance": TIER_TO_RELEVANCE[tier],
+            "input_hash": input_hash(job),
+        }
+    return {
+        "fixture": fixture_name,
+        "label_source": LABEL_SOURCE_INTERIM,
+        "note": (
+            "INTERIM labels seeded from the golden-set `category` field (LLM-authored). "
+            "NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant "
+            "judgments to make the κ/NDCG gate meaningful (G-1336 follow-up)."
+        ),
+        "labels": labels,
+    }

--- a/tests/eval/labels/scoring_golden_set.labels.json
+++ b/tests/eval/labels/scoring_golden_set.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "gs-01": {
+      "input_hash": "sha256:ebad61b3bb2fda618ef38cc45623d38fb967ab1703f6caaaf7a319cd33d37508",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "gs-02": {
+      "input_hash": "sha256:80dc0646fa0f239286b88ac586de412595f3f129b4fc14e3f6f5ecb93d32f711",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "gs-03": {
+      "input_hash": "sha256:5248fd2d006e09992efd83da564d6d32eefc555d012f5b9e8562116963bfd361",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "gs-04": {
+      "input_hash": "sha256:1a19f320f16fd93e360288fdcf72dfade87de73d690e804c0c0391f418787293",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "gs-05": {
+      "input_hash": "sha256:be610fdf2d2994d2c560f9f35ccfa5d29cba27aa2159678f50156bf9c11844a4",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-06": {
+      "input_hash": "sha256:5ff0b925089c3ef38c039e80a348b9bab6a192132e9a7bc439931e981f861437",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-07": {
+      "input_hash": "sha256:57ea329b3d73cd492e324a383ce095ef6217b18fb6518648b126514a244b05ab",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-08": {
+      "input_hash": "sha256:6f1a7537f91bc228b613448ee3391e07a6badc64e6a99f91bd9ede795e434727",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-09": {
+      "input_hash": "sha256:07d9c605f5276cb0e1e2f1a77b59e18702d1ea66a748dfe9e83c863343f6592f",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-10": {
+      "input_hash": "sha256:8a8e395db52c43d10a5af677176f3611ceacfc0333b4e7a8482f56200af9798d",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-11": {
+      "input_hash": "sha256:2e661831cf41427b0b5b25557bcfdcb4d841a121204028fbe271677d2207e465",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "gs-12": {
+      "input_hash": "sha256:e930f43640f05c6eb475e02d73565b96b09a481f12c23eebf5182781427b8592",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "gs-13": {
+      "input_hash": "sha256:c025110a8fb2e5da0d0ba630d3e079b543e798015b8211bb4fa8f36c3185b359",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-14": {
+      "input_hash": "sha256:f8f16680e67d19c85e5a13b5332e47ec995cf10c9fe57d607d5fe592258cf360",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "gs-15": {
+      "input_hash": "sha256:2a8666193166ce761a43f734438e10494eb060c35677d9f58aa7290ca6fa48c9",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "gs-16": {
+      "input_hash": "sha256:8ac7abb448b2ac696eca776fb09409e5256b2485de9b9c669b08525670f80e81",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "gs-17": {
+      "input_hash": "sha256:92a5758259c8a95e50969d4fdce3f0e38c520bea21b5dd2e187a8cdcf466ceb7",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "gs-18": {
+      "input_hash": "sha256:45be3165af5b888d168cf188d1310d2594676bdc61cac085daa7e6e580d6b3a8",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "gs-19": {
+      "input_hash": "sha256:804ce35aa7cf71f158e5e390131b9ad72ca2a98a2b1f927c5cef398482d7fb6d",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "gs-20": {
+      "input_hash": "sha256:6339d340b3815460d0925966de5ec45c6b6c92e1eeb9a2cd28b3002c3ac8c659",
+      "relevance": 3,
+      "tier": "dream"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/labels/scoring_golden_set_design.labels.json
+++ b/tests/eval/labels/scoring_golden_set_design.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set_design.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "ds-01": {
+      "input_hash": "sha256:4f4f8e4d66fd6d1cc52506bf6da3f1e2f58a23377aa9deb044f469b4b21de610",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "ds-02": {
+      "input_hash": "sha256:61bc546370c7fef2345803f5c671a19e9e928ed534d8aa24296690602fe3acf8",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "ds-03": {
+      "input_hash": "sha256:509b5a635e5140d9e180273ea41d4561ae29319ddeabe3e383eb5f16b0157b29",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "ds-04": {
+      "input_hash": "sha256:0ccd92f2e47cd8a88d5e1d8892733b7c1e9aaa30b45d4fbc5e610c54e20be4ce",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "ds-05": {
+      "input_hash": "sha256:b168f2973c29ae09d96e9ee5cfe12e2844cb7d0f40d754c7dce6bb5172672117",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-06": {
+      "input_hash": "sha256:4bebf99942914ca86228d64ce60420a3cada351f2e17afef9bbe5d153d20477c",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-07": {
+      "input_hash": "sha256:157dfc5a07b07ec2b77a6202b008417f3268e1610f1d5ae68598c0edb64c3211",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-08": {
+      "input_hash": "sha256:38f4fb7cec75bf055bd15e55f3667b2d48e0bb9c84e364b0fcdb53a07ab57153",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-09": {
+      "input_hash": "sha256:9af1dd62a33244ef3d8fdad4f0208dbe78f1cdfa6c5468e886fa959f7be487ad",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-10": {
+      "input_hash": "sha256:e2bec546cf54694dc29bee90b20d6fb3db1ad018ec2159112c27344972224fc9",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "ds-11": {
+      "input_hash": "sha256:25530fe8d9487131acc95b0bcb4a93fe56a003b61fbedeaf31ccc0ba622d8b0c",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-12": {
+      "input_hash": "sha256:b601425ffab1903a5c31d7c8bc82a07d7ffb256b968d3f1710d16618de4db0d9",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-13": {
+      "input_hash": "sha256:5f65327ab5bb44d0a2d166138803c2bae10ddd645582928fa042929167a81aba",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-14": {
+      "input_hash": "sha256:1d341f0339572f1dcb40e2277d154247432c273cceb7a96b8ad843f444964648",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-15": {
+      "input_hash": "sha256:0d9824e960ebddfd5c6887b6d13d87b3b2331bcb3f3218dd2cd6cf6d505a5569",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-16": {
+      "input_hash": "sha256:73c3e8fb2407d70a2947e7ca5651e4026a959fc6a03c8d49d9d37e8029720563",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "ds-17": {
+      "input_hash": "sha256:fbd9689a30a4e5d0374041cbd8ec205a1ff76b64f27db171af7b5ef3ab266bf5",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "ds-18": {
+      "input_hash": "sha256:88e9d28b3602929a197aac09dbdc097d2c7c5024de3a59678127c1ed5119fd9a",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "ds-19": {
+      "input_hash": "sha256:f81bdfe4d2e7f0f3f501f5d55595a6b1897baa1f8d1d6b8ee00fe83136561e5c",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "ds-20": {
+      "input_hash": "sha256:e9d841b50b4e260d42c7cd4be4bb3c5213bd2d01689bd3b46a73f3b9bad59fd0",
+      "relevance": 3,
+      "tier": "dream"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/labels/scoring_golden_set_finance.labels.json
+++ b/tests/eval/labels/scoring_golden_set_finance.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set_finance.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "fs-01": {
+      "input_hash": "sha256:55b82ae52ba170659609d066771a335579147b6554bfe048a2f9a800fc1aa7e9",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "fs-02": {
+      "input_hash": "sha256:19aceafcf8429483d39490a31e58d3e67df74cc88e2f2c014303f162cfdb0052",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "fs-03": {
+      "input_hash": "sha256:07bec00e95a1e120284a5e1293df6c305b571cd1325108ba6ae5c6b5b7ef714e",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "fs-04": {
+      "input_hash": "sha256:a444e3cc92e747ba503037dff82c764273a123efce8c715f95f3b246a888fb2a",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "fs-05": {
+      "input_hash": "sha256:639ad507ead1e807dbc5e0f9d506eab17a9acb579333836e8ff7bb7541e7a6d8",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-06": {
+      "input_hash": "sha256:b02a66b0742b45609fcfb045c35b23cbf262e7c3d5d4276fbc7dde51b14ca3df",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-07": {
+      "input_hash": "sha256:e56981fa9711e9fe0ce06744199ea00d703d376d0066cad66cc37836e01177ca",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-08": {
+      "input_hash": "sha256:68e6c827b168b6fa4cee42e029f13fa143b932c0625c83641de2a62ffd9d13e9",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-09": {
+      "input_hash": "sha256:0b1f331286f68948d45ce1c1b5c1594e024c91468882b75a4d5ab7ac8e7344d1",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-10": {
+      "input_hash": "sha256:43e5316f7f178d08b471b4a4cf95093ef97027d07de77045b664f84ee579e4af",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "fs-11": {
+      "input_hash": "sha256:e0d376b72be48b064bf2b1a757b15d8cf03d12150aab8e8831720c28c65b1f45",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-12": {
+      "input_hash": "sha256:28b5233d19fe5cb30bf4814d8c0d59f8e9ac1fb6577ab9310161fe09699178af",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-13": {
+      "input_hash": "sha256:55df224aacebb9597ca3d2b2db8efc4cb5010ef820e5857f9490c3650e0d56e8",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-14": {
+      "input_hash": "sha256:8aa2ea7c24544572e12a831f70a0d7f7212070020855e4683cdc5165d66f7359",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-15": {
+      "input_hash": "sha256:9f83a8e3b9e9a62d99b4640de624f2c64f088cce43ab887349f2a5d9ad8c9028",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-16": {
+      "input_hash": "sha256:671797876a9b874ff22295303a2cdb2a039f55d3f3e061e27ed623dec250ff8d",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "fs-17": {
+      "input_hash": "sha256:41340e1b32b538993b61f0011b219437fca159cfccfce48197afd5917c16e752",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "fs-18": {
+      "input_hash": "sha256:c584677271b695af805d4ac47a6cec1531171c284275b02c2a4b5715da8047fd",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "fs-19": {
+      "input_hash": "sha256:cf6e361ee514958ee00d2c0896c9b04e876618d5c5f8345f1ebbec6d480e44cf",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "fs-20": {
+      "input_hash": "sha256:f3ad250c4ce8a98b9e0dc0c88dffb6dec6a2bbd6b70180cbdc461fa77e0d8de4",
+      "relevance": 3,
+      "tier": "dream"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/labels/scoring_golden_set_healthcare.labels.json
+++ b/tests/eval/labels/scoring_golden_set_healthcare.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set_healthcare.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "hc-01": {
+      "input_hash": "sha256:69aa9c919eb66eb5d5ee0a52166f439d2c7d3c3570c41680000b0fbd90d62e6c",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "hc-02": {
+      "input_hash": "sha256:39bb018a837bc2704b3c3a6b510e8e47e6d5ded78419239fad5d6f85228645c4",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "hc-03": {
+      "input_hash": "sha256:eaecde42abbde2a8ba2d0e8a3817d7fb1643080c999a6e70cfea94ecc132dfed",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "hc-04": {
+      "input_hash": "sha256:e7fec278a1c6f121a6ba497e5b0b956a496e3940153bb353f5df009983f090b9",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "hc-05": {
+      "input_hash": "sha256:b5e2e440165fd150f4d2bffb1947e306638f3acf4acd8fcbe1241f0ae2cd7662",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "hc-06": {
+      "input_hash": "sha256:c2ba615443ade389327d5aeaec4c28fc60a53c703f6b74a32424dd07cc744e21",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-07": {
+      "input_hash": "sha256:5ebd3d1fb94599beae225f86b134dbec0bd68f7947034e412e896a66d9654d0c",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-08": {
+      "input_hash": "sha256:487c1d5eccc6ea3f5fa0ec049f23bb36e5f0997e479d4cd074513c3c2477f19c",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "hc-09": {
+      "input_hash": "sha256:a5b5c0e4d349c6746a2d15c0dbd5e65063d4303f265e68ffd3581824a310ebc4",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "hc-10": {
+      "input_hash": "sha256:b9f9c714b6505b3b0b032ea1a5afa6e10129e2c27ac3768b675acb0d97d52499",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-11": {
+      "input_hash": "sha256:e2cdb1b21b4646b5d24d366b713affc17e9768439c63d3d362b30b82384d98cf",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "hc-12": {
+      "input_hash": "sha256:50d32c8312a3e1f8fd298b4a1a922c685efa8e30b0b243f883c5947ba6621508",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "hc-13": {
+      "input_hash": "sha256:cb9af23dbebb24bef7a14b50e6fdeeb6cdd845f3597d6bc24bff814ff6ade126",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-14": {
+      "input_hash": "sha256:e986e74719e284f8872407e4834be0db4b9e6c7d327ee1216bf63284cdf218d3",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "hc-15": {
+      "input_hash": "sha256:dae2ecd1d284bb8733e82fd8bc9a400a5cb6770076892f8d9466b5c9b1ed958e",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-16": {
+      "input_hash": "sha256:941bebacf50da66ae07eacccb84e09921d01c35559878e1492bc89d62c2b82c9",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "hc-17": {
+      "input_hash": "sha256:9a5e0844d1805987c85df17f12a709a72d31357bb57ae8cced628a855ba54391",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-18": {
+      "input_hash": "sha256:7c71c6a2370488a41214c4ee6a8bb11370a0d37cba496d4ee4d9ee9457deb71e",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "hc-19": {
+      "input_hash": "sha256:99cdd520353c75d1677508e02ad59a98536e1fc6753f75420f630ce65cf5bf8a",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "hc-20": {
+      "input_hash": "sha256:1537c4600e26cb0bfbd00fa1e0929b2fb44ffb3461c154b66883ec0893d4bb91",
+      "relevance": 3,
+      "tier": "dream"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/labels/scoring_golden_set_legal.labels.json
+++ b/tests/eval/labels/scoring_golden_set_legal.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set_legal.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "lg-01": {
+      "input_hash": "sha256:e18d6a563b70dce14fa9d0eed1d16c1ac05735fd0daa426f7e50a064b77a118e",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "lg-02": {
+      "input_hash": "sha256:6eec907f9768471935343cc04945e8e4fdb009125bb3d35981b676b5459eadd9",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-03": {
+      "input_hash": "sha256:4f2db4ee911398706a12c317141819152a5804a7bd3e0d156bc8585607b5cb8f",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-04": {
+      "input_hash": "sha256:30a46d085778bf52748d761f9b450e1d85b7b3f5221be09fc63b003d8b29a50a",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-05": {
+      "input_hash": "sha256:71787b467e82ca3621fc1e38454e2e872cb60b81ec43bcc8187532a73c4dde18",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-06": {
+      "input_hash": "sha256:5b810c50b8f3409b948879ae08b0018684daa4088decf32e810069c9aae4a756",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-07": {
+      "input_hash": "sha256:e771a9e2efbe409c70c7d35a75d15cf3f74eac40995e1bf975c8b4423e9edd65",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-08": {
+      "input_hash": "sha256:efe3d3b6cb017ec31c770cb388fb1cdd07e8d39c989c19a1b12fdcba53580fae",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-09": {
+      "input_hash": "sha256:0a288551f6f9996593cb7c5d458feff05df46865ad0b45b23c8df06927c4cc8e",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-10": {
+      "input_hash": "sha256:591a38beaf3253dbd45de2912e30e4578663414fdc8db977f2e6631cb92535b7",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "lg-11": {
+      "input_hash": "sha256:2b55eedd0e530ca43ff9b727df4cbb1a88468dd3a1603f0cb06bd9f98e993b71",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "lg-12": {
+      "input_hash": "sha256:575b666c9c5d6e5e93ab3892846a07ca42a303e58cf846fa035a78c8703af7ba",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "lg-13": {
+      "input_hash": "sha256:1d96a544ac817136742595d10d3aa13cdd30640f0a52ce3d372bcbd82149805a",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-14": {
+      "input_hash": "sha256:c8275885b939d48209bf820071c1b2a039ba443bc7981b373f4796f780e6f195",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-15": {
+      "input_hash": "sha256:cbc4e70e460f1948edc8a4a1bf8dea87fcd2172ee1c373f66792604a85a531a6",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-16": {
+      "input_hash": "sha256:ed064aa33d98e6e5ae52ca915f6e0a85a10d5c82244ffd6d594f727983486c75",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "lg-17": {
+      "input_hash": "sha256:63aa3ce0057223a9c863d51f2cd532ffd118e188fc0a535f415565e2d93fd97d",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "lg-18": {
+      "input_hash": "sha256:3e4ebe07f12d8ee62366306625e46c89c7e96817d8b82224c96d55e456901a6a",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "lg-19": {
+      "input_hash": "sha256:0f6997e8ca1d5fb0509600d45c5e08e8678cf8544351269a45659cef1e8d49ca",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "lg-20": {
+      "input_hash": "sha256:fc40ea2cce821c5d15181b03a7152e4a460083a213a803695b05a13a0011f724",
+      "relevance": 1,
+      "tier": "mediocre"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/labels/scoring_golden_set_product.labels.json
+++ b/tests/eval/labels/scoring_golden_set_product.labels.json
@@ -1,0 +1,107 @@
+{
+  "fixture": "scoring_golden_set_product.json",
+  "label_source": "interim-model-derived",
+  "labels": {
+    "pm-01": {
+      "input_hash": "sha256:4da95ba8bcc183eee2036b01d3e1438957c749be831b3d9f48635cb456ff691f",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "pm-02": {
+      "input_hash": "sha256:c9c1a69a9367922f8b130f2f1185a9b8ce6bbb69485c6776d8b1f51463acc957",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-03": {
+      "input_hash": "sha256:bd679be735cbcc24fdb1b00a212c0700528817b6dbcdc98972bf2d22844a230b",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-04": {
+      "input_hash": "sha256:675be31f96b6240e5fa09db69b731cd577dc4ba46dec8469db1b1c91aabda303",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-05": {
+      "input_hash": "sha256:bf9b89790a5f1ad9c2041d36fee0d6d2f5754ca011e64c3238b21786b6b7a56b",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "pm-06": {
+      "input_hash": "sha256:cfce662540d156684ab13b75f62ec624ec8d2d11f55dafdb273743b2d30b7c65",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-07": {
+      "input_hash": "sha256:d6653edb5caaec1fa22c8a114c29343531e9df26fb1572b42d31f84f62a2f0f0",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "pm-08": {
+      "input_hash": "sha256:ab8737ce1c2d257b79887ff1daaac096094a03564f12aa33585814428bb7fbdb",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-09": {
+      "input_hash": "sha256:c1698dc6b28ab61bf1854419ad5a2c74ef9e135e3f10a67cd4277587d7f8b324",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-10": {
+      "input_hash": "sha256:1d07ffec83a003077655f56ef2ff1b29eeeca97046c56090bd7bd35cc2d8cd24",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "pm-11": {
+      "input_hash": "sha256:7d409e05e0fc04bfd05d76625f816fd79cbb98aa6967ab42c65ed72e5b45887d",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-12": {
+      "input_hash": "sha256:cf3b933a7c61e2022e4fed366d9d21c725666831718be4df28f318c58d82b981",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "pm-13": {
+      "input_hash": "sha256:86b8bbdee20752b2fc17026966398be8b793ae30c80270a8b1e781e8316519c4",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "pm-14": {
+      "input_hash": "sha256:2ed1f7ffb9a858db74cc36c6d084970033fa2cd95f23673dcecaf4bb76bba854",
+      "relevance": 0,
+      "tier": "reject"
+    },
+    "pm-15": {
+      "input_hash": "sha256:36beefc2fce0735afb46dfb84ee72f58ea8a4383af604413da86d28b01fe567d",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "pm-16": {
+      "input_hash": "sha256:5662191cbd54bec7c68bfdf77ef81e0660a956072a7c39dd8b74871b7aea1d87",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-17": {
+      "input_hash": "sha256:477d915904d5c0e6217dc2199d832509dd76a00f4e64dd61b2546a6f99c18f3c",
+      "relevance": 3,
+      "tier": "dream"
+    },
+    "pm-18": {
+      "input_hash": "sha256:68e76d622a9e0a19e46a2dd5236e5925c0e0d798e591af676e3825a97f9754bd",
+      "relevance": 1,
+      "tier": "mediocre"
+    },
+    "pm-19": {
+      "input_hash": "sha256:03de901f7a1b55a97daf6b28e3976a24a9770bd03a03fb0f3ceda20a7aafe2e7",
+      "relevance": 2,
+      "tier": "strong"
+    },
+    "pm-20": {
+      "input_hash": "sha256:67c0f20a25268f084eb1c0ff9f901993e00cfc1ab73baee85f06acf4471cad67",
+      "relevance": 0,
+      "tier": "reject"
+    }
+  },
+  "note": "INTERIM labels seeded from the golden-set `category` field (LLM-authored). NOT human ground truth. Replace `tier`/`relevance` with human rank/quadrant judgments to make the \u03ba/NDCG gate meaningful (G-1336 follow-up)."
+}

--- a/tests/eval/run_scoring.py
+++ b/tests/eval/run_scoring.py
@@ -1,0 +1,70 @@
+"""Drive the REAL production scorer over a golden-set fixture (G-1336).
+
+The one rule that motivated this whole ticket: the eval exercises
+``career_os.services.scoring.score_job`` — the real production entrypoint —
+never a reimplementation. It runs with the deterministic **MockProvider** (the
+default ``AI_PROVIDER=mock``) so there are zero paid LLM calls and the output is
+reproducible in CI. "Production path, mock provider."
+
+Shared by the eval tests and the baseline generator so both score identically.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.database import Base
+from career_os.models.models import Profile
+from career_os.services.scoring import score_job
+from tests.eval.label_store import load_fixture
+
+
+def make_memory_session() -> Session:
+    """Create a fresh in-memory SQLite session with FK enforcement + a profile."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk_pragma(dbapi_conn, _record):  # noqa: ANN001
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+    session.add(
+        Profile(
+            id=1,
+            name="Eval User",
+            email="eval@test.example.com",
+            location="Remote",
+            job_family="TPM",
+        )
+    )
+    session.commit()
+    return session
+
+
+async def score_fixture(db: Session, fixture_name: str, *, profile_id: int = 1) -> dict[str, float]:
+    """Score every job in a fixture through the real ``score_job``.
+
+    Aligns the seeded profile to the fixture's job family/location so the run is
+    faithful, then returns ``{job_id: fit_score}``.
+    """
+    fixture = load_fixture(fixture_name)
+    profile = db.get(Profile, profile_id)
+    profile.job_family = fixture["profile"]["job_family"]
+    profile.location = fixture["profile"]["location"]
+    db.commit()
+
+    scores: dict[str, float] = {}
+    for job in fixture["jobs"]:
+        scored = await score_job(
+            db,
+            profile_id,
+            job["description"],
+            job_title=job["title"],
+            job_company=job["company"],
+        )
+        scores[job["id"]] = scored.fit_score
+    return scores

--- a/tests/eval/test_golden_agreement.py
+++ b/tests/eval/test_golden_agreement.py
@@ -1,0 +1,134 @@
+"""Golden-set agreement eval on the REAL production scorer (G-1336, finding H).
+
+Marked ``@pytest.mark.eval`` so it runs as a separate (nightly) CI job, not the
+fast unit run. Every metric here comes from ``career_os.services.scoring.score_job``
+driven by the deterministic MockProvider — the real production path, zero paid
+LLM calls (see ``tests/eval/run_scoring.py``).
+
+The gate is a *delta vs a frozen baseline* with tolerance bands, not a brittle
+absolute threshold: it detects when a change to the production scoring pipeline
+moves κ/NDCG, without flapping on nondeterminism (the mock is deterministic).
+
+Honesty note: with the mock provider these κ values hover near 0 (hash scores
+are uncorrelated with the interim labels). They become real *quality* signal
+only once the labels are human and a real reference model is run — see
+``tests/eval/label_store.py``. The infra, metric math, and regression gate are
+what ship here.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.eval.harness import check_label_freshness, compute_agreement
+from tests.eval.run_scoring import make_memory_session, score_fixture
+
+pytestmark = pytest.mark.eval
+
+FIXTURE_NAMES = sorted(
+    Path(p).name
+    for p in glob.glob(
+        str(Path(__file__).resolve().parent.parent / "fixtures" / "scoring_golden_set*.json")
+    )
+)
+
+BASELINE = json.loads((Path(__file__).resolve().parent / "baseline_metrics.json").read_text())
+
+# Tolerance bands for the delta-vs-baseline gate.
+KAPPA_TOLERANCE = 0.15
+NDCG_TOLERANCE = 0.15
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory DB with a seeded profile (fresh per test)."""
+    session = make_memory_session()
+    yield session
+    session.close()
+
+
+@pytest.mark.parametrize("fixture_name", FIXTURE_NAMES)
+def test_label_freshness(fixture_name):
+    """Every labeled job still matches its stored input hash (no stale labels)."""
+    stale = check_label_freshness(fixture_name)
+    assert not stale, (
+        f"{fixture_name}: labels are stale for {stale} — the fixture text changed. "
+        f"Re-label (human) or reseed with `python -m tests.eval.generate_labels`."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fixture_name", FIXTURE_NAMES)
+async def test_agreement_within_baseline_band(fixture_name, db_session):
+    """κ / NDCG@5 on the real scorer stay within tolerance of the frozen baseline."""
+    scored = await score_fixture(db_session, fixture_name)
+    agreement = compute_agreement(fixture_name, scored)
+
+    # Metrics are well-formed.
+    assert -1.0 <= agreement["kappa"] <= 1.0
+    assert 0.0 <= agreement["ndcg@5"] <= 1.0
+    assert agreement["n"] == BASELINE["metrics"][fixture_name]["n"]
+
+    base = BASELINE["metrics"][fixture_name]
+    kappa_delta = abs(agreement["kappa"] - base["kappa"])
+    ndcg_delta = abs(agreement["ndcg@5"] - base["ndcg@5"])
+
+    assert kappa_delta <= KAPPA_TOLERANCE, (
+        f"{fixture_name}: weighted κ drifted {kappa_delta:.3f} from baseline "
+        f"{base['kappa']:.3f} (now {agreement['kappa']:.3f}, tolerance {KAPPA_TOLERANCE}). "
+        f"If intentional, regenerate with `python -m tests.eval.generate_baseline`."
+    )
+    assert ndcg_delta <= NDCG_TOLERANCE, (
+        f"{fixture_name}: NDCG@5 drifted {ndcg_delta:.3f} from baseline "
+        f"{base['ndcg@5']:.3f} (now {agreement['ndcg@5']:.3f}, tolerance {NDCG_TOLERANCE}). "
+        f"If intentional, regenerate with `python -m tests.eval.generate_baseline`."
+    )
+
+
+@pytest.mark.asyncio
+async def test_scorer_is_deterministic_under_mock(db_session):
+    """Two runs of the same fixture give identical scores (baseline can't flap)."""
+    first = await score_fixture(db_session, FIXTURE_NAMES[0])
+    second_db = make_memory_session()
+    try:
+        second = await score_fixture(second_db, FIXTURE_NAMES[0])
+    finally:
+        second_db.close()
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_exercises_real_batch_path(db_session):
+    """The batch entrypoint scores real DiscoveredJob rows via the production path."""
+    from career_os.models.discovery import DiscoveredJob
+    from career_os.models.models import Profile
+    from career_os.services.scoring import batch_score_discovery
+
+    profile = db_session.get(Profile, 1)
+    profile.job_family = "TPM"
+    profile.location = "Remote"
+    db_session.commit()
+
+    for i in range(3):
+        db_session.add(
+            DiscoveredJob(
+                profile_id=1,
+                title=f"Technical Program Manager {i}",
+                company=f"Acme {i}",
+                location="Remote",
+                description="Own cross-functional AI infrastructure programs. Python, cloud.",
+                url=f"https://example.com/job/{i}",
+                title_normalized=f"technical program manager {i}",
+                company_normalized=f"acme {i}",
+                location_normalized="remote",
+            )
+        )
+    db_session.commit()
+
+    result = await batch_score_discovery(db_session, 1)
+    assert result["scored_count"] == 3
+    assert all(0.0 <= s.fit_score <= 10.0 for s in result["scores"])

--- a/tests/test_cli_scoring.py
+++ b/tests/test_cli_scoring.py
@@ -1,0 +1,44 @@
+"""CLI tests for the scoring drift-canary command (G-1336, finding J)."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from career_os.cli.scoring import scoring_app
+from career_os.config import settings
+
+runner = CliRunner()
+
+
+def test_drift_canary_cli_disabled_noops(monkeypatch):
+    """With DRIFT_CANARY_ENABLED off, the command no-ops cleanly (exit 0)."""
+    monkeypatch.setattr(settings, "drift_canary_enabled", False)
+    result = runner.invoke(scoring_app, ["drift-canary"])
+    assert result.exit_code == 0
+    assert "disabled" in result.stdout.lower()
+
+
+def test_drift_canary_cli_enabled_invokes_check(monkeypatch):
+    """With the flag on, the command runs the check via the golden-agreement fn."""
+    monkeypatch.setattr(settings, "drift_canary_enabled", True)
+
+    called = {}
+
+    def _fake_check(db, profile_id, *, agreement_fn, notify):
+        called["ran"] = True
+        called["notify"] = notify
+        return {
+            "status": "ran",
+            "alert": False,
+            "notified": False,
+            "psi": None,
+            "kappa": 0.6,
+            "ndcg": 0.7,
+            "reason": "Stable",
+        }
+
+    # Avoid the real golden re-score + DB; assert the flag gate lets execution through.
+    monkeypatch.setattr("career_os.services.drift_canary.drift_canary_check", _fake_check)
+    result = runner.invoke(scoring_app, ["drift-canary"])
+    assert result.exit_code == 0
+    assert called.get("ran") is True

--- a/tests/test_drift_canary.py
+++ b/tests/test_drift_canary.py
@@ -1,0 +1,171 @@
+"""Unit tests for the scoring drift canary (G-1336, finding J)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from career_os.database import Base
+from career_os.models.models import Profile
+from career_os.models.scoring import ScoredJob
+from career_os.services import drift_canary
+from career_os.services.drift_canary import (
+    compute_score_psi,
+    evaluate_drift,
+    run_drift_canary,
+)
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk(conn, _rec):
+        cur = conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+    session.add(
+        Profile(id=1, name="U", email="u@test.example.com", location="Remote", job_family="TPM")
+    )
+    session.commit()
+    yield session
+    session.close()
+
+
+# ---------------------------------------------------------------------------
+# evaluate_drift — the joint-condition decision logic
+# ---------------------------------------------------------------------------
+
+
+def test_joint_condition_alerts():
+    r = evaluate_drift(psi=0.35, kappa=0.40, ndcg=0.70, baseline_kappa=0.62, baseline_ndcg=0.75)
+    assert r["alert"] is True
+    assert r["distribution_drift"] and r["agreement_drop"]
+
+
+def test_psi_only_does_not_alert():
+    r = evaluate_drift(psi=0.35, kappa=0.62, ndcg=0.75, baseline_kappa=0.62, baseline_ndcg=0.75)
+    assert r["alert"] is False
+    assert r["distribution_drift"] is True
+    assert "benign" in r["reason"]
+
+
+def test_agreement_drop_only_does_not_alert():
+    r = evaluate_drift(psi=0.05, kappa=0.30, ndcg=0.50, baseline_kappa=0.62, baseline_ndcg=0.75)
+    assert r["alert"] is False
+    assert r["agreement_drop"] is True
+
+
+def test_stable_does_not_alert():
+    r = evaluate_drift(psi=0.05, kappa=0.63, ndcg=0.76, baseline_kappa=0.62, baseline_ndcg=0.75)
+    assert r["alert"] is False
+    assert r["reason"] == "Stable"
+
+
+def test_ndcg_drop_alone_can_trip_joint():
+    # κ held, NDCG dropped past tolerance, PSI high → joint trip.
+    r = evaluate_drift(psi=0.30, kappa=0.62, ndcg=0.60, baseline_kappa=0.62, baseline_ndcg=0.75)
+    assert r["alert"] is True
+
+
+# ---------------------------------------------------------------------------
+# compute_score_psi
+# ---------------------------------------------------------------------------
+
+
+def _add_scores(db, values, created_at):
+    for v in values:
+        db.add(
+            ScoredJob(
+                profile_id=1,
+                fit_score=v,
+                reasoning="x",
+                created_at=created_at,
+            )
+        )
+    db.commit()
+
+
+def test_compute_score_psi_insufficient_returns_none(db_session):
+    now = datetime(2026, 7, 15, tzinfo=UTC)
+    _add_scores(db_session, [5.0, 6.0], now - timedelta(hours=1))
+    assert compute_score_psi(db_session, 1, min_samples=20, now=now) is None
+
+
+def test_compute_score_psi_stable_is_low(db_session):
+    now = datetime(2026, 7, 15, tzinfo=UTC)
+    baseline_vals = [5.0] * 6 + [6.0] * 6
+    recent_vals = [5.0] * 6 + [6.0] * 6
+    _add_scores(db_session, baseline_vals, now - timedelta(days=10))
+    _add_scores(db_session, recent_vals, now - timedelta(hours=2))
+    psi = compute_score_psi(db_session, 1, min_samples=10, now=now)
+    assert psi == pytest.approx(0.0, abs=1e-9)
+
+
+def test_compute_score_psi_shift_is_positive(db_session):
+    now = datetime(2026, 7, 15, tzinfo=UTC)
+    _add_scores(db_session, [1.0] * 12, now - timedelta(days=10))  # baseline: all low
+    _add_scores(db_session, [9.0] * 12, now - timedelta(hours=2))  # recent: all high
+    psi = compute_score_psi(db_session, 1, min_samples=10, now=now)
+    assert psi > 0.2
+
+
+# ---------------------------------------------------------------------------
+# run_drift_canary — orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_run_canary_skips_without_psi(db_session):
+    r = run_drift_canary(
+        db_session, 1, kappa=0.3, ndcg=0.4, baseline_kappa=0.62, baseline_ndcg=0.75, psi=None
+    )
+    # psi=None and no stored history → PSI can't be computed → skipped, no alert.
+    assert r["alert"] is False
+    assert "Insufficient" in r["reason"]
+    assert r["notified"] is False
+
+
+def test_run_canary_alerts_and_notifies(db_session, monkeypatch):
+    calls = {}
+
+    def _fake_alert(db, **kwargs):
+        calls.update(kwargs)
+        return {"status": "sent"}
+
+    monkeypatch.setattr(drift_canary, "run_drift_canary", run_drift_canary)  # ensure real fn
+    monkeypatch.setattr("career_os.services.pushover.send_drift_alert", _fake_alert)
+
+    r = run_drift_canary(
+        db_session,
+        1,
+        kappa=0.30,
+        ndcg=0.60,
+        baseline_kappa=0.62,
+        baseline_ndcg=0.75,
+        psi=0.35,
+    )
+    assert r["alert"] is True
+    assert r["notified"] is True
+    assert calls["psi"] == 0.35
+
+
+def test_run_canary_alert_without_notify(db_session):
+    r = run_drift_canary(
+        db_session,
+        1,
+        kappa=0.30,
+        ndcg=0.60,
+        baseline_kappa=0.62,
+        baseline_ndcg=0.75,
+        psi=0.35,
+        notify=False,
+    )
+    assert r["alert"] is True
+    assert r["notified"] is False

--- a/tests/test_drift_canary.py
+++ b/tests/test_drift_canary.py
@@ -8,12 +8,14 @@ import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
+from career_os.config import settings
 from career_os.database import Base
 from career_os.models.models import Profile
 from career_os.models.scoring import ScoredJob
 from career_os.services import drift_canary
 from career_os.services.drift_canary import (
     compute_score_psi,
+    drift_canary_check,
     evaluate_drift,
     run_drift_canary,
 )
@@ -169,3 +171,57 @@ def test_run_canary_alert_without_notify(db_session):
     )
     assert r["alert"] is True
     assert r["notified"] is False
+
+
+# ---------------------------------------------------------------------------
+# drift_canary_check — the flag-gated entrypoint (DRIFT_CANARY_ENABLED)
+# ---------------------------------------------------------------------------
+
+
+def test_drift_canary_check_disabled_is_noop(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "drift_canary_enabled", False)
+    called = []
+
+    def _agreement():
+        called.append(1)
+        return (0.30, 0.60, 0.62, 0.75)
+
+    result = drift_canary_check(db_session, 1, agreement_fn=_agreement, notify=False)
+    assert result["status"] == "disabled"
+    # The golden re-score (a potential paid op) must NOT run when disabled.
+    assert called == []
+
+
+def test_drift_canary_check_enabled_runs_and_alerts(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "drift_canary_enabled", True)
+
+    now = datetime.now(UTC)
+    _add_scores(db_session, [1.0] * 22, now - timedelta(days=10))  # baseline: low
+    _add_scores(db_session, [9.0] * 22, now - timedelta(hours=2))  # recent: high → PSI high
+
+    called = []
+
+    def _agreement():
+        called.append(1)
+        return (0.30, 0.60, 0.62, 0.75)  # κ dropped vs baseline
+
+    result = drift_canary_check(db_session, 1, agreement_fn=_agreement, notify=False)
+    assert result["status"] == "ran"
+    assert called == [1]
+    assert result["alert"] is True
+    assert result["notified"] is False
+
+
+def test_drift_canary_check_enabled_stable_no_alert(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "drift_canary_enabled", True)
+
+    now = datetime.now(UTC)
+    _add_scores(db_session, [1.0] * 22, now - timedelta(days=10))
+    _add_scores(db_session, [9.0] * 22, now - timedelta(hours=2))  # PSI high
+
+    def _agreement():
+        return (0.63, 0.76, 0.62, 0.75)  # agreement held → no joint trip
+
+    result = drift_canary_check(db_session, 1, agreement_fn=_agreement, notify=False)
+    assert result["status"] == "ran"
+    assert result["alert"] is False

--- a/tests/test_scoring_eval.py
+++ b/tests/test_scoring_eval.py
@@ -1,0 +1,174 @@
+"""Unit tests for the scoring-eval metric primitives (G-1336).
+
+Validates the pure-Python metric math against analytically known values AND, when
+available, against scikit-learn as a reference oracle (dev-only; skipped if the
+package is absent). Covers weighted Cohen's κ, NDCG@5, PSI, and the tier
+projection.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from career_os.services.scoring_eval import (
+    DEFAULT_SCORE_BINS,
+    bin_counts,
+    kappa_from_tiers,
+    ndcg_at_k,
+    population_stability_index,
+    psi_from_scores,
+    tier_from_fit_score,
+    weighted_cohen_kappa,
+)
+
+# ---------------------------------------------------------------------------
+# Weighted Cohen's kappa
+# ---------------------------------------------------------------------------
+
+
+def test_kappa_perfect_agreement_is_one():
+    y = [0, 1, 2, 3, 2, 1, 0]
+    assert weighted_cohen_kappa(y, y, num_classes=4) == pytest.approx(1.0)
+
+
+def test_kappa_single_class_degenerate_returns_one():
+    # No disagreement weight to normalize against → treated as perfect.
+    assert weighted_cohen_kappa([2, 2, 2], [2, 2, 2], num_classes=4) == pytest.approx(1.0)
+
+
+def test_kappa_known_value():
+    # Hand-computable 2x2 case. y_true=[0,0,1,1], y_pred=[0,1,1,1].
+    # Confusion: O[0][0]=1,O[0][1]=1,O[1][1]=2. k=2 → linear weights = |i-j|.
+    # Observed disagreement = w-weighted O = O[0][1]*1 = 1.
+    # Row totals=[2,2], col totals=[1,3]. Expected disagree = (2*3 + 2*1)/4 *? compute:
+    #   E[0][1]=2*3/4=1.5 (w=1), E[1][0]=2*1/4=0.5 (w=1) → weighted E = 2.0
+    # kappa = 1 - 1/2 = 0.5
+    kappa = weighted_cohen_kappa([0, 0, 1, 1], [0, 1, 1, 1], num_classes=2)
+    assert kappa == pytest.approx(0.5)
+
+
+def test_kappa_matches_sklearn_oracle():
+    sk = pytest.importorskip("sklearn.metrics")
+    y_true = [0, 1, 2, 3, 1, 2, 0, 3, 2, 1]
+    y_pred = [0, 2, 2, 3, 1, 1, 0, 2, 3, 1]
+    ours = weighted_cohen_kappa(y_true, y_pred, num_classes=4)
+    theirs = sk.cohen_kappa_score(y_true, y_pred, weights="linear")
+    assert ours == pytest.approx(theirs, abs=1e-9)
+
+
+def test_kappa_from_tiers():
+    true = ["reject", "mediocre", "strong", "dream"]
+    pred = ["reject", "mediocre", "strong", "dream"]
+    assert kappa_from_tiers(true, pred) == pytest.approx(1.0)
+
+
+def test_kappa_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        weighted_cohen_kappa([0, 1], [0])
+
+
+def test_kappa_empty_raises():
+    with pytest.raises(ValueError):
+        weighted_cohen_kappa([], [])
+
+
+# ---------------------------------------------------------------------------
+# NDCG@k
+# ---------------------------------------------------------------------------
+
+
+def test_ndcg_perfect_ranking_is_one():
+    rel = [3, 2, 1, 0]
+    scores = [10.0, 8.0, 5.0, 1.0]  # already in ideal order
+    assert ndcg_at_k(rel, scores, k=4) == pytest.approx(1.0)
+
+
+def test_ndcg_known_value_reversed():
+    # rel=[0,1], scores rank item1 (rel=1) first → perfect → 1.0
+    assert ndcg_at_k([0, 1], [1.0, 2.0], k=2) == pytest.approx(1.0)
+    # scores rank item0 (rel=0) first → DCG = 0/log2(2)+1/log2(3); IDCG=1/log2(2)
+    dcg = 0 / math.log2(2) + 1 / math.log2(3)
+    idcg = 1 / math.log2(2)
+    assert ndcg_at_k([0, 1], [2.0, 1.0], k=2) == pytest.approx(dcg / idcg)
+
+
+def test_ndcg_all_zero_relevance_is_zero():
+    assert ndcg_at_k([0, 0, 0], [3.0, 2.0, 1.0], k=3) == 0.0
+
+
+def test_ndcg_matches_sklearn_oracle():
+    sk = pytest.importorskip("sklearn.metrics")
+    rel = [0.0, 1.0, 2.0, 3.0, 1.0, 0.0, 2.0]
+    scores = [0.5, 3.1, 2.2, 9.0, 1.0, 0.1, 4.0]  # distinct → no ties
+    ours = ndcg_at_k(rel, scores, k=5)
+    theirs = sk.ndcg_score([rel], [scores], k=5)
+    assert ours == pytest.approx(theirs, abs=1e-9)
+
+
+def test_ndcg_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        ndcg_at_k([1, 2], [1.0])
+
+
+# ---------------------------------------------------------------------------
+# Tier projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [
+        (0.0, "reject"),
+        (3.0, "reject"),
+        (3.5, "mediocre"),
+        (4.9, "mediocre"),
+        (5.0, "strong"),
+        (7.9, "strong"),
+        (8.0, "dream"),
+        (10.0, "dream"),
+    ],
+)
+def test_tier_from_fit_score(score, expected):
+    assert tier_from_fit_score(score) == expected
+
+
+# ---------------------------------------------------------------------------
+# PSI
+# ---------------------------------------------------------------------------
+
+
+def test_psi_identical_distributions_is_zero():
+    counts = [10, 20, 30, 40]
+    assert population_stability_index(counts, counts) == pytest.approx(0.0)
+
+
+def test_psi_known_two_bin_value():
+    # expected 50/50, actual 25/75. PSI = (.25-.5)ln(.25/.5)+(.75-.5)ln(.75/.5)
+    expected = (0.25 - 0.5) * math.log(0.25 / 0.5) + (0.75 - 0.5) * math.log(0.75 / 0.5)
+    assert population_stability_index([50, 50], [25, 75]) == pytest.approx(expected)
+
+
+def test_psi_shift_exceeds_significant_threshold():
+    # Big shift → PSI well above 0.2.
+    psi = population_stability_index([90, 10], [10, 90])
+    assert psi > 0.2
+
+
+def test_psi_bin_mismatch_raises():
+    with pytest.raises(ValueError):
+        population_stability_index([1, 2], [1, 2, 3])
+
+
+def test_psi_empty_raises():
+    with pytest.raises(ValueError):
+        population_stability_index([0, 0], [1, 1])
+
+
+def test_bin_counts_and_psi_from_scores():
+    counts = bin_counts([0.5, 1.9, 4.5, 9.9], edges=DEFAULT_SCORE_BINS)
+    assert sum(counts) == 4
+    # Same population → PSI 0.
+    scores = [1.0, 5.0, 9.0, 2.0, 7.0]
+    assert psi_from_scores(scores, scores) == pytest.approx(0.0)

--- a/tests/test_scoring_shadow.py
+++ b/tests/test_scoring_shadow.py
@@ -1,0 +1,148 @@
+"""Unit tests for scoring shadow-mode (G-1336, finding I)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from career_os.ai.base import AIProvider
+from career_os.ai.mock_provider import MockProvider
+from career_os.config import settings
+from career_os.database import Base
+from career_os.models.models import Profile
+from career_os.models.scoring import ShadowScore
+from career_os.services.scoring_shadow import (
+    compare_primary_vs_shadow,
+    maybe_record_shadow_score,
+    record_shadow_score,
+)
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk(conn, _rec):
+        cur = conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+    session.add(
+        Profile(id=1, name="U", email="u@test.example.com", location="Remote", job_family="TPM")
+    )
+    session.commit()
+    yield session
+    session.close()
+
+
+class _BoomProvider(AIProvider):
+    @property
+    def name(self):
+        return "boom"
+
+    async def complete(self, prompt, **kwargs):  # noqa: ANN001
+        raise RuntimeError("nope")
+
+    async def score(self, job_description, profile_data, **kwargs):  # noqa: ANN001
+        raise RuntimeError("shadow provider exploded")
+
+    async def embed(self, text, **kwargs):  # noqa: ANN001
+        return [0.0] * 768
+
+
+@pytest.mark.asyncio
+async def test_maybe_shadow_noop_when_unset(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "")
+    result = await maybe_record_shadow_score(
+        db_session, profile_id=1, prompt="p", profile_data={"weights": {}}, primary_fit_score=7.0
+    )
+    assert result is None
+    assert db_session.query(ShadowScore).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_maybe_shadow_logs_when_set(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "rubric-v2")
+    result = await maybe_record_shadow_score(
+        db_session,
+        profile_id=1,
+        prompt="Senior TPM at Acme",
+        profile_data={"weights": {}},
+        primary_fit_score=6.5,
+        provider=MockProvider(),
+    )
+    assert result is not None
+    row = db_session.query(ShadowScore).one()
+    assert row.variant == "rubric-v2"
+    assert row.primary_fit_score == 6.5
+    assert 0.0 <= row.fit_score <= 10.0
+
+
+@pytest.mark.asyncio
+async def test_shadow_is_defensive_on_provider_failure(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "bad")
+    # Must not raise, must not persist a partial row.
+    result = await maybe_record_shadow_score(
+        db_session,
+        profile_id=1,
+        prompt="p",
+        profile_data={"weights": {}},
+        primary_fit_score=5.0,
+        provider=_BoomProvider(),
+    )
+    assert result is None
+    assert db_session.query(ShadowScore).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_record_shadow_score_persists_fields(db_session):
+    row = await record_shadow_score(
+        db_session,
+        profile_id=1,
+        variant="mistral-large",
+        prompt="Data Engineer role",
+        profile_data={"weights": {}},
+        primary_fit_score=4.2,
+        provider=MockProvider(),
+    )
+    assert row.id is not None
+    assert row.variant == "mistral-large"
+    assert row.reasoning  # MockProvider always returns reasoning
+
+
+@pytest.mark.asyncio
+async def test_shadow_hook_fires_inside_score_job(db_session, monkeypatch):
+    """score_job logs a shadow row linked to the persisted primary score."""
+    from career_os.services.scoring import score_job
+
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "0to5-scale")
+    scored = await score_job(
+        db_session,
+        1,
+        "Own cross-functional AI programs. Python, cloud.",
+        job_title="Technical Program Manager",
+        job_company="Acme",
+    )
+    shadow = db_session.query(ShadowScore).one()
+    assert shadow.variant == "0to5-scale"
+    assert shadow.scored_job_id == scored.id
+    assert shadow.primary_fit_score == scored.fit_score
+
+
+def test_compare_primary_vs_shadow_bundle():
+    labels = ["reject", "mediocre", "strong", "dream"]
+    primary = [2.0, 4.5, 6.5, 9.0]  # aligned with labels → strong agreement
+    shadow = [9.0, 6.5, 4.5, 2.0]  # inverted → weak agreement
+    out = compare_primary_vs_shadow(primary, shadow, labels)
+    assert out["n"] == 4
+    assert out["primary"]["kappa"] > out["shadow"]["kappa"]
+    assert out["delta"]["kappa"] == pytest.approx(out["shadow"]["kappa"] - out["primary"]["kappa"])
+
+
+def test_compare_primary_vs_shadow_length_mismatch():
+    with pytest.raises(ValueError):
+        compare_primary_vs_shadow([1.0], [1.0, 2.0], ["reject", "dream"])

--- a/tests/test_scoring_shadow.py
+++ b/tests/test_scoring_shadow.py
@@ -1,10 +1,15 @@
-"""Unit tests for scoring shadow-mode (G-1336, finding I)."""
+"""Unit tests for scoring shadow-mode (G-1336, finding I).
+
+Covers real variant resolution (distinct provider, model override, self-compare
++ unknown → no-op), the fire-and-forget background worker on its own session,
+the score_job wiring, and the comparator.
+"""
 
 from __future__ import annotations
 
 import pytest
 from sqlalchemy import create_engine, event
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from career_os.ai.base import AIProvider
 from career_os.ai.mock_provider import MockProvider
@@ -13,9 +18,11 @@ from career_os.database import Base
 from career_os.models.models import Profile
 from career_os.models.scoring import ShadowScore
 from career_os.services.scoring_shadow import (
+    build_shadow_provider,
     compare_primary_vs_shadow,
-    maybe_record_shadow_score,
     record_shadow_score,
+    run_shadow_score,
+    schedule_shadow_score,
 )
 
 
@@ -54,48 +61,42 @@ class _BoomProvider(AIProvider):
         return [0.0] * 768
 
 
-@pytest.mark.asyncio
-async def test_maybe_shadow_noop_when_unset(db_session, monkeypatch):
-    monkeypatch.setattr(settings, "scoring_shadow_variant", "")
-    result = await maybe_record_shadow_score(
-        db_session, profile_id=1, prompt="p", profile_data={"weights": {}}, primary_fit_score=7.0
-    )
-    assert result is None
-    assert db_session.query(ShadowScore).count() == 0
+# ---------------------------------------------------------------------------
+# build_shadow_provider — real, distinct variant resolution
+# ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_maybe_shadow_logs_when_set(db_session, monkeypatch):
-    monkeypatch.setattr(settings, "scoring_shadow_variant", "rubric-v2")
-    result = await maybe_record_shadow_score(
-        db_session,
-        profile_id=1,
-        prompt="Senior TPM at Acme",
-        profile_data={"weights": {}},
-        primary_fit_score=6.5,
-        provider=MockProvider(),
-    )
-    assert result is not None
-    row = db_session.query(ShadowScore).one()
-    assert row.variant == "rubric-v2"
-    assert row.primary_fit_score == 6.5
-    assert 0.0 <= row.fit_score <= 10.0
+def test_build_shadow_provider_distinct():
+    prov = build_shadow_provider("mock", live_provider_name="anthropic")
+    assert prov is not None
+    assert prov.name == "mock"
 
 
-@pytest.mark.asyncio
-async def test_shadow_is_defensive_on_provider_failure(db_session, monkeypatch):
-    monkeypatch.setattr(settings, "scoring_shadow_variant", "bad")
-    # Must not raise, must not persist a partial row.
-    result = await maybe_record_shadow_score(
-        db_session,
-        profile_id=1,
-        prompt="p",
-        profile_data={"weights": {}},
-        primary_fit_score=5.0,
-        provider=_BoomProvider(),
-    )
-    assert result is None
-    assert db_session.query(ShadowScore).count() == 0
+def test_build_shadow_provider_self_compare_noops():
+    # Same provider, no model override → nothing to learn → None.
+    assert build_shadow_provider("mock", live_provider_name="mock") is None
+
+
+def test_build_shadow_provider_model_override_allows_same_provider():
+    # Same provider but a DIFFERENT model is a legit comparison → resolves, and
+    # the override is applied to the provider's model (stored as `_model`).
+    prov = build_shadow_provider("ollama:llama-custom", live_provider_name="ollama")
+    assert prov is not None
+    assert prov._model == "llama-custom"
+
+
+def test_build_shadow_provider_unknown_noops():
+    assert build_shadow_provider("nonexistent-provider") is None
+
+
+def test_build_shadow_provider_empty_noops():
+    assert build_shadow_provider("") is None
+    assert build_shadow_provider("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# record_shadow_score / run_shadow_score
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -111,15 +112,123 @@ async def test_record_shadow_score_persists_fields(db_session):
     )
     assert row.id is not None
     assert row.variant == "mistral-large"
+    assert row.primary_fit_score == 4.2
     assert row.reasoning  # MockProvider always returns reasoning
 
 
 @pytest.mark.asyncio
-async def test_shadow_hook_fires_inside_score_job(db_session, monkeypatch):
-    """score_job logs a shadow row linked to the persisted primary score."""
+async def test_run_shadow_score_uses_own_session(db_session):
+    factory = lambda: Session(bind=db_session.get_bind())  # noqa: E731
+    row = await run_shadow_score(
+        profile_id=1,
+        variant="rubric-v2",
+        prompt="Senior TPM at Acme",
+        profile_data={"weights": {}},
+        primary_fit_score=6.5,
+        provider=MockProvider(),
+        session_factory=factory,
+    )
+    assert row is not None
+    # Written via a separate session, visible from the test session (shared engine).
+    persisted = db_session.query(ShadowScore).one()
+    assert persisted.variant == "rubric-v2"
+    assert persisted.primary_fit_score == 6.5
+
+
+@pytest.mark.asyncio
+async def test_run_shadow_score_is_defensive(db_session):
+    factory = lambda: Session(bind=db_session.get_bind())  # noqa: E731
+    row = await run_shadow_score(
+        profile_id=1,
+        variant="bad",
+        prompt="p",
+        profile_data={"weights": {}},
+        primary_fit_score=5.0,
+        provider=_BoomProvider(),
+        session_factory=factory,
+    )
+    assert row is None
+    assert db_session.query(ShadowScore).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# schedule_shadow_score — fire-and-forget gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_noop_when_unset(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "")
+    task = schedule_shadow_score(
+        profile_id=1, prompt="p", profile_data={"weights": {}}, primary_fit_score=7.0
+    )
+    assert task is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_noop_when_sample_zero(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "mock")
+    monkeypatch.setattr(settings, "scoring_shadow_sample", 0.0)
+    task = schedule_shadow_score(
+        profile_id=1, prompt="p", profile_data={"weights": {}}, primary_fit_score=7.0
+    )
+    assert task is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_noop_on_self_compare(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "mock")
+    monkeypatch.setattr(settings, "scoring_shadow_sample", 1.0)
+    task = schedule_shadow_score(
+        profile_id=1,
+        prompt="p",
+        profile_data={"weights": {}},
+        primary_fit_score=7.0,
+        live_provider_name="mock",  # same as variant → self-compare → no-op
+    )
+    assert task is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_returns_task_and_writes(db_session, monkeypatch):
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "mock")
+    monkeypatch.setattr(settings, "scoring_shadow_sample", 1.0)
+    factory = lambda: Session(bind=db_session.get_bind())  # noqa: E731
+    task = schedule_shadow_score(
+        profile_id=1,
+        prompt="Senior TPM",
+        profile_data={"weights": {}},
+        primary_fit_score=6.0,
+        scored_job_id=None,
+        live_provider_name="anthropic",  # distinct from "mock" → runs
+        session_factory=factory,
+    )
+    assert task is not None
+    await task  # fire-and-forget task; drive it to completion in the test
+    row = db_session.query(ShadowScore).one()
+    assert row.variant == "mock"
+    assert row.primary_fit_score == 6.0
+
+
+# ---------------------------------------------------------------------------
+# score_job wiring — schedules (does not await) the shadow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_score_job_schedules_shadow_without_blocking(db_session, monkeypatch):
+    from career_os.services import scoring_shadow
     from career_os.services.scoring import score_job
 
-    monkeypatch.setattr(settings, "scoring_shadow_variant", "0to5-scale")
+    calls: list[dict] = []
+
+    def _spy(**kwargs):
+        calls.append(kwargs)
+        return None  # simulate fire-and-forget; return without awaiting anything
+
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "mistral")
+    monkeypatch.setattr(scoring_shadow, "schedule_shadow_score", _spy)
+
     scored = await score_job(
         db_session,
         1,
@@ -127,10 +236,28 @@ async def test_shadow_hook_fires_inside_score_job(db_session, monkeypatch):
         job_title="Technical Program Manager",
         job_company="Acme",
     )
-    shadow = db_session.query(ShadowScore).one()
-    assert shadow.variant == "0to5-scale"
-    assert shadow.scored_job_id == scored.id
-    assert shadow.primary_fit_score == scored.fit_score
+    assert len(calls) == 1
+    assert calls[0]["scored_job_id"] == scored.id
+    assert calls[0]["primary_fit_score"] == scored.fit_score
+    assert calls[0]["live_provider_name"] == "mock"
+
+
+@pytest.mark.asyncio
+async def test_score_job_does_not_schedule_when_unset(db_session, monkeypatch):
+    from career_os.services import scoring_shadow
+    from career_os.services.scoring import score_job
+
+    calls: list[dict] = []
+    monkeypatch.setattr(settings, "scoring_shadow_variant", "")
+    monkeypatch.setattr(scoring_shadow, "schedule_shadow_score", lambda **k: calls.append(k))
+
+    await score_job(db_session, 1, "Some role", job_title="X", job_company="Y")
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# comparator
+# ---------------------------------------------------------------------------
 
 
 def test_compare_primary_vs_shadow_bundle():


### PR DESCRIPTION
## Phase 2 of Scoring Engine v2 (G-1336) — findings H, I, J

Builds the evaluation infrastructure that makes scoring quality **measurable** and scoring changes **safe**, per Tier 3 of `docs/research/2026-07_scoring-technique-audit.md`. Follows G-1335 (the role-fit halo fix).

### The design rule: "production path, mock provider"
Every metric exercises the **real production scorer** — `career_os.services.scoring.score_job` and `batch_score_discovery` — never a reimplementation (the whole lesson from the proxy-path MAE miss). It runs on the deterministic **MockProvider** (`AI_PROVIDER=mock`), so there are **zero paid LLM calls** and CI is reproducible. Fit scoring is a *ranking* problem, so we evaluate **rank/quadrant agreement**, not MAE-to-a-reference.

### H — Golden-set harness + agreement metrics
- `tests/eval/` runs the 6 golden families (120 jobs) through the real `score_job` and computes **weighted Cohen's κ** (ordinal tier agreement) and **NDCG@5** (ranking).
- Gates on **deltas vs a frozen baseline** (`baseline_metrics.json`) with **tolerance bands**, not brittle absolute thresholds — tracks pipeline behavior without flapping.
- Metric math lives in pure-Python `career_os.services.scoring_eval` (weighted κ, NDCG@5, PSI), **cross-checked against scikit-learn** on toy data with analytically-known values.
- **Human labels are the remaining step.** Labels in `tests/eval/labels/*.labels.json` are **interim, model-derived** (seeded from the golden `category`), each bound to its job text by an `input_hash` so a changed fixture invalidates a stale label. The schema is ready for human `tier`/`relevance` judgments; with the mock provider κ≈0 today (hash scores are uncorrelated), so this ships the **infra + metric math + regression gate** — the ~120 human rank/quadrant labels then make the κ/NDCG gate a real quality signal (raise toward κ≥0.60). See `tests/eval/README.md`.

### I — Shadow-mode
- `SCORING_SHADOW_VARIANT` + a `shadow_scores` table (model + migration). When set, `score_job` scores each real job a second time with a candidate rubric/model and logs it — **never surfaced**, fully defensive (a shadow failure can't break live scoring). Mirrors the G-272 embedding-shadow pattern.
- `compare_primary_vs_shadow` scores prod-vs-shadow κ/NDCG against the golden labels.

### J — Drift canary
- `evaluate_drift` / `run_drift_canary` compute **PSI** (pure numpy-free) of the score distribution vs a rolling baseline + re-score the frozen golden set, and alert via the existing **Pushover** integration ONLY on the **joint** condition (PSI drift **AND** a κ/NDCG drop) so a benign job-mix shift never pages. Opt-in (`DRIFT_CANARY_ENABLED`) — invoked by a nightly job/CLI, not an always-on loop, since re-scoring is a small paid op.

### Tests & CI
- New unit tests (fast run): metric math vs known values + sklearn oracle, shadow logging/defensiveness/`score_job` hook, PSI math, joint-alert logic. `tests/eval/` is `@pytest.mark.eval`, excluded from the fast CI run and gated by a new **nightly** job.
- Verified locally: full suite **3743 passed, 26 skipped** (eval deselected); `tests/eval/` **14 passed**; `ruff check` + `ruff format --check` clean; alembic single head + `upgrade`/`downgrade base`/`upgrade` roundtrip; `pip install -e ".[dev]"` resolves.

### New dependency
- `scikit-learn>=1.4` added to the **dev** extra only — a test-time oracle for the pure-Python metric math. **Not a runtime dependency**; the shipped package never imports it.

### Follow-up (human)
- Replace the interim model-derived labels with **~60–120 human rank/quadrant labels** across the 6 families, run a real reference model once, and raise the gate toward weighted κ≥0.60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
