### PR TITLE
G-1371: premium-fallback billing guard + billing-safety test suite

### DIFF
--- a/docs/coe/2026-07-19_premium-anthropic-fallback-billing-regression.md
+++ b/docs/coe/2026-07-19_premium-anthropic-fallback-billing-regression.md
@@ -1,0 +1,90 @@
+# COE: premium-Anthropic fallback silently re-entered the scoring chain and billed the API
+
+**Date:** 2026-07-19 · **Severity:** mid-major · **Area:** Eyas/Kestrel AI-scoring provider chain (cost)
+**Ticket:** G-1371 · **PRs:** Eyas #196, Kestrel (premium-fallback-guard)
+**Related:** `docs/coe/2026-07-09_redundant-scoring-run-cost.md` (the ~$45 redundant-run incident this one explains the *setup* for), G-438/G-442 (cost-control epic), G-636 (tier-0 poller), G-1315 (Anthropic-fallback fix), G-1322/G-1356 (Llama→Mistral scorer swap)
+
+## Impact
+
+Both scheduled AI-scorers (`daily-scan`, `tier-0-ats-poller`) had provider fallback chains that **terminated in premium Anthropic** (`claude-sonnet-5`). Whenever the cheaper providers ahead of it failed (429 rate-limit / 402 out-of-credits / missing key / provider outage), every dropped job silently billed Anthropic at premium pay-per-token rates, with no alarm.
+
+- **Blast radius (measured):** `daily-scan` = 37 runs in 30 days at ~3,785 jobs/run; `tier-0-ats-poller` = **182 runs** in 30 days (every 15 min, 07–17h Mon–Fri). A single full run that falls entirely to Anthropic is ~$22–27 (per the 2026-07-09 COE).
+- **Realised cost:** the 2026-07-09 incident (~$45, two redundant full runs) is the visible tip; the user reported being "charged more" on the Anthropic API for the trailing month — consistent with intermittent premium cascades every time the cheap providers rate-limited.
+- **Second exposure path (openrouter):** `openrouter`'s registry-default model is a premium Claude model (`anthropic/claude-sonnet-*`). A chain routing through openrouter without an `OPENROUTER_MODEL` override bills premium Claude too — the stopgap chain `mistral,openrouter,together` is only safe because the workflow pins `OPENROUTER_MODEL` to a cheap Mistral. The same hazard is live in Kestrel's documented "free" chains.
+- **Nearly hit:** the exact-dollar figure is only on the Anthropic Console (Admin Usage/Cost API), so the true total wasn't quantified in-session. The bleed was *ongoing at discovery* — the morning `daily-scan` had already run, and the poller was still active.
+- This is a **regression**: the identical failure mode (daily scan reaching premium Claude) was fixed on 2026-04-19 and re-appeared. Kestrel (upstream) carries the same architecture and the same gap.
+
+## Timeline
+
+- **2026-04-19** — Original fix: daily scan set to OpenRouter **Llama 3.3 70B free tier** ($0/mo) after a Sonnet swap cost $27+ in one run. Enforced by a memory note (`feedback_scoring_cost_control`): *"NEVER change SCORING_MODEL to Claude/Sonnet without calculating cost impact first."* — discipline, not a test.
+- **2026-04-21** — G-438/G-442 cost-control epic ships (prefilter, batch, prompt caching, presets). Chain still terminated on a free/cheap provider.
+- **~2026-07 (G-1322 / G-1356)** — Quality fix: a 2026-07-09 benchmark finds Llama 3.3 the *worst* scorer (inflates scores ~2pts, drives T1 tier inflation). The free Llama tier is swapped for Mistral as the lead. **Correct on quality — but it deleted the $0 terminal provider, leaving `…,anthropic` as the terminal leg.** No cost review; nobody was thinking about billing.
+- **2026-06-27 (G-636, 40d3606)** — `tier-0-ats-poller` added, "same convention as daily-scan" → inherits `mistral,openai,together,anthropic`, fires ~44×/weekday. Multiplies the latent exposure.
+- **2026-07-09 09:51 (G-1315, 1648d42 + fc41bf5)** — the Anthropic leg had been silently HTTP-400-erroring (bad/removed beta header) → harmless because broken (dropped jobs, billed nothing). G-1315 repairs the leg **and bumps `DEFAULT_MODEL` to `claude-sonnet-5`**. Latent risk becomes active billing.
+- **2026-07-09 11:08** — repo variable `AI_PROVIDER_FALLBACK` set to `mistral,openrouter,together,anthropic` (Anthropic terminal). Same day as G-1315.
+- **2026-07-09** — ~$45 burned on two redundant full runs to "verify the fix" (separate COE).
+- **2026-07-19** — User notices higher Anthropic API charges "after our incident on 7 jul." Root-caused this session; stopgap applied; durable guard + tests added.
+
+## Root cause
+
+The 2026-04-19 fix was a **value protected by human discipline, not an invariant protected by code**. "Set the scoring model to the free tier" is a *state*; the surrounding codebase kept changing, and three independent, each-locally-correct changes eroded that state until it was gone:
+
+1. **A quality fix removed the cost floor** (G-1322: Llama inflates scores → switch to Mistral) — which also silently removed the only $0 provider, exposing `anthropic` as the terminal leg. Reviewed for scoring quality; cost impact invisible.
+2. **A new feature copied the now-unsafe pattern** (G-636 poller) — multiplying exposure 44×/weekday.
+3. **A bug fix un-masked the hazard** (G-1315) — the Anthropic leg was *in* the chain the whole time but harmless because it 400-errored; repairing it (and pointing it at `claude-sonnet-5`) turned latent risk into live billing.
+
+The deeper root cause: **no automated invariant enforced "a scheduled scoring chain may not terminate on a premium provider,"** and **no code-level guard prevented the fallback builder from constructing a premium provider silently.** Per-PR review can't catch this because no single PR reintroduced premium billing — the regression lived in the *composition* of three good changes. A note in a memory file does not survive three sessions and three unrelated motivations.
+
+Contributing design gaps found while root-causing:
+- **No premium/cheap classification exists on providers** — the fallback builder skips a provider only when its name is unknown or it fails to construct (missing key), never for cost. Cost was not a property the code could reason about.
+- **openrouter's default model is premium Claude** — so "openrouter" reads as cheap but isn't unless `OPENROUTER_MODEL` is pinned. Kestrel's docs even recommend chains (`groq,cerebras,sambanova,openrouter,anthropic`) that silently collapse to `groq,openrouter,anthropic` because `cerebras`/`sambanova` aren't registered — landing everything on premium Claude via openrouter's default.
+- **Score-cache keys omit model/provider** (both the pipeline JSON cache and the encrypted SQLite cache), so a model bump silently invalidates nothing and a premium call is unattributable.
+
+## Detection
+
+Detected only when the **user noticed a higher API bill** ~10 days later — the worst detection channel (lagging, manual, money already spent). Could have been caught automatically at three points, none of which existed:
+- A CI invariant test failing when `anthropic` re-entered a scheduled chain (G-1322 / G-636 would both have tripped it).
+- A per-run digest line logging the *winning provider* + per-provider job counts (a premium cascade would have shown in the digest, not just the invoice).
+- A hard spend-cap / loud alarm when the only reachable provider is a paid one.
+
+The 400-broken Anthropic leg actively *masked* the regression for weeks — a broken safety-relevant path hides the risk it carries until something repairs it.
+
+## Resolution
+
+**Immediate stopgap (2026-07-19):**
+```
+gh variable set AI_PROVIDER_FALLBACK --body "mistral,openrouter,together"   # daily-scan: drop terminal anthropic
+gh workflow disable "tier-0-ats-poller.yml" -R pleasedodisturb/Eyas          # pause the 44x/weekday poller
+```
+**Durable fix (PR #196, G-1371) — Eyas, mirrored in Kestrel:**
+- Removed `anthropic` from both workflow default chains.
+- **Code guard:** `factory._filter_premium()` — a pure, unit-tested function that drops premium providers from a fallback chain unless `AI_ALLOW_PREMIUM_FALLBACK=1`. The chain builder can no longer construct a premium provider silently, even if a workflow re-adds it.
+- **`tests/test_billing_safety.py`** — CI-enforced invariants: every provider is cost-classified; the premium set matches; the filter drops/keeps premium correctly; the chain builder excludes premium by default; no scheduled workflow default chain contains a premium provider; any openrouter leg must pin a cheap `OPENROUTER_MODEL`. Added to `ci.yml`'s ratchet list so it actually gates.
+- **Test-isolation hardening:** added `api.mistral.ai` + Gemini to the conftest HTTP block (they were unblocked — a test could have billed them).
+- **Follow-up (G-1371):** hard spend guardrail + winning-provider in the daily digest; poller cadence review.
+
+## What went well / what went wrong
+
+- ✅ The 2026-07-09 COE + `feedback_estimate_cost_before_bulk_paid_ops` documented the *cost shape* of a full run, which made root-causing fast.
+- ✅ Stopgap (repo variable + workflow disable) stops billing on the next scheduled run without waiting for a merge.
+- ✗ The original fix was encoded as a memory note ("NEVER change X"), invisible to the agent making an unrelated quality change three months later.
+- ✗ A quality change (G-1322) and a feature change (G-636) each altered the cost-critical chain with no cost review, because cost wasn't a *checked* property of the chain.
+- ✗ The Anthropic leg was left in the chain even while broken — a latent hazard nobody removed because it wasn't currently firing.
+- ✗ No provider-attribution in run logs, so the premium cascade was invisible until the invoice.
+
+## How a future agent avoids this   ← the point of the whole doc
+
+- **Encode cost floors as CI invariants, never as prose.** If a pipeline "must run on a free/cheap tier," write a test that fails when it doesn't. A memory note saying "never do X" will not survive an unrelated change by a future session. (`tests/test_billing_safety.py` is now that invariant in both Eyas and Kestrel.)
+- **Any edit to a provider chain, scoring model, cost preset, or provider default model is a cost-review edit** — even when the motivation is quality or a new feature. Before changing the chain, ask: does it still terminate on a $0/near-$0 provider, and does every routing leg (openrouter) pin a cheap model? Run the billing suite.
+- **A premium provider must never be a *silent* terminal fallback.** If all cheap providers fail, degrade to no-score + alarm, not cascade to premium. Premium fallback = explicit `AI_ALLOW_PREMIUM_FALLBACK=1` only.
+- **"Cheap provider" can hide a premium model.** openrouter routes to whatever `OPENROUTER_MODEL` says, and the default is premium Claude. Classify by *resolved cost*, not provider brand.
+- **A broken safety path is still a hazard — remove it, don't leave it.** A dangerous leg that's currently harmless only because it errors is a landmine waiting for a bug fix. When a bug fix repairs a previously-broken path, ask "should this path exist at all?" (G-1315 repaired the Anthropic leg without asking that.)
+- **Attribute cost in run output.** Log the winning provider + per-provider job counts every run, so a premium cascade shows up in the digest the same day, not on next month's invoice.
+
+## Action items
+
+- [x] G-1371 / PR #196 — remove `anthropic` from both Eyas scheduled chains; add `_filter_premium` guard + `test_billing_safety.py`; wire into CI; harden conftest host block (this session).
+- [x] Port the guard + billing-safety suite to **Kestrel** (upstream) so fork and parent hold the same invariant (this session).
+- [ ] G-1371 — hard spend guardrail + winning-provider logged in the daily digest; poller cadence review (follow-up).
+- [ ] Kestrel — fix `docs/guides/cost-optimization.md` examples that terminate chains in anthropic / reference unregistered providers (`cerebras`,`sambanova`,`openai`) that silently collapse the chain onto premium (new ticket).
+- [ ] Consider adding provider/model to the score-cache key so a model bump invalidates cache and premium calls are attributable (new ticket).

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -126,6 +126,47 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
 
 _SUPPORTED_PROVIDERS = set(_PROVIDER_REGISTRY.keys())
 
+# ---------------------------------------------------------------------------
+# Premium-provider fallback guard (COE 2026-07-19, G-1371)
+#
+# `anthropic` (claude-sonnet-5 / opus-4-8) bills ~10-20x the cheap providers.
+# It must NEVER be a *silent* terminal leg of a fallback chain: when the cheap
+# providers ahead of it rate-limit or run out of credits, every dropped job
+# cascades onto premium Claude with no alarm. Premium fallback is opt-in only.
+#
+# NOTE: `openrouter` is a *routing* provider whose cost depends on
+# OPENROUTER_MODEL (its registry default is a premium Claude model). Keeping it
+# cheap is enforced at the workflow/config level — see tests/test_billing_safety.py.
+# ---------------------------------------------------------------------------
+_PREMIUM_PROVIDERS = frozenset({"anthropic"})
+
+_ALLOW_PREMIUM_ENV = "AI_ALLOW_PREMIUM_FALLBACK"
+
+
+def _premium_fallback_allowed() -> bool:
+    """True only when premium providers are explicitly opted into as fallbacks."""
+    return os.getenv(_ALLOW_PREMIUM_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _filter_premium(names: list[str]) -> list[str]:
+    """Drop premium providers from a fallback chain unless explicitly opted in.
+
+    Pure function (no I/O, no provider construction) so it is trivially testable.
+    A premium provider reached as a silent fallback is a surprise-bill hazard
+    (COE 2026-07-19); set AI_ALLOW_PREMIUM_FALLBACK=1 to allow it deliberately.
+    """
+    if _premium_fallback_allowed():
+        return names
+    dropped = [n for n in names if n in _PREMIUM_PROVIDERS]
+    if dropped:
+        logger.warning(
+            "Fallback chain: dropping premium provider(s) %s — premium fallback is "
+            "opt-in only (set %s=1 to allow).",
+            dropped,
+            _ALLOW_PREMIUM_ENV,
+        )
+    return [n for n in names if n not in _PREMIUM_PROVIDERS]
+
 
 class UnsupportedProviderError(Exception):
     """Raised when AI_PROVIDER is set to an unsupported value."""
@@ -148,13 +189,16 @@ def _build_fallback_chain() -> list[AIProvider] | None:
     comma-separated env var, or None if the env var is unset or only contains
     a single provider (no chain needed).
 
-    Unknown provider names are silently skipped.
+    Unknown provider names are silently skipped. Premium providers are dropped
+    unless AI_ALLOW_PREMIUM_FALLBACK is set (see _filter_premium) — a premium
+    provider reached as a silent fallback is a surprise-bill hazard (COE
+    2026-07-19).
     """
     raw = os.getenv("AI_PROVIDER_FALLBACK", "").strip()
     if not raw:
         return None
 
-    names = [n.strip().lower() for n in raw.split(",") if n.strip()]
+    names = _filter_premium([n.strip().lower() for n in raw.split(",") if n.strip()])
     providers: list[AIProvider] = []
     for name in names:
         factory_fn = _PROVIDER_REGISTRY.get(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ _BLOCKED_AI_DOMAINS = [
     "api.openai.com",
     "api.groq.com",
     "api.x.ai",
+    "api.mistral.ai",
     "generativelanguage.googleapis.com",
 ]
 

--- a/tests/test_billing_safety.py
+++ b/tests/test_billing_safety.py
@@ -1,0 +1,182 @@
+"""Billing-safety invariants for AI scoring (G-1371, COE 2026-07-19).
+
+Background: the scoring pipeline routes through an `AI_PROVIDER_FALLBACK` chain.
+In the downstream fork (Eyas) that chain silently terminated in premium Anthropic
+(`claude-sonnet-5`) for months; whenever the cheaper providers ahead of it failed
+(429 / 402 / missing key / outage), every dropped job billed Anthropic at premium
+rates with no alarm. The original "run the cheap tier" fix was a value protected
+by a note, not an invariant protected by code — and unrelated later changes eroded
+it. Kestrel (upstream) carries the same architecture and the same gap: its docs
+even recommend chains that collapse onto premium Claude.
+
+This suite turns the discipline into code-enforced invariants:
+
+  1. Every registered provider is cost-classified (forces a cost decision when a
+     provider is added).
+  2. The factory's premium set matches the classification and contains anthropic.
+  3. `_filter_premium` drops premium providers from a chain unless opted in.
+  4. `_build_fallback_chain` never builds a premium provider without the opt-in.
+  5. No scheduled workflow's *literal* default chain contains a premium provider
+     (Kestrel configures the chain via a repo variable, so the primary
+     enforcement here is the code guard, tests 3-4).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from career_os.ai import factory
+from career_os.ai.factory import _ALLOW_PREMIUM_ENV, _PREMIUM_PROVIDERS, _filter_premium
+
+# ---------------------------------------------------------------------------
+# Test-owned cost classification. Every provider in the factory registry MUST
+# appear here — adding a provider without deciding its cost tier fails CI.
+#
+#   FREE     — no marginal cost (local / mock)
+#   CHEAP    — paid but low $/call for the small models we default to
+#   ROUTING  — cost depends on the resolved model (openrouter)
+#   PREMIUM  — ~10-20x cheap providers (claude-sonnet-5 / opus-4-8)
+# ---------------------------------------------------------------------------
+FREE = "free"
+CHEAP = "cheap"
+ROUTING = "routing"
+PREMIUM = "premium"
+
+COST_TIER: dict[str, str] = {
+    "mock": FREE,
+    "demo": FREE,
+    "ollama": FREE,
+    "openrouter": ROUTING,
+    "together": CHEAP,
+    "groq": CHEAP,
+    "xai": CHEAP,
+    "gemini": CHEAP,
+    "mistral": CHEAP,
+    "huggingface": CHEAP,
+    "hf": CHEAP,
+    "anthropic": PREMIUM,
+}
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+# Scheduled workflows whose runs bill on the user's own API keys. nightly.yml
+# runs eval on the mock provider only, so it is excluded.
+SCHEDULED_SCORING_WORKFLOWS = ["daily-scan.yml"]
+
+# Captures the single-quoted default on an env line — matches both
+#   FOO: 'literal'   and   FOO: ${{ vars.X || 'literal' }}
+_QUOTED_DEFAULT = r"^\s*{key}:.*?'([^']*)'"
+
+
+def _quoted_defaults(text: str, key: str) -> list[str]:
+    return re.findall(_QUOTED_DEFAULT.format(key=re.escape(key)), text, re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# 1 & 2 — classification completeness and premium-set agreement
+# ---------------------------------------------------------------------------
+def test_every_registered_provider_is_cost_classified():
+    registered = set(factory._PROVIDER_REGISTRY)
+    classified = set(COST_TIER)
+    missing = registered - classified
+    stale = classified - registered
+    assert not missing, (
+        f"provider(s) {sorted(missing)} are registered but not cost-classified in "
+        f"COST_TIER — decide their billing tier (FREE/CHEAP/ROUTING/PREMIUM) before "
+        f"they can silently join a fallback chain (G-1371)."
+    )
+    assert not stale, f"COST_TIER classifies removed provider(s) {sorted(stale)}"
+
+
+def test_premium_set_matches_classification_and_contains_anthropic():
+    classified_premium = {name for name, tier in COST_TIER.items() if tier == PREMIUM}
+    assert set(_PREMIUM_PROVIDERS) == classified_premium, (
+        "factory._PREMIUM_PROVIDERS and the COST_TIER PREMIUM set disagree — keep "
+        "them in sync so the guard covers exactly the premium providers."
+    )
+    assert "anthropic" in _PREMIUM_PROVIDERS
+
+
+# ---------------------------------------------------------------------------
+# 3 — the pure premium filter
+# ---------------------------------------------------------------------------
+def test_filter_premium_drops_anthropic_by_default(monkeypatch):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    assert _filter_premium(["mistral", "openrouter", "anthropic"]) == [
+        "mistral",
+        "openrouter",
+    ]
+
+
+def test_filter_premium_preserves_cheap_order(monkeypatch):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    chain = ["groq", "mistral", "together"]
+    assert _filter_premium(chain) == chain
+
+
+@pytest.mark.parametrize("optin", ["1", "true", "YES", "on"])
+def test_filter_premium_keeps_anthropic_when_opted_in(monkeypatch, optin):
+    monkeypatch.setenv(_ALLOW_PREMIUM_ENV, optin)
+    assert _filter_premium(["mistral", "anthropic"]) == ["mistral", "anthropic"]
+
+
+# ---------------------------------------------------------------------------
+# 4 — the chain builder never constructs a premium provider without the opt-in
+# ---------------------------------------------------------------------------
+class _Stub:
+    """Minimal stand-in so we don't need real API keys to build a chain."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@pytest.fixture
+def stub_registry(monkeypatch):
+    """Replace the registry with keyless name-stamped stubs."""
+    stubs = {name: (lambda n=name: _Stub(n)) for name in factory._PROVIDER_REGISTRY}
+    monkeypatch.setattr(factory, "_PROVIDER_REGISTRY", stubs)
+    return stubs
+
+
+def test_build_fallback_chain_excludes_premium_by_default(monkeypatch, stub_registry):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.setenv("AI_PROVIDER_FALLBACK", "groq,openrouter,anthropic")
+    chain = factory._build_fallback_chain()
+    assert chain is not None
+    names = [p.name for p in chain]
+    assert "anthropic" not in names, "premium anthropic must not be built silently"
+    assert names == ["groq", "openrouter"]
+
+
+def test_build_fallback_chain_includes_premium_when_opted_in(monkeypatch, stub_registry):
+    monkeypatch.setenv(_ALLOW_PREMIUM_ENV, "1")
+    monkeypatch.setenv("AI_PROVIDER_FALLBACK", "mistral,anthropic")
+    chain = factory._build_fallback_chain()
+    assert chain is not None
+    assert [p.name for p in chain] == ["mistral", "anthropic"]
+
+
+# ---------------------------------------------------------------------------
+# 5 — scheduled-workflow invariant (best-effort; chain is usually a repo var)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("workflow", SCHEDULED_SCORING_WORKFLOWS)
+def test_scheduled_chain_has_no_premium_literal_default(workflow):
+    path = WORKFLOWS_DIR / workflow
+    assert path.exists(), f"expected scheduled workflow not found: {path}"
+    defaults = _quoted_defaults(path.read_text(), "AI_PROVIDER_FALLBACK")
+    if not defaults:
+        pytest.skip(
+            f"{workflow} sets AI_PROVIDER_FALLBACK from a repo variable, not a literal "
+            f"default — the premium chain is enforced by the _filter_premium code guard "
+            f"(tests 3-4), not this file-level check."
+        )
+    premium_tiered = {name for name, tier in COST_TIER.items() if tier == PREMIUM}
+    for chain in defaults:
+        providers = {p.strip() for p in chain.split(",") if p.strip()}
+        hit = providers & premium_tiered
+        assert not hit, (
+            f"{workflow}: premium provider(s) {sorted(hit)} in default chain "
+            f"'{chain}'. Premium fallback must be opt-in, not a hardcoded default "
+            f"(G-1371)."
+        )


### PR DESCRIPTION
## Why
Upstream port of the fix for the premium-Anthropic billing regression found in the Eyas fork. Kestrel has the same provider-chain architecture and the same gap: nothing prevents an `AI_PROVIDER_FALLBACK` chain from silently terminating on premium Anthropic (`claude-sonnet-5`), and `docs/guides/cost-optimization.md` recommends chains (`groq,cerebras,sambanova,openrouter,anthropic`) that **collapse onto premium Claude** — `cerebras`/`sambanova` aren't registered so they're dropped, and `openrouter`'s default model is premium Claude.

Root cause (full COE in `docs/coe/2026-07-19_premium-anthropic-fallback-billing-regression.md`): the "run the cheap tier" rule was a value protected by a memory note, not an invariant protected by code. Three unrelated, each-locally-correct changes eroded it until premium billing resumed silently.

## Changes
- **`_filter_premium()`** in `factory.py` — pure, unit-tested guard that drops premium providers from a fallback chain unless `AI_ALLOW_PREMIUM_FALLBACK=1`. The chain builder can no longer construct a premium leg silently. Since Kestrel's chain is a repo variable, this is the primary enforcement.
- **`tests/test_billing_safety.py`** — cost-classification completeness, premium-set agreement, filter behaviour, chain-builder exclusion, and a scheduled-workflow default-chain guard. Runs under CI's `pytest tests/` (`31 passed, 1 skipped`).
- **conftest**: added `api.mistral.ai` to the AI-host block (was unblocked — a test could have billed it).
- **COE** doc committed.

## Follow-up (separate ticket)
- Fix `docs/guides/cost-optimization.md` examples that terminate chains in `anthropic` / reference unregistered providers.
- Consider adding provider/model to the score-cache key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3BAWH3r7WbfbCxwp7p9LZ
