### PR TITLE
feat(G-1338): confidence-routed cascade (conservative, shadow-first) — part 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,3 +102,24 @@ DISTILLATION_LOGGING_ENABLED=false
 # calibration). Non-destructive — raw fit_scores are never mutated; the relative
 # view is exposed alongside them. Off by default (default behavior unchanged).
 RELATIVE_BATCH_SCORING_ENABLED=false
+
+# Confidence-routed cascade (finding K, Phase 4b): a conservative, SHADOW-FIRST
+# routing layer that skips the expensive LLM call for a job ONLY when all three
+# cheap signals agree it is clearly not a fit — (1) low embedding similarity,
+# (2) no lexical must-have overlap, (3) low ESCO skills-overlap. One or two
+# signals is never enough, and a signal with no data abstains (which blocks a
+# skip). It NEVER auto-accepts. Two SEPARATE flags, both OFF by default:
+#   * SHADOW: log what the router WOULD skip (plus the eventual LLM score) but
+#     still score everything, so the false-skip rate can be measured first.
+#   * ROUTING (live): actually skip unanimous-reject jobs — persisted as a
+#     scored-but-rejected job (never dropped). Keep OFF until shadow data is good.
+CASCADE_SHADOW_ENABLED=false
+CASCADE_ROUTING_ENABLED=false
+# Conservative per-signal reject thresholds (defaults shown). Embedding rejects
+# only BELOW this cosine similarity (far under the 0.65 pre-filter bar); lexical
+# and ESCO reject only at/below zero overlap.
+CASCADE_EMBEDDING_REJECT_THRESHOLD=0.35
+CASCADE_LEXICAL_REJECT_THRESHOLD=0.0
+CASCADE_ESCO_REJECT_THRESHOLD=0.0
+# Deterministic low fit score persisted for a live skip_reject (visible, not lost).
+CASCADE_REJECT_FIT_SCORE=1.0

--- a/alembic/versions/u3v4w5x6y7z8_add_cascade_decisions_table.py
+++ b/alembic/versions/u3v4w5x6y7z8_add_cascade_decisions_table.py
@@ -1,0 +1,96 @@
+"""Add cascade_decisions table for the confidence-routed cascade (G-1338, finding K).
+
+Revision ID: u3v4w5x6y7z8
+Revises: t2u3v4w5x6y7
+Create Date: 2026-07-17 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "u3v4w5x6y7z8"
+down_revision: str | None = "t2u3v4w5x6y7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cascade_decisions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("profile_id", sa.Integer(), nullable=False),
+        sa.Column("scored_job_id", sa.Integer(), nullable=True),
+        sa.Column("discovered_job_id", sa.Integer(), nullable=True),
+        sa.Column("application_id", sa.Integer(), nullable=True),
+        sa.Column("mode", sa.String(length=20), nullable=False),
+        sa.Column("action", sa.String(length=20), nullable=False),
+        sa.Column("would_skip", sa.Boolean(), nullable=False),
+        sa.Column("embedding_similarity", sa.Float(), nullable=True),
+        sa.Column("embedding_available", sa.Boolean(), nullable=False),
+        sa.Column("embedding_votes_reject", sa.Boolean(), nullable=False),
+        sa.Column("lexical_overlap", sa.Float(), nullable=True),
+        sa.Column("lexical_available", sa.Boolean(), nullable=False),
+        sa.Column("lexical_votes_reject", sa.Boolean(), nullable=False),
+        sa.Column("esco_overlap", sa.Float(), nullable=True),
+        sa.Column("esco_available", sa.Boolean(), nullable=False),
+        sa.Column("esco_votes_reject", sa.Boolean(), nullable=False),
+        sa.Column("llm_fit_score", sa.Float(), nullable=True),
+        sa.Column("llm_quadrant", sa.String(length=20), nullable=True),
+        sa.Column("reject_fit_score", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["profile_id"], ["profiles.id"]),
+        sa.ForeignKeyConstraint(["scored_job_id"], ["scored_jobs.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["discovered_job_id"], ["discovered_jobs.id"]),
+        sa.ForeignKeyConstraint(["application_id"], ["applications.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_profile_id"),
+        "cascade_decisions",
+        ["profile_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_scored_job_id"),
+        "cascade_decisions",
+        ["scored_job_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_discovered_job_id"),
+        "cascade_decisions",
+        ["discovered_job_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_application_id"),
+        "cascade_decisions",
+        ["application_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_mode"),
+        "cascade_decisions",
+        ["mode"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cascade_decisions_action"),
+        "cascade_decisions",
+        ["action"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cascade_decisions_action"), table_name="cascade_decisions")
+    op.drop_index(op.f("ix_cascade_decisions_mode"), table_name="cascade_decisions")
+    op.drop_index(op.f("ix_cascade_decisions_application_id"), table_name="cascade_decisions")
+    op.drop_index(op.f("ix_cascade_decisions_discovered_job_id"), table_name="cascade_decisions")
+    op.drop_index(op.f("ix_cascade_decisions_scored_job_id"), table_name="cascade_decisions")
+    op.drop_index(op.f("ix_cascade_decisions_profile_id"), table_name="cascade_decisions")
+    op.drop_table("cascade_decisions")

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -126,6 +126,41 @@ class Settings(BaseSettings):
     # identity: default behavior is unchanged).
     relative_batch_scoring_enabled: bool = False
 
+    # Confidence-routed cascade (Scoring Engine v2 / G-1338, finding K — Phase 4b) —
+    # a conservative, SHADOW-FIRST routing layer that decides which jobs even need
+    # the expensive LLM call. A job is auto-rejected (LLM skipped) ONLY when ALL
+    # THREE cheap signals have data and all three independently agree it is clearly
+    # not a fit: (1) low embedding similarity, (2) no lexical must-have overlap,
+    # (3) low ESCO skills-overlap. One or two signals is never enough (the G-272
+    # lesson). It NEVER auto-accepts — everything that is not a unanimous reject
+    # goes to the LLM as today.
+    #
+    # Two SEPARATE flags, both OFF by default:
+    #   * CASCADE_SHADOW_ENABLED — log what the router WOULD skip (plus the eventual
+    #     LLM score) but still score everything, so the false-skip rate can be
+    #     measured BEFORE trusting the router. This is the primary deliverable.
+    #   * CASCADE_ROUTING_ENABLED — LIVE skipping: a unanimous-reject job actually
+    #     bypasses the LLM and is persisted as a scored-but-rejected job (never
+    #     dropped). Keep OFF until the shadow false-skip rate is acceptably low.
+    cascade_shadow_enabled: bool = False
+    cascade_routing_enabled: bool = False
+
+    # Per-signal conservative reject thresholds. Each signal only votes to reject
+    # on POSITIVE evidence of non-fit; an unavailable signal abstains and blocks a
+    # skip. Deliberately strict so a good job is never skipped on a weak signal:
+    #   * embedding: reject only when cosine similarity is BELOW this (far below the
+    #     0.65 pre-filter bar — a confident reject, not a filter).
+    #   * lexical / esco: reject only when overlap is AT OR BELOW this (0.0 = the
+    #     candidate shares genuinely zero must-have terms / ESCO skills with the JD).
+    cascade_embedding_reject_threshold: float = 0.35
+    cascade_lexical_reject_threshold: float = 0.0
+    cascade_esco_reject_threshold: float = 0.0
+
+    # Deterministic low fit score persisted for a LIVE skip_reject (so the job is
+    # visibly scored-but-rejected, never silently dropped). Lands in the "reject"
+    # tier (< 3.5) and below the quadrant threshold (5.0).
+    cascade_reject_fit_score: float = 1.0
+
     # Drift canary (Scoring Engine v2 / G-1336, finding J) — nightly-style check
     # that computes PSI of the score distribution vs a rolling baseline and
     # re-scores the frozen golden set, alerting via Pushover ONLY on the joint

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from dotenv import load_dotenv
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 # Ensure .env vars land in os.environ before anything reads them (ported from
@@ -152,14 +152,18 @@ class Settings(BaseSettings):
     #     0.65 pre-filter bar — a confident reject, not a filter).
     #   * lexical / esco: reject only when overlap is AT OR BELOW this (0.0 = the
     #     candidate shares genuinely zero must-have terms / ESCO skills with the JD).
-    cascade_embedding_reject_threshold: float = 0.35
-    cascade_lexical_reject_threshold: float = 0.0
-    cascade_esco_reject_threshold: float = 0.0
+    # Bounded [0, 1] so a misconfigured operator with the live flag on cannot set a
+    # threshold high enough to mass-skip good jobs (a high reject bar would reject
+    # almost everything). All three are similarity/overlap fractions in [0, 1].
+    cascade_embedding_reject_threshold: float = Field(default=0.35, ge=0.0, le=1.0)
+    cascade_lexical_reject_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
+    cascade_esco_reject_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
 
     # Deterministic low fit score persisted for a LIVE skip_reject (so the job is
     # visibly scored-but-rejected, never silently dropped). Lands in the "reject"
-    # tier (< 3.5) and below the quadrant threshold (5.0).
-    cascade_reject_fit_score: float = 1.0
+    # tier (< 3.5) and below the quadrant threshold (5.0). Bounded to the fit-score
+    # range [0, 10]; keep it low so a skipped job never masquerades as a fit.
+    cascade_reject_fit_score: float = Field(default=1.0, ge=0.0, le=10.0)
 
     # Drift canary (Scoring Engine v2 / G-1336, finding J) — nightly-style check
     # that computes PSI of the score distribution vs a rolling baseline and

--- a/src/career_os/models/__init__.py
+++ b/src/career_os/models/__init__.py
@@ -25,6 +25,7 @@ from career_os.models.models import (
 from career_os.models.onboarding import OnboardingState
 from career_os.models.pushover import NotificationLog, NotificationPreference
 from career_os.models.scoring import (
+    CascadeDecision,
     DistillationSample,
     ScoredJob,
     ScoringWeights,
@@ -53,6 +54,7 @@ __all__ = [
     "ContactApplication",
     "ContactInteraction",
     "ApplicationPackage",
+    "CascadeDecision",
     "CoachingSuggestion",
     "DistillationSample",
     "Embedding",

--- a/src/career_os/models/scoring.py
+++ b/src/career_os/models/scoring.py
@@ -261,6 +261,93 @@ class DistillationSample(Base):
         )
 
 
+class CascadeDecision(Base):
+    """A confidence-routed cascade routing decision (G-1338, finding K — Phase 4b).
+
+    The cascade is a conservative, shadow-first routing layer that decides which
+    jobs even need the expensive LLM scoring call, using three cheap signals:
+    embedding similarity, lexical must-have overlap, and ESCO skills-overlap. A
+    job is routed to ``skip_reject`` **only** when ALL THREE signals have data and
+    all three independently agree it is clearly not a fit (unanimous, conservative
+    agreement — one or two signals is never enough). Everything else is scored by
+    the LLM as usual.
+
+    Every routing decision is recorded here so the router can be measured before
+    it is ever trusted:
+
+    * In **shadow mode** (``CASCADE_SHADOW_ENABLED``) the LLM still scores every
+      job; the decision is logged with the eventual ``llm_fit_score`` so a
+      comparator can compute the **false-skip rate** (jobs the router would have
+      rejected that the LLM actually scored as a fit) BEFORE live skipping is ever
+      enabled.
+    * In **live mode** (``CASCADE_ROUTING_ENABLED``, a SEPARATE flag) a
+      ``skip_reject`` job bypasses the LLM and is persisted as a scored-but-
+      rejected job (``reject_fit_score``) — never dropped. ``llm_fit_score`` is
+      NULL for a live-skipped job because no LLM call was made.
+
+    This table is **write-only from the scoring path** — nothing in the live
+    product reads it, and a routing/logging failure never breaks or slows scoring.
+    """
+
+    __tablename__ = "cascade_decisions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("profiles.id"), nullable=False, index=True
+    )
+    # SET NULL so pruning a live score never drops the routing audit trail.
+    scored_job_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("scored_jobs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    discovered_job_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("discovered_jobs.id"), nullable=True, index=True
+    )
+    application_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("applications.id"), nullable=True, index=True
+    )
+
+    # "shadow" (LLM still scored everything) or "live" (skip_reject bypassed the LLM).
+    mode: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    # "skip_reject" or "score".
+    action: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    # Denormalized convenience flag (action == "skip_reject") for cheap aggregation.
+    would_skip: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # --- The three routing signals (value + availability + per-signal vote) ---
+    # ``*_available`` is False when the signal had no data to judge (e.g. no
+    # embedding, no parsed requirements, no ESCO-grounded skills). An unavailable
+    # signal can NEVER vote to reject — abstention blocks a skip.
+    embedding_similarity: Mapped[float | None] = mapped_column(Float, nullable=True)
+    embedding_available: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    embedding_votes_reject: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    lexical_overlap: Mapped[float | None] = mapped_column(Float, nullable=True)
+    lexical_available: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    lexical_votes_reject: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    esco_overlap: Mapped[float | None] = mapped_column(Float, nullable=True)
+    esco_available: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    esco_votes_reject: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # --- Outcome ---
+    # The eventual LLM fit score (shadow rows, and live rows that were scored).
+    # NULL when a live skip_reject bypassed the LLM entirely.
+    llm_fit_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    llm_quadrant: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # The deterministic low score persisted for a live skip_reject (NULL otherwise).
+    reject_fit_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CascadeDecision(id={self.id}, mode='{self.mode}', action='{self.action}', "
+            f"profile_id={self.profile_id})>"
+        )
+
+
 class ScoringFeedback(Base):
     """User feedback on an AI-generated score.
 

