### PR TITLE
fix(G-1352): scoring-v2 cross-phase cleanup (shadow gate, distillation desire, batch parity)

### DIFF
--- a/src/career_os/services/async_batch.py
+++ b/src/career_os/services/async_batch.py
@@ -16,7 +16,8 @@ import logging
 from enum import StrEnum
 
 from career_os.ai.base import AIProvider
-from career_os.schemas.ai import ScoreResult, apply_role_fit_gate
+from career_os.schemas.ai import ScoreResult
+from career_os.services.scoring_calibration import apply_calibration_and_gate
 
 logger = logging.getLogger(__name__)
 
@@ -186,15 +187,26 @@ async def retrieve_batch_results(
             parsed.append(entry)
             continue
 
-        # structured is already a ScoreResult (parsed by the provider).
-        # Role-fit hard gate (G-1335): cap fit_score post-parse on the async
-        # Batch API path too, so prestige can't substitute for role fit there.
+        # structured is already a ScoreResult (parsed + dim-scaled by the provider).
+        # Run the SAME calibrate→gate tail as the single-scorer path (G-1337 finding
+        # G + G-1335), so the async Batch API path no longer silently skips
+        # calibration: prestige can't substitute for role fit AND cheap-model scores
+        # line up with the reference scale here too. Both are off by default.
+        #
+        # Distillation logging (G-1338 finding M) is deliberately NOT wired here: this
+        # path has no per-job DB session or persisted ScoredJob (the results endpoint
+        # returns dicts and the batch results are never written to `scored_jobs` in
+        # this service), so there is no scored_job_id to key a training tuple on.
+        # Known gap — a follow-up ticket tracks wiring distillation into a persisting
+        # async-batch consumer; see the PR body for the rationale.
         if isinstance(structured, ScoreResult):
-            entry["score_result"] = apply_role_fit_gate(structured)
+            entry["score_result"] = apply_calibration_and_gate(structured, provider.name)
         else:
             # Try to coerce dict → ScoreResult
             try:
-                entry["score_result"] = apply_role_fit_gate(ScoreResult(**structured))
+                entry["score_result"] = apply_calibration_and_gate(
+                    ScoreResult(**structured), provider.name
+                )
             except Exception as exc:
                 entry["error"] = f"Failed to parse score result: {exc}"
 

--- a/src/career_os/services/batch_scoring.py
+++ b/src/career_os/services/batch_scoring.py
@@ -24,6 +24,7 @@ from career_os.schemas.ai import (
     apply_role_fit_gate,
     scale_score_result_dimensions,
 )
+from career_os.services.scoring_calibration import apply_calibration_and_gate
 
 logger = logging.getLogger(__name__)
 
@@ -333,6 +334,18 @@ async def batch_score_jobs(
             )
             batch_results = parse_batch_response(response.content, ordered_ids)
 
+            # parse_batch_response already scales dims + applies the role-fit gate.
+            # Run the shared calibrate→gate tail so this multi-job path also picks up
+            # per-provider calibration (G-1337) — the same post-processing the single
+            # scorer and async Batch API paths use. Off by default; the gate re-fires
+            # last. (Distillation is not wired here: this path returns ScoreResults to
+            # its caller and creates no ScoredJob, so there is no per-job DB context —
+            # same known gap as the async path, tracked as a follow-up.)
+            batch_results = {
+                job_id: apply_calibration_and_gate(sr, provider.name)
+                for job_id, sr in batch_results.items()
+            }
+
             if batch_results:
                 all_results.update(batch_results)
                 logger.info(
@@ -372,7 +385,9 @@ async def batch_score_jobs(
                     profile_data=profile_data,
                 )
                 if response.structured and isinstance(response.structured, ScoreResult):
-                    all_results[str(job["id"])] = apply_role_fit_gate(response.structured)
+                    all_results[str(job["id"])] = apply_calibration_and_gate(
+                        response.structured, provider.name
+                    )
                 else:
                     logger.warning(
                         "Individual fallback for job %s did not return ScoreResult",

--- a/src/career_os/services/distillation.py
+++ b/src/career_os/services/distillation.py
@@ -95,6 +95,7 @@ def log_distillation_sample(
     discovered_job_id: int | None = None,
     rubric_version: str | None = None,
     extra_signals: dict | None = None,
+    persisted_desire_score: float | None = None,
 ) -> DistillationSample | None:
     """Persist one training tuple. No-op unless the flag is on. Never raises.
 
@@ -102,19 +103,31 @@ def log_distillation_sample(
     been committed. Uses the caller's session but is fully defensive: on any
     failure it rolls back the (uncommitted) sample and returns ``None`` — the
     already-committed :class:`ScoredJob` is never affected.
+
+    ``persisted_desire_score`` is the desire value actually written to
+    :class:`ScoredJob` (which may be *derived* when the model omitted
+    ``desire_score``). When provided it is stored on the training tuple — and drives
+    the quadrant — instead of ``score_result.desire_score``, so the logged tuple
+    reflects the PERSISTED score rather than ``None`` for derived-desire jobs
+    (WR-02). Defaults to ``score_result.desire_score`` when not supplied.
     """
     if not settings.distillation_logging_enabled:
         return None
 
     try:
         signals = build_distillation_signals(score_result, profile_data, extra=extra_signals)
-        quadrant = classify_quadrant(score_result.fit_score, score_result.desire_score)
+        desire_score = (
+            persisted_desire_score
+            if persisted_desire_score is not None
+            else score_result.desire_score
+        )
+        quadrant = classify_quadrant(score_result.fit_score, desire_score)
         sample = DistillationSample(
             profile_id=profile_id,
             scored_job_id=scored_job_id,
             discovered_job_id=discovered_job_id,
             fit_score=score_result.fit_score,
-            desire_score=score_result.desire_score,
+            desire_score=desire_score,
             quadrant=quadrant,
             signals=json.dumps(signals),
             rubric_version=rubric_version,

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3398,29 +3398,25 @@ async def score_job(
                 score_data.fit_score,
             )
 
-    # Per-provider post-hoc calibration (G-1337, finding G). Off by default and a
-    # strict no-op unless SCORING_CALIBRATION_ENABLED is set AND a calibrator has
-    # been fit + registered for this provider. Applied BEFORE the final role-fit
-    # gate below so the hard cap always has the last word — calibration can never
-    # lift a role-mismatched job back over a quadrant boundary.
-    if settings.scoring_calibration_enabled:
-        from career_os.services.scoring_calibration import apply_provider_calibration
+    # Per-provider post-hoc calibration (G-1337, finding G) THEN the final role-fit
+    # gate (G-1335), via the shared calibrate→gate tail so this path, the async
+    # Batch API path, and the multi-job batch path all post-process identically.
+    # Calibration is off by default and a strict no-op unless SCORING_CALIBRATION_
+    # ENABLED is set AND a calibrator is registered for this provider. It runs BEFORE
+    # the gate so the hard cap always has the last word — calibration can never lift
+    # a role-mismatched job back over a quadrant boundary. The gate re-fires after
+    # averaging too: a merged borderline result fails closed (inherits a mismatch /
+    # disqualifier flagged by either pass), so a job a second pass reveals as a role
+    # mismatch still gets capped. ``_apply_role_fit_gate`` is passed so cap events log.
+    from career_os.services.scoring_calibration import apply_calibration_and_gate
 
-        calibrated = apply_provider_calibration(provider.name, score_data.fit_score, enabled=True)
-        if calibrated != score_data.fit_score:
-            logger.info(
-                "Calibrated fit_score for provider %s: %.2f → %.2f",
-                provider.name,
-                score_data.fit_score,
-                calibrated,
-            )
-            score_data = score_data.model_copy(update={"fit_score": calibrated})
-
-    # Re-apply the role-fit gate after averaging + calibration — the merged result
-    # fails closed (inherits a mismatch/disqualifier flagged by either pass), so a
-    # borderline job that a second pass reveals as a role mismatch still gets capped,
-    # and calibration can never lift a gated score over the ceiling.
-    score_data = _apply_role_fit_gate(score_data)
+    score_data = apply_calibration_and_gate(
+        score_data,
+        provider.name,
+        calibration_enabled=settings.scoring_calibration_enabled,
+        gate=_apply_role_fit_gate,
+        log=True,
+    )
 
     # Serialize score_breakdown to JSON for storage
     breakdown_json = (

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3565,6 +3565,10 @@ async def score_job(
             discovered_job_id=discovered_job_id,
             rubric_version=RUBRIC_VERSION,
             extra_signals={"esco": esco} if esco else None,
+            # WR-02: log the desire actually persisted to ScoredJob — which may be
+            # *derived* when the model omitted desire_score — so the training tuple's
+            # desire_score + quadrant match the stored row instead of being None.
+            persisted_desire_score=desire_score,
         )
 
     return scored_job

--- a/src/career_os/services/scoring.py
+++ b/src/career_os/services/scoring.py
@@ -3373,12 +3373,16 @@ async def score_job(
             )
             if response2.structured and isinstance(response2.structured, ScoreResult):
                 score_data2 = response2.structured
+                # Capture the true first-pass fit_score BEFORE averaging overwrites
+                # score_data, so the log reports pass1 (this) and pass2 (score_data2)
+                # distinctly rather than pass2 twice.
+                pass1_fit_score = score_data.fit_score
                 score_data = _average_score_results(score_data, score_data2)
                 scoring_passes = 2
                 logger.info(
                     "Averaged borderline scores: pass1=%.2f pass2=%.2f → avg=%.2f",
-                    score_data2.fit_score,  # original first-pass stored before averaging
-                    response2.structured.fit_score,
+                    pass1_fit_score,
+                    score_data2.fit_score,
                     score_data.fit_score,
                 )
             else:

--- a/src/career_os/services/scoring_calibration.py
+++ b/src/career_os/services/scoring_calibration.py
@@ -33,9 +33,14 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from career_os.schemas.ai import ScoreResult
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +199,54 @@ def apply_provider_calibration(
     if calibrator is None:
         return raw_score
     return calibrator.predict(raw_score)
+
+
+def apply_calibration_and_gate(
+    score_result: ScoreResult,
+    provider_name: str,
+    *,
+    calibration_enabled: bool | None = None,
+    gate: Callable[[ScoreResult], ScoreResult] | None = None,
+    log: bool = False,
+) -> ScoreResult:
+    """Shared scoring post-processing tail: calibrate ``fit_score`` then re-apply the gate.
+
+    The single place every scoring path (single-scorer, async Batch API, and the
+    multi-job-per-prompt batch) runs its calibrate→gate tail, so a provider's
+    calibration map (G-1337) and the G-1335 role-fit hard gate are applied
+    *identically* everywhere. Calibration runs first and the gate always runs last,
+    so calibration can never lift a role-mismatched job back over the ceiling.
+
+    Off by default and order-preserving: when calibration is disabled (or no
+    calibrator is registered for ``provider_name``) this is exactly the gate applied
+    once — ``fit_score`` is untouched for a non-gated job. ``calibration_enabled``
+    defaults to ``settings.scoring_calibration_enabled``; pass an explicit value in
+    tests. ``gate`` defaults to the pure schema-layer :func:`apply_role_fit_gate`;
+    the single-scorer path passes its logging wrapper so cap events are still logged.
+    """
+    from career_os.schemas.ai import apply_role_fit_gate
+
+    if gate is None:
+        gate = apply_role_fit_gate
+
+    if calibration_enabled is None:
+        from career_os.config import settings
+
+        calibration_enabled = settings.scoring_calibration_enabled
+
+    if calibration_enabled:
+        calibrated = apply_provider_calibration(provider_name, score_result.fit_score, enabled=True)
+        if calibrated != score_result.fit_score:
+            if log:
+                logger.info(
+                    "Calibrated fit_score for provider %s: %.2f → %.2f",
+                    provider_name,
+                    score_result.fit_score,
+                    calibrated,
+                )
+            score_result = score_result.model_copy(update={"fit_score": calibrated})
+
+    return gate(score_result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/services/scoring_shadow.py
+++ b/src/career_os/services/scoring_shadow.py
@@ -37,7 +37,7 @@ from career_os.ai.factory import get_ai_provider
 from career_os.config import settings
 from career_os.database import SessionLocal
 from career_os.models.scoring import ShadowScore
-from career_os.schemas.ai import ScoreResult
+from career_os.schemas.ai import ScoreResult, apply_role_fit_gate
 from career_os.schemas.scoring import classify_quadrant
 
 logger = logging.getLogger(__name__)
@@ -115,7 +115,14 @@ async def record_shadow_score(
         logger.warning("Shadow variant %s returned no structured score — skipping log", variant)
         return None
 
-    candidate: ScoreResult = response.structured
+    # Apply the SAME role-fit hard gate (G-1335) the live scorer applies to its
+    # primary fit_score, BEFORE persisting/comparing. ``primary_fit_score`` here is
+    # already post-gate (it comes from ``score_job`` after the gate), so gating the
+    # candidate too keeps the comparison apples-to-apples: for a role-mismatched job
+    # (live capped ≤3) the candidate is capped ≤3 as well, instead of leaving it at
+    # an un-gated 8 and making a good candidate model look worse on exactly the jobs
+    # the gate exists to fix (κ/NDCG in ``compare_primary_vs_shadow``).
+    candidate: ScoreResult = apply_role_fit_gate(response.structured)
     dims_json = (
         json.dumps(candidate.dimensional_scores.model_dump())
         if candidate.dimensional_scores is not None

--- a/tests/test_async_batch.py
+++ b/tests/test_async_batch.py
@@ -293,6 +293,56 @@ class TestRetrieveBatchResults:
         with pytest.raises(BatchResultError, match="retrieval failed"):
             await retrieve_batch_results(provider, "batch_123")
 
+    @pytest.mark.asyncio
+    async def test_retrieve_results_applies_calibration(self, monkeypatch):
+        """WR-04: the async Batch API path now runs the SAME calibration as the
+        single-scorer path — a registered map for the provider is applied."""
+        from career_os.config import settings
+        from career_os.services.scoring_calibration import (
+            IsotonicCalibrator,
+            clear_calibrators,
+            register_calibrator,
+        )
+
+        clear_calibrators()
+        # Halve the scale for provider "fake": raw 7.5 → 3.75.
+        register_calibrator("fake", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+        monkeypatch.setattr(settings, "scoring_calibration_enabled", True)
+        try:
+            ai_resp = _make_ai_response(structured=_make_score_result())
+            provider = FakeProvider(batch_status="ended", batch_results={"job-1": ai_resp})
+            results = await retrieve_batch_results(provider, "batch_done")
+            assert results[0]["score_result"].fit_score == pytest.approx(3.75)
+        finally:
+            clear_calibrators()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_results_gate_still_wins_over_calibration(self, monkeypatch):
+        """WR-04: calibration can't lift a role-mismatched job over the gate ceiling."""
+        from career_os.config import settings
+        from career_os.schemas.ai import ROLE_FIT_GATE_CEILING, RoleMatch
+        from career_os.services.scoring_calibration import (
+            IsotonicCalibrator,
+            clear_calibrators,
+            register_calibrator,
+        )
+
+        clear_calibrators()
+        # A calibrator that would INFLATE scores — must not defeat the gate.
+        register_calibrator("fake", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(9.0, 10.0)))
+        monkeypatch.setattr(settings, "scoring_calibration_enabled", True)
+        try:
+            score = _make_score_result()
+            score = score.model_copy(
+                update={"role_match": RoleMatch(is_same_role_family=False, evidence="SWE≠target")}
+            )
+            ai_resp = _make_ai_response(structured=score)
+            provider = FakeProvider(batch_status="ended", batch_results={"job-1": ai_resp})
+            results = await retrieve_batch_results(provider, "batch_done")
+            assert results[0]["score_result"].fit_score == ROLE_FIT_GATE_CEILING
+        finally:
+            clear_calibrators()
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests

--- a/tests/test_batch_scoring.py
+++ b/tests/test_batch_scoring.py
@@ -408,6 +408,74 @@ class TestBatchScoreJobs:
         provider.score.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_batch_scoring_applies_calibration(self, monkeypatch):
+        """WR-04: the multi-job batch path now runs the SAME per-provider
+        calibration as the single-scorer path."""
+        from career_os.config import settings
+        from career_os.services.scoring_calibration import (
+            IsotonicCalibrator,
+            clear_calibrators,
+            register_calibrator,
+        )
+
+        clear_calibrators()
+        # Halve the scale for provider "mock": raw 7.5 → 3.75.
+        register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+        monkeypatch.setattr(settings, "scoring_calibration_enabled", True)
+        try:
+            scores = [_make_score_dict("101", 7.5)]
+            mock_response = AIResponse(
+                content=json.dumps(scores),
+                provider="mock",
+                feature=AIFeature.score,
+                structured=None,
+                model="mock-v1",
+            )
+            provider = AsyncMock()
+            provider.complete = AsyncMock(return_value=mock_response)
+            provider.name = "mock"
+
+            results = await batch_score_jobs(
+                provider, [SAMPLE_JOBS[0]], SAMPLE_PROFILE, batch_size=10
+            )
+            assert results["101"].fit_score == pytest.approx(3.75)
+        finally:
+            clear_calibrators()
+
+    @pytest.mark.asyncio
+    async def test_batch_scoring_calibration_off_is_identity(self, monkeypatch):
+        """With calibration off (default) the batch path leaves fit_score untouched."""
+        from career_os.config import settings
+        from career_os.services.scoring_calibration import (
+            IsotonicCalibrator,
+            clear_calibrators,
+            register_calibrator,
+        )
+
+        clear_calibrators()
+        register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+        monkeypatch.setattr(settings, "scoring_calibration_enabled", False)
+        try:
+            scores = [_make_score_dict("101", 7.5)]
+            mock_response = AIResponse(
+                content=json.dumps(scores),
+                provider="mock",
+                feature=AIFeature.score,
+                structured=None,
+                model="mock-v1",
+            )
+            provider = AsyncMock()
+            provider.complete = AsyncMock(return_value=mock_response)
+            provider.name = "mock"
+
+            results = await batch_score_jobs(
+                provider, [SAMPLE_JOBS[0]], SAMPLE_PROFILE, batch_size=10
+            )
+            assert results["101"].fit_score == 7.5
+        finally:
+            clear_calibrators()
+
+    @pytest.mark.asyncio
     async def test_configurable_batch_size_from_env(self):
         """batch_size=None reads from environment."""
         scores = [_make_score_dict("101")]

--- a/tests/test_borderline_scoring.py
+++ b/tests/test_borderline_scoring.py
@@ -470,6 +470,45 @@ class TestBorderlineScoring:
             )
 
     @pytest.mark.asyncio
+    async def test_averaging_log_reports_distinct_passes(self, db_session: Session, caplog):
+        """WR-03: the averaging log reports the TRUE pass-1 value and pass-2 value
+        distinctly — not pass-2 twice (the pre-fix bug logged the average as pass1)."""
+        import logging
+
+        # Distinct pass-1 (5.0) and pass-2 (6.0) → average 5.5.
+        pass1 = _make_score_result(fit_score=5.0)
+        pass2 = _make_score_result(fit_score=6.0)
+
+        mock_provider = AsyncMock()
+        mock_provider.score.side_effect = [_make_ai_response(pass1), _make_ai_response(pass2)]
+
+        with (
+            patch("career_os.services.scoring.get_ai_provider", return_value=mock_provider),
+            patch("career_os.services.scoring.settings") as mock_settings,
+            caplog.at_level(logging.INFO, logger="career_os.services.scoring"),
+        ):
+            mock_settings.feedback_calibration_enabled = False
+            mock_settings.borderline_scoring_enabled = True
+            mock_settings.borderline_low_threshold = 4.0
+            mock_settings.borderline_high_threshold = 6.5
+
+            await score_job(
+                db_session,
+                profile_id=1,
+                job_description="Borderline TPM role",
+                job_title="TPM",
+                job_company="Datadog",
+            )
+
+        avg_logs = [
+            r.getMessage() for r in caplog.records if "Averaged borderline" in r.getMessage()
+        ]
+        assert len(avg_logs) == 1
+        # True pass-1 (5.00) and pass-2 (6.00) are distinct; average is 5.50.
+        assert "pass1=5.00 pass2=6.00" in avg_logs[0]
+        assert "avg=5.50" in avg_logs[0]
+
+    @pytest.mark.asyncio
     async def test_second_pass_invalid_response_uses_fallback(self, db_session: Session):
         """If second pass returns non-ScoreResult, original score is used."""
         borderline_result = _make_score_result(fit_score=5.0)

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -202,6 +202,36 @@ def test_log_records_the_right_tuple(db_session, enable_distillation):
     assert db_session.query(DistillationSample).count() == 1
 
 
+def test_log_prefers_persisted_desire_over_result(db_session, enable_distillation):
+    """WR-02: when the model omits desire_score, the derived value persisted to
+    ScoredJob is what gets logged (and drives the quadrant), not None."""
+    from career_os.schemas.scoring import classify_quadrant
+
+    result = _make_score_result(fit_score=8.0, desire_score=None)  # model omitted desire
+    assert result.desire_score is None
+
+    sample = log_distillation_sample(
+        db_session,
+        profile_id=1,
+        score_result=result,
+        profile_data={},
+        persisted_desire_score=6.5,  # the value derived + persisted to ScoredJob
+    )
+    assert sample is not None
+    assert sample.desire_score == 6.5  # persisted value, not the result's None
+    # Quadrant reflects the persisted desire (fit 8 + desire 6.5), not None.
+    assert sample.quadrant == classify_quadrant(8.0, 6.5)
+    assert sample.quadrant is not None
+
+
+def test_log_falls_back_to_result_desire_when_no_override(db_session, enable_distillation):
+    """Back-compat: absent an override, the result's own desire_score is used."""
+    result = _make_score_result(fit_score=8.0, desire_score=6.0)
+    sample = log_distillation_sample(db_session, profile_id=1, score_result=result, profile_data={})
+    assert sample is not None
+    assert sample.desire_score == 6.0
+
+
 def test_log_defensive_on_failure_returns_none(db_session, enable_distillation):
     """A DB failure (bad FK) is swallowed — returns None, never raises."""
     # profile_id 99999 does not exist → FK violation on commit (PRAGMA FK=ON).
@@ -309,6 +339,43 @@ async def test_score_job_logs_sample_when_enabled(db_session, monkeypatch, enabl
     assert samples[0].scored_job_id == scored.id
     assert samples[0].fit_score == scored.fit_score
     assert samples[0].rubric_version == "v1.1"
+
+
+@pytest.mark.asyncio
+async def test_score_job_logs_derived_desire_matching_persisted(
+    db_session, monkeypatch, enable_distillation
+):
+    """WR-02 end-to-end: when the model OMITS desire_score, score_job derives it,
+    persists it to ScoredJob, and the distillation tuple logs that SAME non-None
+    desire + quadrant — not None."""
+    from career_os.schemas.scoring import classify_quadrant
+
+    monkeypatch.setattr(settings, "feedback_calibration_enabled", False)
+    monkeypatch.setattr(settings, "borderline_scoring_enabled", False)
+
+    # Provider returns a result with desire_score=None but dims present → derived.
+    result = _make_score_result(fit_score=8.0, desire_score=None, dims=True)
+    assert result.desire_score is None
+    resp = MagicMock()
+    resp.structured = result
+    provider = AsyncMock()
+    provider.score.return_value = resp
+    provider.name = "mock"
+
+    with patch("career_os.services.scoring.get_ai_provider", return_value=provider):
+        scored = await score_job(
+            db_session, profile_id=1, job_description="TPM role", job_title="TPM"
+        )
+
+    # Desire was derived + persisted (non-None) on the ScoredJob.
+    assert scored.desire_score is not None
+    assert scored.desire_score_method == "derived"
+
+    sample = db_session.query(DistillationSample).filter_by(scored_job_id=scored.id).one()
+    # The training tuple must reflect the PERSISTED derived desire, not None.
+    assert sample.desire_score == scored.desire_score
+    assert sample.desire_score is not None
+    assert sample.quadrant == classify_quadrant(scored.fit_score, scored.desire_score)
 
 
 @pytest.mark.asyncio

--- a/tests/test_scoring_calibration.py
+++ b/tests/test_scoring_calibration.py
@@ -27,6 +27,7 @@ from career_os.services.scoring import score_job
 from career_os.services.scoring_calibration import (
     MIN_CALIBRATION_SAMPLES,
     IsotonicCalibrator,
+    apply_calibration_and_gate,
     apply_provider_calibration,
     clear_calibrators,
     fit_from_feedback,
@@ -155,6 +156,64 @@ def test_empty_calibrator_is_identity_clamped():
     cal = IsotonicCalibrator(knot_x=(), knot_y=())
     assert cal.predict(6.0) == pytest.approx(6.0)
     assert cal.predict(12.0) == 10.0
+
+
+# ---------------------------------------------------------------------------
+# apply_calibration_and_gate — the shared post-processing tail (WR-04)
+# ---------------------------------------------------------------------------
+
+
+def _gate_result(fit_score: float, *, mismatch: bool = False) -> ScoreResult:
+    role_match = RoleMatch(is_same_role_family=False, evidence="x") if mismatch else None
+    return ScoreResult(
+        role_match=role_match,
+        fit_score=fit_score,
+        reasoning="A" * 120,
+        estimated_salary="$150k",
+        effort_flag="medium",
+        prep_level="moderate",
+        prep_notes="p",
+        readiness_score=80.0,
+        career_alignment=8.0,
+        score_breakdown=[
+            ScoreBreakdownFactor(factor="a", contribution=1.0, description="d"),
+            ScoreBreakdownFactor(factor="b", contribution=1.0, description="d"),
+            ScoreBreakdownFactor(factor="c", contribution=1.0, description="d"),
+        ],
+    )
+
+
+def test_helper_calibrates_then_gates():
+    """Calibration is applied, then the gate — for a non-mismatch it's just the map."""
+    register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+    out = apply_calibration_and_gate(_gate_result(8.0), "mock", calibration_enabled=True)
+    assert out.fit_score == pytest.approx(4.0)
+
+
+def test_helper_disabled_is_identity():
+    """Calibration disabled → only the (idempotent) gate runs; fit untouched."""
+    register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+    out = apply_calibration_and_gate(_gate_result(8.0), "mock", calibration_enabled=False)
+    assert out.fit_score == pytest.approx(8.0)
+
+
+def test_helper_gate_wins_over_calibration():
+    """A calibrator that inflates a role-mismatched score can't beat the gate."""
+    register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(9.0, 10.0)))
+    out = apply_calibration_and_gate(
+        _gate_result(8.0, mismatch=True), "mock", calibration_enabled=True
+    )
+    assert out.fit_score == pytest.approx(3.0)
+
+
+def test_helper_defaults_enabled_from_settings(monkeypatch):
+    """calibration_enabled defaults to settings.scoring_calibration_enabled."""
+    from career_os.config import settings
+
+    register_calibrator("mock", IsotonicCalibrator(knot_x=(0.0, 10.0), knot_y=(0.0, 5.0)))
+    monkeypatch.setattr(settings, "scoring_calibration_enabled", True)
+    out = apply_calibration_and_gate(_gate_result(8.0), "mock")
+    assert out.fit_score == pytest.approx(4.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scoring_shadow.py
+++ b/tests/test_scoring_shadow.py
@@ -61,6 +61,56 @@ class _BoomProvider(AIProvider):
         return [0.0] * 768
 
 
+class _RoleMismatchProvider(AIProvider):
+    """Candidate provider that returns a role-mismatched but high fit_score.
+
+    Models a strong-looking holistic score on a job the candidate's role family
+    does NOT match — exactly what the G-1335 gate exists to cap.
+    """
+
+    @property
+    def name(self):
+        return "candidate"
+
+    async def complete(self, prompt, **kwargs):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def score(self, job_description, profile_data, **kwargs):  # noqa: ANN001
+        from career_os.schemas.ai import (
+            AIFeature,
+            AIResponse,
+            RoleMatch,
+            ScoreBreakdownFactor,
+            ScoreResult,
+        )
+
+        return AIResponse(
+            content="",
+            provider="candidate",
+            feature=AIFeature.score,
+            structured=ScoreResult(
+                role_match=RoleMatch(is_same_role_family=False, evidence="SWE role, not TPM"),
+                fit_score=8.0,
+                desire_score=7.0,
+                reasoning="x" * 120,
+                estimated_salary="$150k",
+                effort_flag="medium",
+                prep_level="moderate",
+                prep_notes="p",
+                readiness_score=80.0,
+                career_alignment=8.0,
+                score_breakdown=[
+                    ScoreBreakdownFactor(factor="a", contribution=1.0, description="d"),
+                    ScoreBreakdownFactor(factor="b", contribution=1.0, description="d"),
+                    ScoreBreakdownFactor(factor="c", contribution=1.0, description="d"),
+                ],
+            ),
+        )
+
+    async def embed(self, text, **kwargs):  # noqa: ANN001
+        return [0.0] * 768
+
+
 # ---------------------------------------------------------------------------
 # build_shadow_provider — real, distinct variant resolution
 # ---------------------------------------------------------------------------
@@ -114,6 +164,33 @@ async def test_record_shadow_score_persists_fields(db_session):
     assert row.variant == "mistral-large"
     assert row.primary_fit_score == 4.2
     assert row.reasoning  # MockProvider always returns reasoning
+
+
+@pytest.mark.asyncio
+async def test_record_shadow_score_gates_role_mismatch_candidate(db_session):
+    """WR-01: a role-mismatched candidate is stored capped ≤ ROLE_FIT_GATE_CEILING.
+
+    The primary passed in is already post-gate (≤3 for a mismatch). Gating the
+    candidate before persisting keeps the shadow comparison apples-to-apples so a
+    good candidate model isn't penalized on exactly the jobs the gate exists to fix.
+    """
+    from career_os.schemas.ai import ROLE_FIT_GATE_CEILING
+
+    row = await record_shadow_score(
+        db_session,
+        profile_id=1,
+        variant="candidate",
+        prompt="Senior Software Engineer at Acme",
+        profile_data={"weights": {}},
+        primary_fit_score=3.0,  # how the live scorer stores this mismatch
+        provider=_RoleMismatchProvider(),
+    )
+    assert row is not None
+    # Candidate returned 8.0 but the gate must cap it to match the primary's regime.
+    assert row.fit_score <= ROLE_FIT_GATE_CEILING
+    assert row.fit_score == ROLE_FIT_GATE_CEILING
+    # Desire axis is deliberately left intact by the gate (prestige belongs there).
+    assert row.desire_score == 7.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Milestone cleanup — Scoring Engine v2

Fixes four cross-phase measurement-fidelity issues found in the integration review. All are in **off-by-default** features (they don't affect live scoring), but each corrupts the data the feature exists to produce. With every scoring-v2 flag off, live scoring behavior is byte-identical.

### WR-01 (real) — shadow-mode compared a gated primary against an un-gated candidate
`services/scoring_shadow.py` persisted the candidate `ScoreResult.fit_score` **without** `apply_role_fit_gate`, while `score_job` passes the primary as its POST-gate `fit_score`. For role-mismatched jobs (live capped to ≤3, shadow left at e.g. 8), `compare_primary_vs_shadow` computed κ/NDCG across mismatched post-processing regimes — making a good candidate model look worse on exactly the jobs G-1335 was built to fix.
**Fix:** `record_shadow_score` now applies `apply_role_fit_gate` to the candidate before persisting/comparing (gate only touches `fit_score`; dims/desire intact). Test: a role-mismatched candidate is stored capped ≤3.

### WR-02 (real) — distillation logged None desire/quadrant for derived-desire jobs
When the model omits `desire_score`, `score_job` derives it and writes it to `scored_job.desire_score` **without** mutating `score_data.desire_score`. `log_distillation_sample` read `score_result.desire_score` → stored `desire_score=None`/`quadrant=None` even though the persisted job had a real derived desire + quadrant.
**Fix:** `log_distillation_sample` takes an optional `persisted_desire_score`; `score_job` passes the value it actually persisted, so the training tuple matches the stored row. Test: derived-desire job logs the SAME non-None desire + quadrant that got persisted.

### WR-03 (cosmetic) — borderline 2-pass log printed pass-2 twice
The averaging log's `pass1`/`pass2` args both resolved to the second pass (the true pass-1 value was already overwritten by the average), and the "original first-pass stored before averaging" comment was wrong.
**Fix:** capture the real pass-1 `fit_score` into a local BEFORE averaging overwrites it, and log that as pass1. Test asserts distinct pass1/pass2 in the log.

### WR-04 (real gap) — async Batch API + multi-prompt batch skipped calibration
`async_batch.retrieve_batch_results` and `batch_scoring.batch_score_jobs` applied scale + role-fit gate but **not** per-provider calibration (G-1337). The documented "nightly scoring at 50% off" async path silently ignored calibration when the flag is on.
**Chosen: option (a).** Extracted a shared calibrate→gate tail, `scoring_calibration.apply_calibration_and_gate`, so all three paths post-process identically (calibration first, gate always last so it wins). Wired into `score_job` (replacing its inline calibrate + re-gate, logging preserved), `retrieve_batch_results`, and `batch_score_jobs` (batch results + individual fallback).

**Honest scope note on distillation in the batch paths:** distillation logging is deliberately NOT wired into the two batch paths. Neither has a per-job DB session or a persisted `ScoredJob` — the async results endpoint (`api/batch.py`) returns dicts and never writes to `scored_jobs`; `batch_score_jobs` returns `ScoreResult`s to its caller and creates no `ScoredJob`. There is no `scored_job_id` to key a training tuple on at those layers. Both call sites carry a code comment documenting the gap, and a **follow-up ticket should be filed** to wire distillation into a persisting async-batch consumer. (`batch_scoring` is production-dead — only `tools/`+tests reference it — fixed for parity.)

## Verification
- Full fast suite (`-m "not eval"`): **3897 passed, 26 skipped**
- `tests/eval/`: **20 passed**
- `ruff check` + `ruff format --check`: clean
- Single alembic head `u3v4w5x6y7z8` — **no migration** (logic-only fixes)
- Ran on the branch worktree source (`career_os.__file__` confirmed in worktree; local Python 3.14, CI 3.11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)