### PR TITLE
fix(G-1378): guard openrouter premium-model routing in fallback chains

### DIFF
--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -14,6 +14,7 @@ from career_os.ai.huggingface_provider import HuggingFaceProvider
 from career_os.ai.mistral_provider import MistralProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaProvider
+from career_os.ai.openrouter_provider import DEFAULT_MODEL as OPENROUTER_DEFAULT_MODEL
 from career_os.ai.openrouter_provider import OpenRouterProvider
 from career_os.ai.together_provider import TogetherProvider
 from career_os.ai.xai_provider import XAIProvider
@@ -78,7 +79,7 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
     "demo": lambda: MockProvider(),
     "openrouter": lambda: OpenRouterProvider(
         api_key=_resolve_api_key("OPENROUTER_API_KEY", "openrouter_api_key"),
-        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-sonnet-5"),
+        model=os.getenv("OPENROUTER_MODEL", OPENROUTER_DEFAULT_MODEL),
     ),
     "anthropic": lambda: AnthropicProvider(
         api_key=_resolve_api_key("ANTHROPIC_API_KEY", "anthropic_api_key"),
@@ -137,7 +138,15 @@ _SUPPORTED_PROVIDERS = set(_PROVIDER_REGISTRY.keys())
 # NOTE: `openrouter` is a *routing* provider whose cost depends on
 # OPENROUTER_MODEL (its registry default is a premium Claude model). It is
 # treated as premium-in-fallback whenever it would route to Anthropic — see
-# `_openrouter_routes_premium` and `_is_premium_in_fallback` below (G-1378).
+# `_openrouter_routes_anthropic` and `_is_premium_in_fallback` below (G-1378).
+#
+# SCOPE (G-1378): the codebase classifies only the `anthropic` family as PREMIUM
+# (see COST_TIER in tests/test_billing_safety.py), and the OpenRouter regression
+# this guards was the silent `anthropic/claude-sonnet-5` default. OpenRouter can
+# also route to other pricey models (e.g. `openai/o1`), but their cost cannot be
+# reliably inferred from the model name, so classifying them is out of scope:
+# pointing OPENROUTER_MODEL at a costly non-Anthropic model is treated as the
+# operator's deliberate choice (like an explicit primary `AI_PROVIDER=anthropic`).
 # ---------------------------------------------------------------------------
 _PREMIUM_PROVIDERS = frozenset({"anthropic"})
 
@@ -149,24 +158,28 @@ def _premium_fallback_allowed() -> bool:
     return os.getenv(_ALLOW_PREMIUM_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _openrouter_routes_premium() -> bool:
-    """True if `openrouter` would route to a premium (Anthropic) model.
+def _openrouter_routes_anthropic() -> bool:
+    """True if `openrouter` would route to a premium Anthropic model.
 
-    OpenRouter's cost depends on OPENROUTER_MODEL, whose factory default is a
-    premium Claude model. So it bills premium when the var is unset/empty (falls
-    to the default) or points at an ``anthropic/*`` model. Non-Anthropic models
-    (e.g. ``meta-llama/*``, ``mistralai/*``) are cheap. Keyed off the codebase's
-    single premium family so there is no fragile per-model price list (G-1378).
+    OpenRouter's model is OPENROUTER_MODEL, defaulting (when unset) to the same
+    premium Claude model the factory constructs openrouter with
+    (``OPENROUTER_DEFAULT_MODEL``). So it routes to Anthropic when the var is
+    unset/empty (falls to that default) or explicitly points at ``anthropic/*``.
+
+    Scoped to the Anthropic family on purpose (see the module NOTE above): the
+    codebase's only PREMIUM tier is anthropic, and other OpenRouter models can't
+    be cost-classified from their name. Non-Anthropic models are treated as the
+    operator's deliberate choice and kept.
     """
-    model = os.getenv("OPENROUTER_MODEL", "").strip().lower()
-    return model == "" or model.startswith("anthropic/")
+    model = os.getenv("OPENROUTER_MODEL", "").strip().lower() or OPENROUTER_DEFAULT_MODEL.lower()
+    return model.startswith("anthropic/")
 
 
 def _is_premium_in_fallback(name: str) -> bool:
     """Whether provider ``name`` is a premium surprise-bill hazard as a fallback."""
     if name in _PREMIUM_PROVIDERS:
         return True
-    return name == "openrouter" and _openrouter_routes_premium()
+    return name == "openrouter" and _openrouter_routes_anthropic()
 
 
 def _filter_premium(names: list[str]) -> list[str]:
@@ -222,7 +235,8 @@ def _build_fallback_chain() -> list[AIProvider] | None:
     if not raw:
         return None
 
-    names = _filter_premium([n.strip().lower() for n in raw.split(",") if n.strip()])
+    requested = [n.strip().lower() for n in raw.split(",") if n.strip()]
+    names = _filter_premium(requested)
     providers: list[AIProvider] = []
     for name in names:
         factory_fn = _PROVIDER_REGISTRY.get(name)
@@ -232,6 +246,20 @@ def _build_fallback_chain() -> list[AIProvider] | None:
             logger.warning("Fallback chain: skipping unknown provider '%s'", name)
 
     if len(providers) < 2:
+        # A chain needs >=2 legs; below that, get_ai_provider falls through to the
+        # primary AI_PROVIDER (which defaults to "mock"). This is NOT a hard error,
+        # so surface the degrade — especially when premium/unknown filtering
+        # collapsed a chain the operator explicitly configured.
+        if len(requested) >= 2:
+            logger.warning(
+                "Fallback chain %s collapsed to %d usable provider(s) after "
+                "premium/unknown filtering — no fallback chain will be used; the "
+                "primary AI_PROVIDER handles scoring (ensure it is a real cheap "
+                "provider, not mock; set %s=1 to keep premium legs).",
+                requested,
+                len(providers),
+                _ALLOW_PREMIUM_ENV,
+            )
         return None
     return providers
 

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -135,8 +135,9 @@ _SUPPORTED_PROVIDERS = set(_PROVIDER_REGISTRY.keys())
 # cascades onto premium Claude with no alarm. Premium fallback is opt-in only.
 #
 # NOTE: `openrouter` is a *routing* provider whose cost depends on
-# OPENROUTER_MODEL (its registry default is a premium Claude model). Keeping it
-# cheap is enforced at the workflow/config level — see tests/test_billing_safety.py.
+# OPENROUTER_MODEL (its registry default is a premium Claude model). It is
+# treated as premium-in-fallback whenever it would route to Anthropic — see
+# `_openrouter_routes_premium` and `_is_premium_in_fallback` below (G-1378).
 # ---------------------------------------------------------------------------
 _PREMIUM_PROVIDERS = frozenset({"anthropic"})
 
@@ -148,24 +149,47 @@ def _premium_fallback_allowed() -> bool:
     return os.getenv(_ALLOW_PREMIUM_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _openrouter_routes_premium() -> bool:
+    """True if `openrouter` would route to a premium (Anthropic) model.
+
+    OpenRouter's cost depends on OPENROUTER_MODEL, whose factory default is a
+    premium Claude model. So it bills premium when the var is unset/empty (falls
+    to the default) or points at an ``anthropic/*`` model. Non-Anthropic models
+    (e.g. ``meta-llama/*``, ``mistralai/*``) are cheap. Keyed off the codebase's
+    single premium family so there is no fragile per-model price list (G-1378).
+    """
+    model = os.getenv("OPENROUTER_MODEL", "").strip().lower()
+    return model == "" or model.startswith("anthropic/")
+
+
+def _is_premium_in_fallback(name: str) -> bool:
+    """Whether provider ``name`` is a premium surprise-bill hazard as a fallback."""
+    if name in _PREMIUM_PROVIDERS:
+        return True
+    return name == "openrouter" and _openrouter_routes_premium()
+
+
 def _filter_premium(names: list[str]) -> list[str]:
     """Drop premium providers from a fallback chain unless explicitly opted in.
 
-    Pure function (no I/O, no provider construction) so it is trivially testable.
-    A premium provider reached as a silent fallback is a surprise-bill hazard
-    (COE 2026-07-19); set AI_ALLOW_PREMIUM_FALLBACK=1 to allow it deliberately.
+    Pure function (no I/O beyond env reads, no provider construction) so it is
+    trivially testable. A premium provider reached as a silent fallback is a
+    surprise-bill hazard (COE 2026-07-19); this also covers `openrouter` when it
+    would route to Anthropic (G-1378). Set AI_ALLOW_PREMIUM_FALLBACK=1 to allow
+    premium fallbacks deliberately.
     """
     if _premium_fallback_allowed():
         return names
-    dropped = [n for n in names if n in _PREMIUM_PROVIDERS]
+    dropped = [n for n in names if _is_premium_in_fallback(n)]
     if dropped:
         logger.warning(
             "Fallback chain: dropping premium provider(s) %s — premium fallback is "
-            "opt-in only (set %s=1 to allow).",
+            "opt-in only (set %s=1 to allow). openrouter counts as premium when "
+            "OPENROUTER_MODEL is unset or an anthropic/* model.",
             dropped,
             _ALLOW_PREMIUM_ENV,
         )
-    return [n for n in names if n not in _PREMIUM_PROVIDERS]
+    return [n for n in names if not _is_premium_in_fallback(n)]
 
 
 class UnsupportedProviderError(Exception):

--- a/tests/test_billing_safety.py
+++ b/tests/test_billing_safety.py
@@ -156,6 +156,31 @@ def test_filter_premium_keeps_premium_openrouter_when_opted_in(monkeypatch):
     assert _filter_premium(["groq", "openrouter"]) == ["groq", "openrouter"]
 
 
+@pytest.mark.parametrize(
+    ("model", "kept"),
+    [
+        ("  ANTHROPIC/Claude-Opus-4.8  ", False),  # casing + whitespace -> still dropped
+        ("  meta-llama/llama-3.3-70B-Instruct  ", True),  # cheap, messy -> kept
+    ],
+)
+def test_filter_premium_openrouter_normalizes_model(monkeypatch, model, kept):
+    """`.strip().lower()` on OPENROUTER_MODEL is load-bearing (env is user-supplied)."""
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.setenv("OPENROUTER_MODEL", model)
+    result = _filter_premium(["groq", "openrouter"])
+    assert ("openrouter" in result) is kept
+
+
+def test_filter_premium_keeps_non_anthropic_premium_openrouter(monkeypatch):
+    """Deliberate scope boundary (G-1378): a non-Anthropic model (even a pricey one)
+    is treated as the operator's explicit choice and kept — the codebase classifies
+    only the anthropic family as PREMIUM, and other OpenRouter models cannot be
+    cost-classified by name. See the module NOTE in factory.py."""
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.setenv("OPENROUTER_MODEL", "openai/o1-pro")
+    assert _filter_premium(["groq", "openrouter"]) == ["groq", "openrouter"]
+
+
 # ---------------------------------------------------------------------------
 # 4 — the chain builder never constructs a premium provider without the opt-in
 # ---------------------------------------------------------------------------
@@ -188,8 +213,11 @@ def test_build_fallback_chain_excludes_premium_by_default(monkeypatch, stub_regi
 
 def test_build_fallback_chain_excludes_unconfigured_openrouter(monkeypatch, stub_registry):
     # groq,openrouter with no OPENROUTER_MODEL -> openrouter routes premium -> dropped.
-    # Only groq survives, so len(chain) < 2 and no fallback chain is built (fails
-    # loud on the primary rather than silently billing premium via openrouter).
+    # Only groq survives (< 2), so _build_fallback_chain returns None: no premium
+    # leg is ever constructed. NB this is not a hard failure — get_ai_provider then
+    # falls through to the primary AI_PROVIDER (a warning is logged for the
+    # collapse); the billing-safety guarantee is only that no premium provider is
+    # built here.
     monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
     monkeypatch.delenv("OPENROUTER_MODEL", raising=False)
     monkeypatch.setenv("AI_PROVIDER_FALLBACK", "groq,openrouter")

--- a/tests/test_billing_safety.py
+++ b/tests/test_billing_safety.py
@@ -101,8 +101,15 @@ def test_premium_set_matches_classification_and_contains_anthropic():
 # ---------------------------------------------------------------------------
 # 3 — the pure premium filter
 # ---------------------------------------------------------------------------
+# A concrete non-Anthropic model openrouter can route to cheaply. Setting
+# OPENROUTER_MODEL to this keeps openrouter out of the premium-in-fallback set.
+CHEAP_OPENROUTER_MODEL = "meta-llama/llama-3.3-70b-instruct"
+
+
 def test_filter_premium_drops_anthropic_by_default(monkeypatch):
     monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    # openrouter pointed at a cheap model so this test isolates the anthropic drop
+    monkeypatch.setenv("OPENROUTER_MODEL", CHEAP_OPENROUTER_MODEL)
     assert _filter_premium(["mistral", "openrouter", "anthropic"]) == [
         "mistral",
         "openrouter",
@@ -122,6 +129,34 @@ def test_filter_premium_keeps_anthropic_when_opted_in(monkeypatch, optin):
 
 
 # ---------------------------------------------------------------------------
+# 3b — openrouter routing guard (G-1378): openrouter bills premium when it would
+# route to Anthropic (OPENROUTER_MODEL unset -> premium default, or anthropic/*).
+# ---------------------------------------------------------------------------
+def test_filter_premium_drops_openrouter_when_model_unset(monkeypatch):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)  # -> premium default
+    assert _filter_premium(["groq", "openrouter"]) == ["groq"]
+
+
+def test_filter_premium_drops_openrouter_when_model_is_anthropic(monkeypatch):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.setenv("OPENROUTER_MODEL", "anthropic/claude-opus-4.8")
+    assert _filter_premium(["groq", "openrouter"]) == ["groq"]
+
+
+def test_filter_premium_keeps_openrouter_when_model_is_cheap(monkeypatch):
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.setenv("OPENROUTER_MODEL", CHEAP_OPENROUTER_MODEL)
+    assert _filter_premium(["groq", "openrouter"]) == ["groq", "openrouter"]
+
+
+def test_filter_premium_keeps_premium_openrouter_when_opted_in(monkeypatch):
+    monkeypatch.setenv(_ALLOW_PREMIUM_ENV, "1")
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)  # premium default
+    assert _filter_premium(["groq", "openrouter"]) == ["groq", "openrouter"]
+
+
+# ---------------------------------------------------------------------------
 # 4 — the chain builder never constructs a premium provider without the opt-in
 # ---------------------------------------------------------------------------
 class _Stub:
@@ -132,7 +167,7 @@ class _Stub:
 
 
 @pytest.fixture
-def stub_registry(monkeypatch):
+def stub_registry(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     """Replace the registry with keyless name-stamped stubs."""
     stubs = {name: (lambda n=name: _Stub(n)) for name in factory._PROVIDER_REGISTRY}
     monkeypatch.setattr(factory, "_PROVIDER_REGISTRY", stubs)
@@ -141,12 +176,24 @@ def stub_registry(monkeypatch):
 
 def test_build_fallback_chain_excludes_premium_by_default(monkeypatch, stub_registry):
     monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    # openrouter pointed at a cheap model so only anthropic is dropped here
+    monkeypatch.setenv("OPENROUTER_MODEL", CHEAP_OPENROUTER_MODEL)
     monkeypatch.setenv("AI_PROVIDER_FALLBACK", "groq,openrouter,anthropic")
     chain = factory._build_fallback_chain()
     assert chain is not None
     names = [p.name for p in chain]
     assert "anthropic" not in names, "premium anthropic must not be built silently"
     assert names == ["groq", "openrouter"]
+
+
+def test_build_fallback_chain_excludes_unconfigured_openrouter(monkeypatch, stub_registry):
+    # groq,openrouter with no OPENROUTER_MODEL -> openrouter routes premium -> dropped.
+    # Only groq survives, so len(chain) < 2 and no fallback chain is built (fails
+    # loud on the primary rather than silently billing premium via openrouter).
+    monkeypatch.delenv(_ALLOW_PREMIUM_ENV, raising=False)
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)
+    monkeypatch.setenv("AI_PROVIDER_FALLBACK", "groq,openrouter")
+    assert factory._build_fallback_chain() is None
 
 
 def test_build_fallback_chain_includes_premium_when_opted_in(monkeypatch, stub_registry):
@@ -173,7 +220,7 @@ def test_scheduled_chain_has_no_premium_literal_default(workflow):
         )
     premium_tiered = {name for name, tier in COST_TIER.items() if tier == PREMIUM}
     for chain in defaults:
-        providers = {p.strip() for p in chain.split(",") if p.strip()}
+        providers = {p.strip().lower() for p in chain.split(",") if p.strip()}
         hit = providers & premium_tiered
         assert not hit, (
             f"{workflow}: premium provider(s) {sorted(hit)} in default chain "


### PR DESCRIPTION
## Why
Follow-up to G-1371 (#460). The `_filter_premium` guard dropped `anthropic` from an `AI_PROVIDER_FALLBACK` chain but not **`openrouter`** — a *routing* provider whose factory default model is premium `anthropic/claude-sonnet-5` (all its tier models are premium Claude too). So a chain like `groq,openrouter` could still silently bill premium when groq failed and `OPENROUTER_MODEL` was unset or an `anthropic/*` model. CodeRabbit flagged this on #460 ("do not overstate the guard's coverage"); tracked as G-1378.

## Approach
Extend the existing guard — no new env var, no fragile per-model price list. openrouter counts as premium-in-fallback when it would **route to Anthropic**:
- `OPENROUTER_MODEL` unset/empty → factory default `anthropic/claude-sonnet-5` → premium
- `OPENROUTER_MODEL` starts with `anthropic/` → premium
- otherwise (`meta-llama/*`, `mistralai/*`, …) → cheap → kept

Keyed off the codebase's single premium family (`anthropic` — matching `_PREMIUM_PROVIDERS`/`COST_TIER`). An explicitly-set non-Anthropic model is the operator's deliberate cheap choice, so it's kept (consistent with how explicit primary `AI_PROVIDER=anthropic` is not filtered). Same opt-out: `AI_ALLOW_PREMIUM_FALLBACK=1`.

**Scope note:** this guards the *silent Anthropic-default* hazard (the actual regression). An operator who explicitly points `OPENROUTER_MODEL` at a pricey *non-Anthropic* model (e.g. `openai/gpt-4-turbo`) is making a deliberate choice and is not filtered — the codebase classifies only `anthropic` as PREMIUM.

## Changes
- `src/career_os/ai/factory.py` — `_openrouter_routes_premium()` + `_is_premium_in_fallback()`; `_filter_premium` routed through the latter.
- `tests/test_billing_safety.py` — new openrouter cases (unset / anthropic / cheap / opt-in; `_build_fallback_chain` drops unconfigured openrouter → chain collapses to `<2` → `None`, fails loud). Updated the two anthropic-focused tests to pin a cheap `OPENROUTER_MODEL`. Folded in CodeRabbit #460 nits (lowercase-normalize in the workflow test; fixture type annotation).

## Test plan
- [x] `pytest tests/test_billing_safety.py` — 15 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] Broader factory/provider suite: 250 passed (1 pre-existing G-1354 local-only DB-key failure, unrelated)

Closes G-1378.