--- a/src/career_os/services/cascade_router.py
+++ b/src/career_os/services/cascade_router.py
@@ -1,0 +1,644 @@
+"""Confidence-routed cascade (G-1338, finding K — Phase 4b, part 2).
+
+A conservative, SHADOW-FIRST routing layer that decides which jobs even need the
+expensive LLM scoring call, using three cheap, non-LLM signals. It **reframes the
+blocked G-272 embedding pre-filter**: embeddings were never meant to be a gate on
+their own (overlapping distributions mis-reject good jobs), so instead of a single
+cosine threshold this router requires *unanimous* agreement across three
+orthogonal signals before it will ever skip a job.
+
+The rule (locked design):
+
+* **Auto-REJECT only.** A job is routed to :attr:`CascadeAction.SKIP_REJECT` — the
+  LLM is skipped — ONLY when ALL THREE signals **have data** and all three
+  independently vote "clearly not a fit":
+
+    1. **embedding similarity** below a conservative reject threshold (reuses the
+       G-272 profile↔job cosine similarity),
+    2. **lexical must-have overlap** at/below threshold (zero) — the JD's parsed
+       must-have terms share no fuzzy/lexical overlap with the candidate, or (when
+       no requirements are parsed) none of the candidate's skills appear in the JD
+       text,
+    3. **ESCO skills-overlap** at/below threshold (zero) — from the 4a
+       :mod:`~career_os.services.esco_features` feature.
+
+  One or two signals is NEVER enough. Crucially, a signal with **no data**
+  (no embedding, no parsed requirements + empty JD text, no ESCO-grounded skills)
+  ABSTAINS — and an abstaining signal blocks a skip. So a skip requires positive
+  non-fit evidence from all three at once. This is the whole G-272 lesson.
+
+* **NEVER auto-ACCEPT.** There is no "clear-strong skip". Everything that is not a
+  unanimous reject is routed to :attr:`CascadeAction.SCORE` and hits the LLM
+  exactly as it does today.
+
+* **SHADOW-FIRST.** In shadow mode the LLM still scores everything; the routing
+  decision is logged beside the eventual LLM score so the **false-skip rate**
+  (jobs the router would have rejected that the LLM actually scored as a fit) can
+  be measured BEFORE live skipping is ever trusted.
+
+* **Live is a separate flag, off by default.** A live ``SKIP_REJECT`` bypasses the
+  LLM and is persisted as a scored-but-rejected job (never dropped).
+
+Everything here is **defensive**: a routing or logging failure is logged and
+swallowed, and on any uncertainty the router falls back to ``SCORE`` — it never
+skips a job on an error. The router itself makes **zero LLM calls**.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from rapidfuzz import fuzz
+from sqlalchemy.orm import Session
+
+from career_os.config import settings
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.models import Application
+from career_os.models.scoring import CascadeDecision as CascadeDecisionRow
+from career_os.models.scoring import ScoredJob
+from career_os.models.skills import JobRequirement, Skill
+from career_os.schemas.scoring import classify_quadrant
+from career_os.services.esco_features import compute_job_skills_overlap
+
+logger = logging.getLogger(__name__)
+
+# rapidfuzz WRatio floor (0–100) for a lexical token match. Matches the
+# skill_normalizer's fuzzy threshold so "the same skill, spelled differently"
+# still counts as overlap and does NOT push a job toward a wrongful skip.
+_LEXICAL_FUZZ_THRESHOLD = 85.0
+
+# Fit threshold (0–10) the false-skip comparator uses to decide the LLM "would
+# have kept" a job. 5.0 is the quadrant boundary (a job the LLM scored >= 5.0 is
+# at least not a reject) — a skip of such a job is a false skip.
+DEFAULT_FIT_THRESHOLD = 5.0
+
+
+class CascadeAction(StrEnum):
+    """The routing decision for a single job."""
+
+    SKIP_REJECT = "skip_reject"
+    SCORE = "score"
+
+
+@dataclass
+class SignalVote:
+    """One routing signal's verdict for a job.
+
+    ``available`` is False when the signal had no data to judge on. An unavailable
+    signal can never vote to reject (``votes_reject`` is forced False), so
+    abstention structurally blocks a skip.
+    """
+
+    name: str
+    available: bool
+    value: float | None
+    votes_reject: bool
+    detail: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Hard invariant: an unavailable signal never votes to reject.
+        if not self.available:
+            self.votes_reject = False
+
+
+@dataclass
+class CascadeDecision:
+    """The full routing decision plus the three signal votes."""
+
+    action: CascadeAction
+    embedding: SignalVote
+    lexical: SignalVote
+    esco: SignalVote
+
+    @property
+    def would_skip(self) -> bool:
+        """True iff the router would skip the LLM for this job."""
+        return self.action == CascadeAction.SKIP_REJECT
+
+    @property
+    def signals(self) -> tuple[SignalVote, SignalVote, SignalVote]:
+        """The three signal votes in a stable order."""
+        return (self.embedding, self.lexical, self.esco)
+
+    def reject_reasons(self) -> list[str]:
+        """Human-readable per-signal reasons (only meaningful on a skip)."""
+        reasons: list[str] = []
+        for s in self.signals:
+            if s.available and s.votes_reject:
+                val = f"{s.value:.3f}" if s.value is not None else "n/a"
+                reasons.append(f"{s.name}={val}")
+        return reasons
+
+
+# ---------------------------------------------------------------------------
+# The three signals (each pure / DB-read-only, individually defensive)
+# ---------------------------------------------------------------------------
+
+
+def embedding_signal(
+    similarity: float | None,
+    *,
+    reject_threshold: float | None = None,
+) -> SignalVote:
+    """Vote from the G-272 profile↔job embedding cosine similarity.
+
+    ``similarity`` is the already-computed cosine similarity (0–1), or ``None``
+    when the job had no embedding (the signal then abstains). Votes to reject only
+    when the similarity is strictly BELOW the conservative reject threshold.
+    """
+    threshold = (
+        settings.cascade_embedding_reject_threshold
+        if reject_threshold is None
+        else reject_threshold
+    )
+    available = similarity is not None
+    votes_reject = available and similarity < threshold  # type: ignore[operator]
+    return SignalVote(
+        name="embedding",
+        available=available,
+        value=similarity,
+        votes_reject=votes_reject,
+        detail={"threshold": threshold},
+    )
+
+
+def _normalize_term(term: str) -> str:
+    """Lowercase + strip a skill/term for lexical comparison."""
+    return term.strip().lower()
+
+
+def _term_matches_any(term: str, candidates: list[str]) -> bool:
+    """True if ``term`` fuzzily matches any candidate term (set overlap)."""
+    t = _normalize_term(term)
+    if not t:
+        return False
+    for cand in candidates:
+        c = _normalize_term(cand)
+        if not c:
+            continue
+        if t in c or c in t:
+            return True
+        if fuzz.WRatio(t, c) >= _LEXICAL_FUZZ_THRESHOLD:
+            return True
+    return False
+
+
+def _term_in_text(term: str, text: str) -> bool:
+    """True if ``term`` appears (substring, case-insensitive) in free JD text.
+
+    Substring only — free-text fuzzy matching is too noisy for short skill tokens
+    and could manufacture overlap that isn't there. Being strict here makes the
+    lexical signal MORE likely to abstain-or-reject honestly, never to fabricate a
+    match that wrongly rescues a job from a (correct) skip.
+    """
+    t = _normalize_term(term)
+    if len(t) < 3:
+        return False
+    return t in text.lower()
+
+
+def compute_lexical_overlap(
+    musthave_terms: list[str],
+    candidate_terms: list[str],
+) -> dict:
+    """Pure fuzzy overlap of the JD's must-have terms against candidate terms.
+
+    Returns ``{overlap_score, matched, total, matched_terms, missing_terms}``.
+    ``overlap_score`` is ``matched / total`` (0.0 when there are no must-have
+    terms — the caller must check ``total`` to distinguish "no data" from "zero
+    overlap", exactly like the ESCO feature).
+    """
+    seen: set[str] = set()
+    unique_terms: list[str] = []
+    for term in musthave_terms:
+        norm = _normalize_term(term)
+        if norm and norm not in seen:
+            seen.add(norm)
+            unique_terms.append(term)
+
+    matched_terms: list[str] = []
+    missing_terms: list[str] = []
+    for term in unique_terms:
+        if _term_matches_any(term, candidate_terms):
+            matched_terms.append(term)
+        else:
+            missing_terms.append(term)
+
+    total = len(unique_terms)
+    overlap_score = round(len(matched_terms) / total, 4) if total else 0.0
+    return {
+        "overlap_score": overlap_score,
+        "matched": len(matched_terms),
+        "total": total,
+        "matched_terms": matched_terms,
+        "missing_terms": missing_terms,
+    }
+
+
+def _candidate_skill_names(db: Session, profile_id: int) -> list[str]:
+    """Candidate profile skill names (the lexical 'have' side)."""
+    rows = db.query(Skill.name).filter(Skill.profile_id == profile_id).all()
+    return [name for (name,) in rows if name]
+
+
+def _job_musthave_terms(db: Session, application_id: int, profile_id: int) -> list[str]:
+    """The JD's must-have terms: critical parsed requirements, else all of them."""
+    rows = (
+        db.query(JobRequirement.skill_name, JobRequirement.severity)
+        .filter(
+            JobRequirement.application_id == application_id,
+            JobRequirement.profile_id == profile_id,
+        )
+        .all()
+    )
+    critical = [name for (name, sev) in rows if name and (sev or "").lower() == "critical"]
+    if critical:
+        return critical
+    return [name for (name, _sev) in rows if name]
+
+
+def lexical_signal(
+    db: Session,
+    *,
+    profile_id: int,
+    application_id: int | None,
+    jd_text: str | None,
+    reject_threshold: float | None = None,
+) -> SignalVote:
+    """Vote from lexical must-have overlap between the JD and the candidate.
+
+    Primary path (when the job has parsed requirements): fuzzy-match the JD's
+    must-have terms against the candidate's skill names. Fallback (no parsed
+    requirements): count how many of the candidate's skills appear in the raw JD
+    text. Abstains when neither has data. Votes to reject only when overlap is
+    at/below the (zero) threshold — genuinely no lexical common ground.
+    """
+    threshold = (
+        settings.cascade_lexical_reject_threshold if reject_threshold is None else reject_threshold
+    )
+    candidate = _candidate_skill_names(db, profile_id)
+
+    musthaves = (
+        _job_musthave_terms(db, application_id, profile_id) if application_id is not None else []
+    )
+
+    source: str
+    if musthaves and candidate:
+        result = compute_lexical_overlap(musthaves, candidate)
+        source = "requirements"
+    elif jd_text and candidate:
+        # Fallback: are ANY of the candidate's skills lexically present in the JD?
+        matched = [s for s in candidate if _term_in_text(s, jd_text)]
+        total = len(candidate)
+        result = {
+            "overlap_score": round(len(matched) / total, 4) if total else 0.0,
+            "matched": len(matched),
+            "total": total,
+            "matched_terms": matched,
+            "missing_terms": [s for s in candidate if s not in matched],
+        }
+        source = "jd_text"
+    else:
+        # No must-have terms AND no usable JD-text/candidate pairing → abstain.
+        return SignalVote(
+            name="lexical",
+            available=False,
+            value=None,
+            votes_reject=False,
+            detail={"source": "none"},
+        )
+
+    available = result["total"] > 0
+    overlap = result["overlap_score"]
+    votes_reject = available and overlap <= threshold
+    return SignalVote(
+        name="lexical",
+        available=available,
+        value=overlap if available else None,
+        votes_reject=votes_reject,
+        detail={
+            "source": source,
+            "matched": result["matched"],
+            "total": result["total"],
+            "threshold": threshold,
+        },
+    )
+
+
+def esco_signal(
+    db: Session,
+    *,
+    profile_id: int,
+    application_id: int | None,
+    reject_threshold: float | None = None,
+) -> SignalVote:
+    """Vote from the 4a ESCO severity-weighted skills-overlap feature.
+
+    Abstains when the job has no ESCO-grounded requirements (``total == 0`` — the
+    esco_features docstring warns ``overlap_score == 0.0`` conflates "no data" and
+    "zero coverage", so we key availability on ``total``). Votes to reject only
+    when there IS data and the weighted coverage is at/below the (zero) threshold.
+    """
+    threshold = (
+        settings.cascade_esco_reject_threshold if reject_threshold is None else reject_threshold
+    )
+    if application_id is None:
+        return SignalVote(
+            name="esco", available=False, value=None, votes_reject=False, detail={"total": 0}
+        )
+    overlap = compute_job_skills_overlap(db, application_id=application_id, profile_id=profile_id)
+    total = overlap.get("total", 0)
+    available = total > 0
+    score = overlap.get("overlap_score", 0.0)
+    votes_reject = available and score <= threshold
+    return SignalVote(
+        name="esco",
+        available=available,
+        value=score if available else None,
+        votes_reject=votes_reject,
+        detail={
+            "matched": overlap.get("matched", 0),
+            "total": total,
+            "threshold": threshold,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# The router
+# ---------------------------------------------------------------------------
+
+
+def route_job(
+    db: Session,
+    *,
+    profile_id: int,
+    application_id: int | None = None,
+    discovered_job_id: int | None = None,
+    embedding_similarity: float | None = None,
+    jd_text: str | None = None,
+    embedding_reject_threshold: float | None = None,
+    lexical_reject_threshold: float | None = None,
+    esco_reject_threshold: float | None = None,
+) -> CascadeDecision:
+    """Compute the routing decision for one job from the three signals.
+
+    Returns :attr:`CascadeAction.SKIP_REJECT` **iff all three signals have data
+    AND all three vote to reject** (unanimous, conservative). Any abstaining or
+    non-reject signal yields :attr:`CascadeAction.SCORE`. Makes zero LLM calls.
+    """
+    emb = embedding_signal(embedding_similarity, reject_threshold=embedding_reject_threshold)
+    lex = lexical_signal(
+        db,
+        profile_id=profile_id,
+        application_id=application_id,
+        jd_text=jd_text,
+        reject_threshold=lexical_reject_threshold,
+    )
+    esc = esco_signal(
+        db,
+        profile_id=profile_id,
+        application_id=application_id,
+        reject_threshold=esco_reject_threshold,
+    )
+
+    unanimous_reject = all(s.available and s.votes_reject for s in (emb, lex, esc))
+    action = CascadeAction.SKIP_REJECT if unanimous_reject else CascadeAction.SCORE
+    return CascadeDecision(action=action, embedding=emb, lexical=lex, esco=esc)
+
+
+def safe_route_job(
+    db: Session,
+    *,
+    profile_id: int,
+    application_id: int | None = None,
+    discovered_job_id: int | None = None,
+    embedding_similarity: float | None = None,
+    jd_text: str | None = None,
+) -> CascadeDecision | None:
+    """Defensive wrapper around :func:`route_job` for the live scoring path.
+
+    Returns ``None`` on ANY failure (rolling back a poisoned read transaction) so
+    the caller falls through to normal LLM scoring — the router never skips a job
+    because of its own error.
+    """
+    try:
+        return route_job(
+            db,
+            profile_id=profile_id,
+            application_id=application_id,
+            discovered_job_id=discovered_job_id,
+            embedding_similarity=embedding_similarity,
+            jd_text=jd_text,
+        )
+    except Exception:
+        logger.warning(
+            "Cascade routing failed for profile=%s discovered_job=%s application=%s "
+            "(swallowed — job will be scored normally)",
+            profile_id,
+            discovered_job_id,
+            application_id,
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            logger.debug("Cascade routing rollback also failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Persistence — nothing silently dropped
+# ---------------------------------------------------------------------------
+
+
+def persist_cascade_reject(
+    db: Session,
+    *,
+    profile_id: int,
+    decision: CascadeDecision,
+    discovered_job_id: int | None = None,
+    application_id: int | None = None,
+    reject_fit_score: float | None = None,
+) -> ScoredJob:
+    """Persist a LIVE cascade skip as a scored-but-rejected job.
+
+    A skipped job is NEVER dropped — it is written to ``scored_jobs`` with a
+    deterministic low ``fit_score`` and a reasoning string naming the cascade, and
+    its cached ``fit_score`` is propagated to the linked DiscoveredJob/Application
+    (mirroring ``_update_linked_scores``) so it renders as a normal (low) score in
+    the UI. Commits and returns the persisted row.
+    """
+    score = settings.cascade_reject_fit_score if reject_fit_score is None else reject_fit_score
+    reasons = ", ".join(decision.reject_reasons()) or "all three signals below threshold"
+    scored = ScoredJob(
+        profile_id=profile_id,
+        discovered_job_id=discovered_job_id,
+        application_id=application_id,
+        fit_score=score,
+        readiness_score=0.0,
+        career_alignment=0.0,
+        reasoning=(
+            "Auto-rejected by the confidence-routed cascade without an LLM call: all "
+            f"three cheap signals agreed this is not a fit ({reasons}). "
+            "Enable full scoring to override."
+        ),
+        effort_flag="low",
+        prep_level="unknown",
+        is_stale=False,
+    )
+    db.add(scored)
+
+    # Propagate to linked records (inlined to avoid a scoring<->cascade import cycle).
+    if discovered_job_id is not None:
+        dj = db.query(DiscoveredJob).filter(DiscoveredJob.id == discovered_job_id).first()
+        if dj:
+            dj.fit_score = score
+    if application_id is not None:
+        app_record = db.query(Application).filter(Application.id == application_id).first()
+        if app_record:
+            app_record.fit_score = score
+
+    db.commit()
+    db.refresh(scored)
+    return scored
+
+
+def record_cascade_decision(
+    db: Session,
+    *,
+    profile_id: int,
+    decision: CascadeDecision,
+    mode: str,
+    scored_job_id: int | None = None,
+    discovered_job_id: int | None = None,
+    application_id: int | None = None,
+    llm_fit_score: float | None = None,
+    llm_desire_score: float | None = None,
+    reject_fit_score: float | None = None,
+) -> CascadeDecisionRow | None:
+    """Log a routing decision to ``cascade_decisions``. Defensive; never raises.
+
+    Records the action, the three signal votes, and the outcome. In shadow mode
+    ``llm_fit_score`` is the eventual live score (so the false-skip comparator can
+    run); in a live skip it is ``None`` (no LLM call) and ``reject_fit_score`` is
+    the deterministic score persisted instead. Any failure is logged and swallowed
+    and the session rolled back — logging never affects the committed score.
+    """
+    try:
+        quadrant = (
+            classify_quadrant(llm_fit_score, llm_desire_score)
+            if llm_fit_score is not None
+            else None
+        )
+        emb, lex, esc = decision.embedding, decision.lexical, decision.esco
+        row = CascadeDecisionRow(
+            profile_id=profile_id,
+            scored_job_id=scored_job_id,
+            discovered_job_id=discovered_job_id,
+            application_id=application_id,
+            mode=mode,
+            action=decision.action.value,
+            would_skip=decision.would_skip,
+            embedding_similarity=emb.value,
+            embedding_available=emb.available,
+            embedding_votes_reject=emb.votes_reject,
+            lexical_overlap=lex.value,
+            lexical_available=lex.available,
+            lexical_votes_reject=lex.votes_reject,
+            esco_overlap=esc.value,
+            esco_available=esc.available,
+            esco_votes_reject=esc.votes_reject,
+            llm_fit_score=llm_fit_score,
+            llm_quadrant=quadrant,
+            reject_fit_score=reject_fit_score,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return row
+    except Exception:
+        logger.warning(
+            "Cascade decision logging failed for scored_job=%s (swallowed — scoring unaffected)",
+            scored_job_id,
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            logger.debug("Cascade decision logging rollback also failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# False-skip comparator — the gate for enabling live routing
+# ---------------------------------------------------------------------------
+
+
+def false_skip_rate(
+    samples: list[tuple[bool, float | None]],
+    *,
+    fit_threshold: float = DEFAULT_FIT_THRESHOLD,
+) -> dict:
+    """Compute the false-skip rate over ``(would_skip, llm_fit_score)`` samples.
+
+    Pure. A **false skip** is a job the router would have skipped
+    (``would_skip=True``) that the LLM actually scored at/above ``fit_threshold``
+    (i.e. a fit the router would have wrongly rejected). Samples whose
+    ``llm_fit_score`` is ``None`` (no LLM score to compare — e.g. a live-skipped
+    job) are excluded from the denominator.
+
+    Returns::
+
+        {
+            "n": int,                    # samples with a comparable LLM score
+            "would_skip": int,           # of those, how many the router would skip
+            "false_skips": int,          # would-skip AND llm_fit_score >= threshold
+            "false_skip_rate": float,    # false_skips / would_skip (0.0 if none)
+            "skip_rate": float,          # would_skip / n (0.0 if n == 0)
+            "fit_threshold": float,
+        }
+
+    ``false_skip_rate`` is the number the owner reads to decide whether the router
+    is safe to run live: it is the fraction of the router's *rejections* that were
+    genuine fits. It should be driven near zero before ``CASCADE_ROUTING_ENABLED``
+    is turned on.
+    """
+    comparable = [(ws, fit) for (ws, fit) in samples if fit is not None]
+    n = len(comparable)
+    would_skip = sum(1 for (ws, _fit) in comparable if ws)
+    false_skips = sum(1 for (ws, fit) in comparable if ws and fit >= fit_threshold)  # type: ignore[operator]
+    return {
+        "n": n,
+        "would_skip": would_skip,
+        "false_skips": false_skips,
+        "false_skip_rate": round(false_skips / would_skip, 4) if would_skip else 0.0,
+        "skip_rate": round(would_skip / n, 4) if n else 0.0,
+        "fit_threshold": fit_threshold,
+    }
+
+
+def run_false_skip_report(
+    db: Session,
+    *,
+    profile_id: int | None = None,
+    fit_threshold: float = DEFAULT_FIT_THRESHOLD,
+) -> dict:
+    """Run :func:`false_skip_rate` over logged SHADOW cascade decisions.
+
+    Reads shadow-mode ``cascade_decisions`` rows that carry an ``llm_fit_score``
+    (the ones with a real LLM score to compare against) and returns the false-skip
+    report. Optionally scoped to one ``profile_id``. Read-only.
+    """
+    query = db.query(CascadeDecisionRow.would_skip, CascadeDecisionRow.llm_fit_score).filter(
+        CascadeDecisionRow.mode == "shadow",
+        CascadeDecisionRow.llm_fit_score.isnot(None),
+    )
+    if profile_id is not None:
+        query = query.filter(CascadeDecisionRow.profile_id == profile_id)
+    samples = [(bool(ws), fit) for (ws, fit) in query.all()]
+    report = false_skip_rate(samples, fit_threshold=fit_threshold)
+    report["profile_id"] = profile_id
+    return report

--- a/src/career_os/services/cascade_router.py
+++ b/src/career_os/services/cascade_router.py
@@ -488,6 +488,12 @@ def persist_cascade_reject(
     its cached ``fit_score`` is propagated to the linked DiscoveredJob/Application
     (mirroring ``_update_linked_scores``) so it renders as a normal (low) score in
     the UI. Commits and returns the persisted row.
+
+    By design a cascade-skipped job has ``desire_score=None`` (no LLM ran to
+    produce one), so ``classify_quadrant`` returns ``None`` and the row is
+    *unclassified* in quadrant-filtered views. This is intentional — the router
+    only ever asserts a fit REJECT, never a desire, so it must not fabricate a
+    quadrant. The job stays visible via its (low) ``fit_score``.
     """
     score = settings.cascade_reject_fit_score if reject_fit_score is None else reject_fit_score
     reasons = ", ".join(decision.reject_reasons()) or "all three signals below threshold"

--- a/src/career_os/services/cascade_router.py
+++ b/src/career_os/services/cascade_router.py
@@ -60,7 +60,10 @@ from career_os.models.scoring import CascadeDecision as CascadeDecisionRow
 from career_os.models.scoring import ScoredJob
 from career_os.models.skills import JobRequirement, Skill
 from career_os.schemas.scoring import classify_quadrant
-from career_os.services.esco_features import compute_job_skills_overlap
+from career_os.services.esco_features import (
+    compute_job_skills_overlap,
+    get_candidate_skill_uris,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +343,12 @@ def esco_signal(
     esco_features docstring warns ``overlap_score == 0.0`` conflates "no data" and
     "zero coverage", so we key availability on ``total``). Votes to reject only
     when there IS data and the weighted coverage is at/below the (zero) threshold.
+
+    **Also abstains when the CANDIDATE has zero ESCO-normalized skills.** In that
+    case the overlap is structurally 0 no matter how good the job is — that is
+    absence of candidate data, NOT evidence of non-fit, so it must not push a good
+    job toward a wrongful skip. This closes the sharpest "good job skipped" path:
+    an un-normalized profile against an ESCO-tagged JD.
     """
     threshold = (
         settings.cascade_esco_reject_threshold if reject_threshold is None else reject_threshold
@@ -347,6 +356,15 @@ def esco_signal(
     if application_id is None:
         return SignalVote(
             name="esco", available=False, value=None, votes_reject=False, detail={"total": 0}
+        )
+    if not get_candidate_skill_uris(db, profile_id):
+        # Candidate has no ESCO-normalized skills → no data to judge coverage.
+        return SignalVote(
+            name="esco",
+            available=False,
+            value=None,
+            votes_reject=False,
+            detail={"reason": "candidate_has_no_esco_uris"},
         )
     overlap = compute_job_skills_overlap(db, application_id=application_id, profile_id=profile_id)
     total = overlap.get("total", 0)

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3803,9 +3803,70 @@ async def batch_score_discovery(
     errors: list[dict[str, str]] = []
     credits_exhausted = False
 
+    # Confidence-routed cascade (G-1338, finding K — Phase 4b). Both flags OFF by
+    # default → strictly inert: `cascade_on` is False, no routing/logging runs, and
+    # every job is scored by the LLM exactly as before. Shadow logs what it WOULD
+    # skip (LLM still scores all); live actually skips unanimous-reject jobs.
+    cascade_shadow = settings.cascade_shadow_enabled
+    cascade_live = settings.cascade_routing_enabled
+    cascade_on = cascade_shadow or cascade_live
+
     for job in jobs:
+        description = job.description or f"{job.title} at {job.company} in {job.location}"
+
+        # Route the job (defensive: None on any failure → falls through to scoring).
+        decision = None
+        if cascade_on:
+            from career_os.services.cascade_router import safe_route_job
+
+            decision = safe_route_job(
+                db,
+                profile_id=profile_id,
+                application_id=job.application_id,
+                discovered_job_id=job.id,
+                embedding_similarity=similarities.get(job.id),
+                jd_text=f"{job.title or ''}\n{job.description or ''}",
+            )
+
+        # LIVE skip: a unanimous-reject job bypasses the LLM and is persisted as a
+        # scored-but-rejected job (never dropped). Only reachable when the separate
+        # CASCADE_ROUTING_ENABLED flag is on. Any failure here falls through to
+        # normal scoring — the router never drops or loses a job on error.
+        if cascade_live and decision is not None and decision.would_skip:
+            from career_os.services.cascade_router import (
+                persist_cascade_reject,
+                record_cascade_decision,
+            )
+
+            try:
+                scored = persist_cascade_reject(
+                    db,
+                    profile_id=profile_id,
+                    decision=decision,
+                    discovered_job_id=job.id,
+                    application_id=job.application_id,
+                )
+                scores.append(scored)
+                record_cascade_decision(
+                    db,
+                    profile_id=profile_id,
+                    decision=decision,
+                    mode="live",
+                    scored_job_id=scored.id,
+                    discovered_job_id=job.id,
+                    application_id=job.application_id,
+                    llm_fit_score=None,
+                    reject_fit_score=scored.fit_score,
+                )
+                continue
+            except Exception as exc:
+                logger.warning(
+                    "Cascade live-skip persistence failed for job %d (%s) — scoring normally",
+                    job.id,
+                    exc,
+                )
+
         try:
-            description = job.description or f"{job.title} at {job.company} in {job.location}"
             scored = await score_job(
                 db,
                 profile_id,
@@ -3832,6 +3893,24 @@ async def batch_score_discovery(
                     "discovered_job_id": str(job.id),
                     "error": str(exc),
                 }
+            )
+            continue
+
+        # Cascade shadow/live logging for a SCORED job: record the routing decision
+        # beside the eventual LLM score so the false-skip rate can be measured.
+        if cascade_on and decision is not None:
+            from career_os.services.cascade_router import record_cascade_decision
+
+            record_cascade_decision(
+                db,
+                profile_id=profile_id,
+                decision=decision,
+                mode="live" if cascade_live else "shadow",
+                scored_job_id=scored.id,
+                discovered_job_id=job.id,
+                application_id=job.application_id,
+                llm_fit_score=scored.fit_score,
+                llm_desire_score=scored.desire_score,
             )
 
     total_time = time.monotonic() - start_time

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3811,6 +3811,17 @@ async def batch_score_discovery(
     cascade_live = settings.cascade_routing_enabled
     cascade_on = cascade_shadow or cascade_live
 
+    # Operator visibility: live routing REQUIRES the embedding signal (it is one of
+    # the three that must unanimously agree), so with no embeddings at all the
+    # cascade can never skip anything and "live" silently no-ops. Log once so the
+    # operator isn't puzzled that enabling live routing skipped zero jobs.
+    if cascade_live and jobs and not similarities:
+        logger.warning(
+            "CASCADE_ROUTING_ENABLED is on but no job embeddings are available "
+            "(embedding provider unavailable?) — the cascade cannot skip any job "
+            "without the embedding signal, so live routing is a no-op this run."
+        )
+
     for job in jobs:
         description = job.description or f"{job.title} at {job.company} in {job.location}"
 
@@ -3860,6 +3871,16 @@ async def batch_score_discovery(
                 )
                 continue
             except Exception as exc:
+                # Roll back FIRST, before anything else touches the session — a
+                # failed persist_cascade_reject commit leaves the session in
+                # PendingRollbackError, and every remaining job in the batch (and
+                # even formatting this exception) would otherwise fail. Only after
+                # the session is clean do we log and fall through to score_job so
+                # the job is still scored normally. Mirrors safe_route_job.
+                try:
+                    db.rollback()
+                except Exception:
+                    logger.debug("Cascade live-skip rollback also failed", exc_info=True)
                 logger.warning(
                     "Cascade live-skip persistence failed for job %d (%s) — scoring normally",
                     job.id,

--- a/tests/test_cascade_router.py
+++ b/tests/test_cascade_router.py
@@ -1,0 +1,736 @@
+"""Tests for the confidence-routed cascade (G-1338, finding K — Phase 4b).
+
+Covers, with teeth:
+  * each signal (embedding / lexical / esco) — value, availability/abstain, vote;
+  * the CRITICAL router-safety assertion: SKIP_REJECT requires ALL THREE signals
+    available AND voting reject — a job failing only 1 or 2 (or with any
+    abstaining signal) must route to SCORE, never skip;
+  * shadow logging + full defensiveness on failure;
+  * the false-skip comparator on toy data with hand-computed values;
+  * strict off-by-default identity through batch_score_discovery (both flags off →
+    the pipeline behaves exactly as on main: LLM scores everything, no skips, no
+    cascade rows) — even for a job that WOULD be a unanimous reject;
+  * live mode persists a skipped job as rejected (not dropped), with no LLM call.
+
+All on the mock provider / deterministic fixtures — zero paid LLM calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from career_os.config import settings
+from career_os.database import Base
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.models import Application, Profile
+from career_os.models.scoring import CascadeDecision as CascadeDecisionRow
+from career_os.models.scoring import ScoredJob
+from career_os.models.skills import JobRequirement, Skill
+from career_os.schemas.ai import (
+    ATSKeyword,
+    DimensionalScores,
+    ScoreBreakdownFactor,
+    ScoreResult,
+)
+from career_os.services.cascade_router import (
+    CascadeAction,
+    CascadeDecision,
+    SignalVote,
+    compute_lexical_overlap,
+    embedding_signal,
+    esco_signal,
+    false_skip_rate,
+    lexical_signal,
+    persist_cascade_reject,
+    record_cascade_decision,
+    route_job,
+    run_false_skip_report,
+    safe_route_job,
+)
+
+_ESCO_A = "http://data.europa.eu/esco/skill/AAAA"
+_ESCO_B = "http://data.europa.eu/esco/skill/BBBB"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_session() -> Session:
+    """Fresh in-memory SQLite session seeded with a scorable profile (id=1)."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def _fk(dbapi_conn, _rec):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(bind=engine)
+    connection = engine.connect()
+    session = sessionmaker(bind=connection, autocommit=False, autoflush=False)()
+    session.add(
+        Profile(id=1, name="Test User", email="t@example.com", location="Berlin", job_family="TPM")
+    )
+    session.commit()
+    yield session
+    session.close()
+    connection.close()
+    engine.dispose()
+
+
+def _make_score_result(fit_score: float = 8.0, desire_score: float | None = 6.0) -> ScoreResult:
+    return ScoreResult(
+        fit_score=fit_score,
+        readiness_score=70.0,
+        career_alignment=7.0,
+        reasoning="reason",
+        estimated_salary="$100k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="notes",
+        desire_score=desire_score,
+        score_breakdown=[
+            ScoreBreakdownFactor(factor="a", contribution=1.0, description="x"),
+            ScoreBreakdownFactor(factor="b", contribution=1.0, description="y"),
+            ScoreBreakdownFactor(factor="c", contribution=1.0, description="z"),
+        ],
+        dimensional_scores=DimensionalScores(
+            technical_fit=8.0,
+            seniority_alignment=8.0,
+            compensation_fit=7.0,
+            location_fit=6.0,
+            career_trajectory=8.0,
+            company_fit=7.0,
+        ),
+        ats_keywords=[ATSKeyword(keyword="k", category="technical", matched=True)],
+    )
+
+
+def _patch_provider(fit_score: float = 8.0):
+    resp = MagicMock()
+    resp.structured = _make_score_result(fit_score=fit_score)
+    provider = AsyncMock()
+    provider.score.return_value = resp
+    provider.name = "mock"
+    return provider
+
+
+def _vote(available: bool, value: float | None, votes_reject: bool, name: str = "x") -> SignalVote:
+    return SignalVote(name=name, available=available, value=value, votes_reject=votes_reject)
+
+
+def _decision(action: CascadeAction, e: SignalVote, lx: SignalVote, es: SignalVote):
+    return CascadeDecision(action=action, embedding=e, lexical=lx, esco=es)
+
+
+# ---------------------------------------------------------------------------
+# SignalVote invariant
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_signal_can_never_vote_reject():
+    """An unavailable signal is forced to votes_reject=False (abstain blocks skip)."""
+    v = SignalVote(name="x", available=False, value=None, votes_reject=True)
+    assert v.votes_reject is False
+
+
+# ---------------------------------------------------------------------------
+# embedding_signal
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_none_abstains():
+    v = embedding_signal(None, reject_threshold=0.35)
+    assert v.available is False
+    assert v.votes_reject is False
+
+
+def test_embedding_low_votes_reject():
+    v = embedding_signal(0.10, reject_threshold=0.35)
+    assert v.available is True
+    assert v.votes_reject is True
+    assert v.value == 0.10
+
+
+def test_embedding_high_does_not_reject():
+    v = embedding_signal(0.90, reject_threshold=0.35)
+    assert v.available is True
+    assert v.votes_reject is False
+
+
+def test_embedding_boundary_is_exclusive():
+    # Exactly at threshold is NOT below → not a reject (conservative).
+    assert embedding_signal(0.35, reject_threshold=0.35).votes_reject is False
+
+
+# ---------------------------------------------------------------------------
+# compute_lexical_overlap (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_lexical_overlap_exact_and_fuzzy():
+    out = compute_lexical_overlap(
+        ["Python", "Kubernetes"], ["python programming", "kubernetes (k8s)"]
+    )
+    assert out["matched"] == 2
+    assert out["total"] == 2
+    assert out["overlap_score"] == 1.0
+
+
+def test_lexical_overlap_zero():
+    out = compute_lexical_overlap(["Welding", "Forklift"], ["Python", "Kubernetes"])
+    assert out["matched"] == 0
+    assert out["total"] == 2
+    assert out["overlap_score"] == 0.0
+    assert out["missing_terms"] == ["Welding", "Forklift"]
+
+
+def test_lexical_overlap_dedupes_terms():
+    out = compute_lexical_overlap(["Python", "python", "PYTHON"], ["Java"])
+    assert out["total"] == 1  # deduped
+
+
+def test_lexical_overlap_no_terms_is_zero_not_crash():
+    out = compute_lexical_overlap([], ["Python"])
+    assert out["total"] == 0
+    assert out["overlap_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# lexical_signal (DB): requirements path, jd_text fallback, abstain
+# ---------------------------------------------------------------------------
+
+
+def _seed_candidate_skills(db, names, *, esco_uris=None):
+    esco_uris = esco_uris or [None] * len(names)
+    for name, uri in zip(names, esco_uris, strict=True):
+        db.add(
+            Skill(
+                profile_id=1,
+                name=name,
+                esco_uri=uri,
+                category="technical",
+                proficiency="advanced",
+                evidence_source="manual",
+            )
+        )
+    db.commit()
+
+
+def _seed_application(db) -> Application:
+    app = Application(profile_id=1, company="Acme", role="TPM", status="discovered")
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _seed_requirements(db, app_id, terms):
+    """terms: list of (skill_name, severity, esco_uri)."""
+    for name, sev, uri in terms:
+        db.add(
+            JobRequirement(
+                application_id=app_id,
+                profile_id=1,
+                skill_name=name,
+                severity=sev,
+                esco_uri=uri,
+            )
+        )
+    db.commit()
+
+
+def test_lexical_signal_requirements_zero_overlap_votes_reject(db_session):
+    _seed_candidate_skills(db_session, ["Python", "Roadmapping"])
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Welding", "critical", None)])
+    v = lexical_signal(db_session, profile_id=1, application_id=app.id, jd_text="irrelevant")
+    assert v.available is True
+    assert v.votes_reject is True
+    assert v.detail["source"] == "requirements"
+
+
+def test_lexical_signal_requirements_overlap_does_not_reject(db_session):
+    _seed_candidate_skills(db_session, ["Python"])
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Python", "critical", None)])
+    v = lexical_signal(db_session, profile_id=1, application_id=app.id, jd_text="")
+    assert v.available is True
+    assert v.votes_reject is False
+    assert v.value == 1.0
+
+
+def test_lexical_signal_jd_text_fallback_when_no_requirements(db_session):
+    _seed_candidate_skills(db_session, ["Python", "Roadmapping"])
+    # No requirements → fall back to JD text; none of the skills appear → reject.
+    v = lexical_signal(
+        db_session, profile_id=1, application_id=None, jd_text="We need a welder and a forklift op"
+    )
+    assert v.available is True
+    assert v.votes_reject is True
+    assert v.detail["source"] == "jd_text"
+
+
+def test_lexical_signal_jd_text_present_does_not_reject(db_session):
+    _seed_candidate_skills(db_session, ["Python"])
+    v = lexical_signal(
+        db_session, profile_id=1, application_id=None, jd_text="Strong Python experience required"
+    )
+    assert v.votes_reject is False
+
+
+def test_lexical_signal_abstains_without_data(db_session):
+    # No candidate skills at all → abstain (no data on either side).
+    v = lexical_signal(db_session, profile_id=1, application_id=None, jd_text="anything")
+    assert v.available is False
+    assert v.votes_reject is False
+
+
+# ---------------------------------------------------------------------------
+# esco_signal (DB)
+# ---------------------------------------------------------------------------
+
+
+def test_esco_signal_zero_coverage_votes_reject(db_session):
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Welding", "critical", _ESCO_B)])
+    v = esco_signal(db_session, profile_id=1, application_id=app.id)
+    assert v.available is True
+    assert v.votes_reject is True
+    assert v.value == 0.0
+
+
+def test_esco_signal_covered_does_not_reject(db_session):
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Python", "critical", _ESCO_A)])
+    v = esco_signal(db_session, profile_id=1, application_id=app.id)
+    assert v.available is True
+    assert v.votes_reject is False
+    assert v.value == 1.0
+
+
+def test_esco_signal_abstains_without_requirements(db_session):
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
+    app = _seed_application(db_session)  # no requirements
+    v = esco_signal(db_session, profile_id=1, application_id=app.id)
+    assert v.available is False
+    assert v.votes_reject is False
+
+
+def test_esco_signal_abstains_without_application(db_session):
+    v = esco_signal(db_session, profile_id=1, application_id=None)
+    assert v.available is False
+
+
+# ---------------------------------------------------------------------------
+# route_job — THE critical safety assertion
+# ---------------------------------------------------------------------------
+
+
+def _seed_unanimous_reject_case(db):
+    """Seed DB state where all three signals have data and all vote reject."""
+    _seed_candidate_skills(db, ["Python", "Roadmapping"], esco_uris=[_ESCO_A, None])
+    app = _seed_application(db)
+    _seed_requirements(db, app.id, [("Welding", "critical", _ESCO_B)])
+    return app
+
+
+def test_route_skip_requires_all_three(db_session):
+    """All three available + reject → SKIP_REJECT (embedding passed low)."""
+    app = _seed_unanimous_reject_case(db_session)
+    d = route_job(
+        db_session,
+        profile_id=1,
+        application_id=app.id,
+        embedding_similarity=0.10,
+        jd_text="welding forklift",
+    )
+    assert d.action == CascadeAction.SKIP_REJECT
+    assert d.would_skip is True
+    assert all(s.available and s.votes_reject for s in d.signals)
+
+
+def test_route_scores_when_embedding_high(db_session):
+    """Lexical + ESCO reject, but embedding is high → NOT unanimous → SCORE."""
+    app = _seed_unanimous_reject_case(db_session)
+    d = route_job(
+        db_session,
+        profile_id=1,
+        application_id=app.id,
+        embedding_similarity=0.90,  # only signal that flips
+        jd_text="welding forklift",
+    )
+    assert d.action == CascadeAction.SCORE
+    assert d.embedding.votes_reject is False
+    assert d.lexical.votes_reject is True
+    assert d.esco.votes_reject is True
+
+
+def test_route_scores_when_embedding_abstains(db_session):
+    """Two signals reject but embedding has NO data → abstain blocks skip → SCORE."""
+    app = _seed_unanimous_reject_case(db_session)
+    d = route_job(
+        db_session,
+        profile_id=1,
+        application_id=app.id,
+        embedding_similarity=None,  # abstain
+        jd_text="welding forklift",
+    )
+    assert d.action == CascadeAction.SCORE
+    assert d.embedding.available is False
+
+
+def test_route_scores_when_only_embedding_rejects(db_session):
+    """Low embedding but lexical + ESCO both MATCH → one signal is never enough."""
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Python", "critical", _ESCO_A)])
+    d = route_job(
+        db_session,
+        profile_id=1,
+        application_id=app.id,
+        embedding_similarity=0.05,
+        jd_text="python",
+    )
+    assert d.action == CascadeAction.SCORE
+    assert d.embedding.votes_reject is True
+    assert d.lexical.votes_reject is False
+    assert d.esco.votes_reject is False
+
+
+def test_route_scores_when_esco_abstains_even_if_emb_and_lex_reject(db_session):
+    """ESCO has no data (no esco_uri on requirement) → abstain → SCORE."""
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
+    app = _seed_application(db_session)
+    # requirement has NO esco_uri → esco signal abstains (total==0), lexical rejects.
+    _seed_requirements(db_session, app.id, [("Welding", "critical", None)])
+    d = route_job(
+        db_session,
+        profile_id=1,
+        application_id=app.id,
+        embedding_similarity=0.05,
+        jd_text="welding",
+    )
+    assert d.esco.available is False
+    assert d.lexical.votes_reject is True
+    assert d.embedding.votes_reject is True
+    assert d.action == CascadeAction.SCORE  # abstaining ESCO blocks the skip
+
+
+# ---------------------------------------------------------------------------
+# safe_route_job — defensive
+# ---------------------------------------------------------------------------
+
+
+def test_safe_route_job_returns_none_on_failure(db_session):
+    with patch("career_os.services.cascade_router.route_job", side_effect=RuntimeError("boom")):
+        out = safe_route_job(db_session, profile_id=1, embedding_similarity=0.1)
+    assert out is None  # never raises → caller scores normally
+
+
+# ---------------------------------------------------------------------------
+# record_cascade_decision — logging + defensiveness
+# ---------------------------------------------------------------------------
+
+
+def test_record_decision_shadow_logs_llm_score(db_session):
+    d = _decision(
+        CascadeAction.SKIP_REJECT,
+        _vote(True, 0.1, True, "embedding"),
+        _vote(True, 0.0, True, "lexical"),
+        _vote(True, 0.0, True, "esco"),
+    )
+    row = record_cascade_decision(
+        db_session, profile_id=1, decision=d, mode="shadow", llm_fit_score=8.0, llm_desire_score=6.0
+    )
+    assert row is not None
+    assert row.mode == "shadow"
+    assert row.action == "skip_reject"
+    assert row.would_skip is True
+    assert row.llm_fit_score == 8.0
+    assert row.llm_quadrant is not None
+    assert row.embedding_votes_reject is True
+    assert db_session.query(CascadeDecisionRow).count() == 1
+
+
+def test_record_decision_defensive_on_bad_fk(db_session):
+    """A bad profile FK is swallowed — returns None, session recovers."""
+    d = _decision(
+        CascadeAction.SCORE,
+        _vote(True, 0.9, False, "embedding"),
+        _vote(False, None, False, "lexical"),
+        _vote(False, None, False, "esco"),
+    )
+    out = record_cascade_decision(db_session, profile_id=99999, decision=d, mode="shadow")
+    assert out is None
+    assert db_session.query(CascadeDecisionRow).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# false_skip_rate — toy data, hand-computed
+# ---------------------------------------------------------------------------
+
+
+def test_false_skip_rate_known_values():
+    # would_skip / llm_fit_score pairs:
+    #   (True, 8.0)  → would skip a genuine fit → FALSE SKIP
+    #   (True, 2.0)  → would skip a true reject → correct skip
+    #   (True, 5.0)  → 5.0 >= threshold 5.0 → FALSE SKIP
+    #   (False, 9.0) → not a skip → ignored in numerator
+    #   (True, None) → no LLM score → excluded entirely
+    samples = [(True, 8.0), (True, 2.0), (True, 5.0), (False, 9.0), (True, None)]
+    out = false_skip_rate(samples, fit_threshold=5.0)
+    assert out["n"] == 4  # the None row is excluded
+    assert out["would_skip"] == 3
+    assert out["false_skips"] == 2  # 8.0 and 5.0
+    assert out["false_skip_rate"] == round(2 / 3, 4)
+    assert out["skip_rate"] == round(3 / 4, 4)
+
+
+def test_false_skip_rate_no_skips_is_zero():
+    out = false_skip_rate([(False, 8.0), (False, 2.0)], fit_threshold=5.0)
+    assert out["would_skip"] == 0
+    assert out["false_skips"] == 0
+    assert out["false_skip_rate"] == 0.0
+
+
+def test_run_false_skip_report_reads_shadow_rows(db_session):
+    d_skip = _decision(
+        CascadeAction.SKIP_REJECT,
+        _vote(True, 0.1, True, "embedding"),
+        _vote(True, 0.0, True, "lexical"),
+        _vote(True, 0.0, True, "esco"),
+    )
+    d_score = _decision(
+        CascadeAction.SCORE,
+        _vote(True, 0.9, False, "embedding"),
+        _vote(True, 1.0, False, "lexical"),
+        _vote(True, 1.0, False, "esco"),
+    )
+    # A would-skip job the LLM scored 8.0 (a false skip), plus a scored job at 9.0.
+    record_cascade_decision(
+        db_session, profile_id=1, decision=d_skip, mode="shadow", llm_fit_score=8.0
+    )
+    record_cascade_decision(
+        db_session, profile_id=1, decision=d_score, mode="shadow", llm_fit_score=9.0
+    )
+    # A live row (llm_fit_score None) must be ignored by the shadow report.
+    record_cascade_decision(
+        db_session,
+        profile_id=1,
+        decision=d_skip,
+        mode="live",
+        llm_fit_score=None,
+        reject_fit_score=1.0,
+    )
+    rep = run_false_skip_report(db_session, profile_id=1, fit_threshold=5.0)
+    assert rep["n"] == 2
+    assert rep["would_skip"] == 1
+    assert rep["false_skips"] == 1
+    assert rep["false_skip_rate"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# persist_cascade_reject — nothing dropped
+# ---------------------------------------------------------------------------
+
+
+def test_persist_cascade_reject_writes_visible_rejected_job(db_session):
+    app = _seed_application(db_session)
+    dj = DiscoveredJob(
+        profile_id=1,
+        title="Welder",
+        company="Acme",
+        title_normalized="welder",
+        company_normalized="acme",
+        location_normalized="berlin",
+        application_id=app.id,
+    )
+    db_session.add(dj)
+    db_session.commit()
+    db_session.refresh(dj)
+
+    d = _decision(
+        CascadeAction.SKIP_REJECT,
+        _vote(True, 0.1, True, "embedding"),
+        _vote(True, 0.0, True, "lexical"),
+        _vote(True, 0.0, True, "esco"),
+    )
+    scored = persist_cascade_reject(
+        db_session,
+        profile_id=1,
+        decision=d,
+        discovered_job_id=dj.id,
+        application_id=app.id,
+        reject_fit_score=1.0,
+    )
+    assert scored.id is not None
+    assert scored.fit_score == 1.0
+    assert "cascade" in scored.reasoning.lower()
+    # Nothing dropped: the job is persisted + fit_score propagated to linked rows.
+    assert db_session.query(ScoredJob).count() == 1
+    db_session.refresh(dj)
+    assert dj.fit_score == 1.0
+    app_row = db_session.query(Application).filter(Application.id == app.id).one()
+    assert app_row.fit_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# batch_score_discovery integration — off-by-default identity, shadow, live
+# ---------------------------------------------------------------------------
+
+
+def _seed_scorable_discovered_job(db) -> tuple[Application, DiscoveredJob]:
+    """A discovered job whose signals would all vote reject (given a low embed)."""
+    _seed_candidate_skills(db, ["Python", "Roadmapping"], esco_uris=[_ESCO_A, None])
+    app = _seed_application(db)
+    _seed_requirements(db, app.id, [("Welding", "critical", _ESCO_B)])
+    dj = DiscoveredJob(
+        profile_id=1,
+        title="Welder",
+        company="Acme",
+        location="Berlin",
+        description="We need welding and forklift operation.",
+        title_normalized="welder",
+        company_normalized="acme",
+        location_normalized="berlin",
+        application_id=app.id,
+    )
+    db.add(dj)
+    db.commit()
+    db.refresh(dj)
+    return app, dj
+
+
+async def _run_batch(db, sim_value: float | None):
+    """Run batch_score_discovery with a forced embedding similarity + mock provider."""
+    from career_os.services import scoring as scoring_mod
+
+    async def fake_sims(_db, _pid, jobs, _provider):
+        return {j.id: sim_value for j in jobs} if sim_value is not None else {}
+
+    with (
+        patch("career_os.services.scoring.get_ai_provider", return_value=_patch_provider(8.0)),
+        patch("career_os.services.embeddings.compute_job_similarities", side_effect=fake_sims),
+    ):
+        return await scoring_mod.batch_score_discovery(db, profile_id=1)
+
+
+@pytest.mark.asyncio
+async def test_batch_off_by_default_scores_everything_no_cascade_rows(db_session, monkeypatch):
+    """Both flags OFF → identity: the would-be-reject job is LLM-scored, no rows."""
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+    assert settings.cascade_shadow_enabled is False
+    assert settings.cascade_routing_enabled is False
+
+    _app, dj = _seed_scorable_discovered_job(db_session)
+    result = await _run_batch(db_session, sim_value=0.05)  # low embed, but flags off
+
+    assert result["scored_count"] == 1
+    scored = db_session.query(ScoredJob).one()
+    assert scored.discovered_job_id == dj.id
+    assert scored.fit_score == 8.0  # real LLM score, NOT the reject score
+    assert db_session.query(CascadeDecisionRow).count() == 0  # nothing logged
+
+
+@pytest.mark.asyncio
+async def test_batch_shadow_logs_but_still_scores(db_session, monkeypatch):
+    """Shadow ON → LLM still scores everything; the would-skip decision is logged."""
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+    monkeypatch.setattr(settings, "cascade_shadow_enabled", True)
+    monkeypatch.setattr(settings, "cascade_routing_enabled", False)
+
+    _app, dj = _seed_scorable_discovered_job(db_session)
+    result = await _run_batch(db_session, sim_value=0.05)
+
+    # LLM scored it for real (shadow never skips).
+    assert result["scored_count"] == 1
+    scored = db_session.query(ScoredJob).one()
+    assert scored.fit_score == 8.0
+    # And the routing decision was logged with the eventual LLM score.
+    row = db_session.query(CascadeDecisionRow).one()
+    assert row.mode == "shadow"
+    assert row.would_skip is True
+    assert row.llm_fit_score == 8.0
+    assert row.scored_job_id == scored.id
+
+
+@pytest.mark.asyncio
+async def test_batch_live_skips_and_persists_rejected_job(db_session, monkeypatch):
+    """Live ON → the unanimous-reject job bypasses the LLM but is persisted."""
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+    monkeypatch.setattr(settings, "cascade_routing_enabled", True)
+    monkeypatch.setattr(settings, "cascade_shadow_enabled", False)
+    monkeypatch.setattr(settings, "cascade_reject_fit_score", 1.0)
+
+    _app, dj = _seed_scorable_discovered_job(db_session)
+
+    provider = _patch_provider(8.0)
+
+    async def fake_sims(_db, _pid, jobs, _provider):
+        return {j.id: 0.05 for j in jobs}
+
+    from career_os.services import scoring as scoring_mod
+
+    with (
+        patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+        patch("career_os.services.embeddings.compute_job_similarities", side_effect=fake_sims),
+    ):
+        result = await scoring_mod.batch_score_discovery(db_session, profile_id=1)
+
+    # The job was NOT sent to the LLM...
+    provider.score.assert_not_called()
+    # ...but it is NOT dropped — persisted as a scored-but-rejected job.
+    assert result["scored_count"] == 1
+    scored = db_session.query(ScoredJob).one()
+    assert scored.discovered_job_id == dj.id
+    assert scored.fit_score == 1.0
+    assert "cascade" in scored.reasoning.lower()
+    # A live cascade row was logged with no LLM score + the reject score.
+    row = db_session.query(CascadeDecisionRow).one()
+    assert row.mode == "live"
+    assert row.would_skip is True
+    assert row.llm_fit_score is None
+    assert row.reject_fit_score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_batch_live_scores_normally_when_not_unanimous(db_session, monkeypatch):
+    """Live ON but signals NOT unanimous (high embed) → normal LLM score, no skip."""
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+    monkeypatch.setattr(settings, "cascade_routing_enabled", True)
+
+    _app, dj = _seed_scorable_discovered_job(db_session)
+    provider = _patch_provider(8.0)
+
+    async def fake_sims(_db, _pid, jobs, _provider):
+        return {j.id: 0.95 for j in jobs}  # high embed → not unanimous
+
+    from career_os.services import scoring as scoring_mod
+
+    with (
+        patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+        patch("career_os.services.embeddings.compute_job_similarities", side_effect=fake_sims),
+    ):
+        await scoring_mod.batch_score_discovery(db_session, profile_id=1)
+
+    provider.score.assert_called()  # LLM WAS used
+    scored = db_session.query(ScoredJob).one()
+    assert scored.fit_score == 8.0
+    row = db_session.query(CascadeDecisionRow).one()
+    assert row.mode == "live"
+    assert row.would_skip is False
+    assert row.llm_fit_score == 8.0

--- a/tests/test_cascade_router.py
+++ b/tests/test_cascade_router.py
@@ -419,6 +419,31 @@ def test_route_scores_when_only_embedding_rejects(db_session):
     assert d.esco.votes_reject is False
 
 
+def test_route_scores_when_lexical_abstains_even_if_emb_and_esco_reject(db_session):
+    """Lexical abstains while embedding + ESCO both reject → SCORE.
+
+    The natural DB coupling (lexical + ESCO both derive from the same
+    JobRequirement rows) makes an "ESCO rejects while lexical abstains" state
+    unreachable through the signals' own computation — so this asserts the router
+    AGGREGATION invariant directly by forcing lexical to abstain. Any abstaining
+    signal blocks the skip, exactly like the embedding/esco abstain cases.
+    """
+    app = _seed_unanimous_reject_case(db_session)
+    abstain = SignalVote(name="lexical", available=False, value=None, votes_reject=False)
+    with patch("career_os.services.cascade_router.lexical_signal", return_value=abstain):
+        d = route_job(
+            db_session,
+            profile_id=1,
+            application_id=app.id,
+            embedding_similarity=0.05,
+            jd_text="welding forklift",
+        )
+    assert d.lexical.available is False
+    assert d.embedding.votes_reject is True
+    assert d.esco.votes_reject is True
+    assert d.action == CascadeAction.SCORE  # abstaining lexical blocks the skip
+
+
 def test_route_scores_when_esco_abstains_even_if_emb_and_lex_reject(db_session):
     """ESCO has no data (no esco_uri on requirement) → abstain → SCORE."""
     _seed_candidate_skills(db_session, ["Python"], esco_uris=[_ESCO_A])
@@ -746,3 +771,103 @@ async def test_batch_live_scores_normally_when_not_unanimous(db_session, monkeyp
     assert row.mode == "live"
     assert row.would_skip is False
     assert row.llm_fit_score == 8.0
+
+
+def _seed_reject_discovered_job(db, title: str) -> DiscoveredJob:
+    """Seed one more unanimous-reject discovered job (own app + critical req)."""
+    app = _seed_application(db)
+    _seed_requirements(db, app.id, [("Welding", "critical", _ESCO_B)])
+    dj = DiscoveredJob(
+        profile_id=1,
+        title=title,
+        company="Acme",
+        location="Berlin",
+        description="We need welding and forklift operation.",
+        title_normalized=title.lower(),
+        company_normalized="acme",
+        location_normalized="berlin",
+        application_id=app.id,
+    )
+    db.add(dj)
+    db.commit()
+    db.refresh(dj)
+    return dj
+
+
+@pytest.mark.asyncio
+async def test_batch_live_persist_failure_is_isolated_by_rollback(db_session, monkeypatch):
+    """A persist_cascade_reject failure must NOT poison the rest of the batch.
+
+    Regression guard for the missing rollback: without it, a failed
+    persist_cascade_reject commit leaves the session in PendingRollbackError and
+    every remaining job in the batch would then raise. With the rollback, each
+    would-skip job cleanly falls through to normal LLM scoring.
+    """
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+    monkeypatch.setattr(settings, "cascade_routing_enabled", True)
+    monkeypatch.setattr(settings, "cascade_shadow_enabled", False)
+
+    # Two unanimous-reject jobs sharing the candidate profile.
+    _seed_candidate_skills(db_session, ["Python", "Roadmapping"], esco_uris=[_ESCO_A, None])
+    _seed_reject_discovered_job(db_session, "Welder One")
+    _seed_reject_discovered_job(db_session, "Welder Two")
+
+    provider = _patch_provider(8.0)
+
+    async def fake_sims(_db, _pid, jobs, _provider):
+        return {j.id: 0.05 for j in jobs}
+
+    def _failing_persist(db, **_kwargs):
+        # Realistic failure mode: a commit that violates a FK leaves the session in
+        # PendingRollbackError — exactly the poisoned state the batch-level rollback
+        # must clear before falling through to score_job.
+        db.add(ScoredJob(profile_id=999999, fit_score=1.0, reasoning="bad-fk"))
+        db.commit()  # raises IntegrityError (no such profile) → session poisoned
+
+    from career_os.services import scoring as scoring_mod
+
+    with (
+        patch("career_os.services.scoring.get_ai_provider", return_value=provider),
+        patch("career_os.services.embeddings.compute_job_similarities", side_effect=fake_sims),
+        # Every live-skip persistence poisons the session → each job must recover.
+        patch(
+            "career_os.services.cascade_router.persist_cascade_reject",
+            side_effect=_failing_persist,
+        ),
+    ):
+        result = await scoring_mod.batch_score_discovery(db_session, profile_id=1)
+
+    # The rollback let BOTH jobs score normally via the LLM — no poisoned-session
+    # cascade, no jobs stranded in errors.
+    assert result["scored_count"] == 2
+    assert result["errors"] == []
+    assert db_session.query(ScoredJob).count() == 2
+    assert all(s.fit_score == 8.0 for s in db_session.query(ScoredJob).all())
+    assert provider.score.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Config bounds — a misconfigured live threshold can't mass-skip
+# ---------------------------------------------------------------------------
+
+
+def test_reject_thresholds_are_bounded():
+    """Reject thresholds are validated to [0, 1] — a footgun guard for live mode."""
+    from pydantic import ValidationError
+
+    from career_os.config import Settings
+
+    for field in (
+        "cascade_embedding_reject_threshold",
+        "cascade_lexical_reject_threshold",
+        "cascade_esco_reject_threshold",
+    ):
+        with pytest.raises(ValidationError):
+            Settings(**{field: 1.5})
+        with pytest.raises(ValidationError):
+            Settings(**{field: -0.1})
+
+    # In-range values are accepted.
+    s = Settings(cascade_embedding_reject_threshold=0.5)
+    assert s.cascade_embedding_reject_threshold == 0.5

--- a/tests/test_cascade_router.py
+++ b/tests/test_cascade_router.py
@@ -331,6 +331,18 @@ def test_esco_signal_abstains_without_application(db_session):
     assert v.available is False
 
 
+def test_esco_signal_abstains_when_candidate_has_no_esco_uris(db_session):
+    """An un-normalized profile (no ESCO URIs) vs an ESCO-tagged JD → abstain,
+    NOT reject — absence of candidate data is not evidence of non-fit."""
+    _seed_candidate_skills(db_session, ["Python"], esco_uris=[None])  # not normalized
+    app = _seed_application(db_session)
+    _seed_requirements(db_session, app.id, [("Welding", "critical", _ESCO_B)])
+    v = esco_signal(db_session, profile_id=1, application_id=app.id)
+    assert v.available is False
+    assert v.votes_reject is False
+    assert v.detail["reason"] == "candidate_has_no_esco_uris"
+
+
 # ---------------------------------------------------------------------------
 # route_job — THE critical safety assertion
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Confidence-routed cascade — Phase 4b, part 2 (finding K)

Unblocks the stalled **G-272 embedding pre-filter**. G-272 stalled because a single cosine threshold can't cleanly *reject* — the good/bad similarity distributions overlap, so one threshold mis-rejects good jobs. The SOTA answer: embeddings were never meant to be a gate. This adds a routing layer that decides which jobs even need the expensive LLM call, using **three orthogonal cheap signals** and requiring **unanimous, conservative agreement** before it will ever skip.

**Design is locked and deliberately conservative + shadow-first. It does NOT go more aggressive.**

### The rule
- **Auto-REJECT only.** A job skips the LLM (`SKIP_REJECT`) **only when all three signals have data AND all three independently vote "clearly not a fit"**: (1) low embedding similarity, (2) no lexical must-have overlap, (3) low ESCO skills-overlap. One or two signals is never enough (the whole G-272 lesson).
- **Abstention blocks a skip.** A signal with no data (no embedding, no parsed requirements + empty JD text, no ESCO-grounded skills) *abstains* — and an abstaining signal can never contribute to a skip (`SignalVote.__post_init__` forces `votes_reject=False` when unavailable). So a skip requires *positive* non-fit evidence from all three at once.
- **NEVER auto-ACCEPT.** There is no "clear-strong skip". Everything that is not a unanimous reject goes to the LLM exactly as today.
- **Never skips on error.** `safe_route_job` returns `None` on any failure ⇒ the caller scores normally.

### The three signals (`services/cascade_router.py`)
1. **embedding** — reuses the existing G-272 profile↔job cosine similarity (the already-computed `similarities` dict in `batch_score_discovery`, so zero extra cost). Votes reject only strictly **below** a conservative threshold (default **0.35**, far under the 0.65 pre-filter bar — a confident reject, not a filter).
2. **lexical must-have overlap** (NEW, cheap) — fuzzy overlap (`rapidfuzz`, **no new dep**) of the JD's parsed must-have terms (critical `JobRequirement`s) vs candidate skills, with a raw-JD-text fallback (candidate skills present in the JD) when no requirements are parsed. Votes reject only at genuinely **zero** overlap.
3. **ESCO skills-overlap** — reuses the 4a `esco_features.compute_job_skills_overlap`; availability keyed on `total` (not the 0.0-conflating `overlap_score`). Votes reject only at **zero** weighted coverage.

### Shadow-first (primary deliverable) — `CASCADE_SHADOW_ENABLED`, off by default
The LLM still scores everything; the router logs what it *would* skip beside the eventual LLM `fit_score` to `cascade_decisions`. This makes the **false-skip rate** measurable *before* live is ever trusted: `false_skip_rate` / `run_false_skip_report` compute, of the jobs the router would skip, the fraction the LLM actually scored ≥ a fit threshold (5.0 = the quadrant boundary). Rows with no LLM score are excluded from the denominator. Driving this near zero is the owner's gate for enabling live.

### Live — `CASCADE_ROUTING_ENABLED`, separate flag, off by default
A unanimous-reject job bypasses the LLM and is persisted via `persist_cascade_reject` as a **scored-but-rejected** `ScoredJob` (deterministic low `fit_score`, cascade reasoning), with the score propagated to the linked `DiscoveredJob`/`Application`. **Nothing is silently dropped** — the job stays visible as a low score. Live is impossible to trigger without explicitly setting this flag.

### Safety / invariants
- **Both flags OFF by default.** With both off, `batch_score_discovery` is byte-for-byte the pre-existing pipeline — no routing, no logging, no skips (verified against a would-be-reject job).
- **Zero paid LLM ops** — the router makes no LLM calls; everything is tested on MockProvider / deterministic fixtures.
- Migration in root `alembic/` only (`u3v4w5x6y7z8`), single head, downgrade roundtrip verified. Phase 1–4a untouched (role-fit gate, 0–5→0–10 scaling, eval harness, calibration, distillation logging, ESCO overlap, relative scoring) — full suite stays green.

### Tests
`tests/test_cascade_router.py` — 34 tests. Key routing-safety assertions: `SKIP_REJECT` requires all three available+reject; a job failing only 1 or 2 (or with any abstaining signal) routes to `SCORE`. Plus signal units, shadow logging + defensiveness, the false-skip comparator on hand-computed toy data, off-by-default identity, and live persists-not-drops.

Full fast suite (`-m "not eval"`): **3880 passed, 26 skipped**. Eval suite (`tests/eval/`): **20 passed**. `ruff check` / `format --check`: clean. Single alembic head confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)