### PR TITLE
test(G-1354): make provider api-key tests hermetic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,24 @@ def block_real_ai_calls(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "send", guarded_send)
 
 
+@pytest.fixture(autouse=True)
+def hermetic_db_credentials(monkeypatch):
+    """Never resolve provider API keys from the developer's real database.
+
+    `career_os.ai.factory._resolve_api_key` falls back to
+    `_read_credential_from_db`, which reads the on-disk `data/career_os.db`. On a
+    dev machine with a stored key (e.g. an `openrouter_api_key` in
+    `integration_configs`), the 'missing key' tests received a real credential and
+    failed — while CI's fresh DB had none and passed (G-1354). Force the DB lookup
+    to return empty so key resolution depends only on the env-controlled test
+    inputs. A test that needs a stored credential can re-patch this in its body.
+    """
+    monkeypatch.setattr(
+        "career_os.ai.factory._read_credential_from_db",
+        lambda credential_key: "",
+    )
+
+
 from tests.profile_data import DEFAULT_PROFILE_KWARGS, SECOND_PROFILE_KWARGS  # noqa: F401
 
 


### PR DESCRIPTION
## Why
7 tests in `test_ai_provider.py` + `test_provider_uat.py` assert that a *missing* provider key raises, but `factory._resolve_api_key` falls back to `_read_credential_from_db`, which reads the on-disk `data/career_os.db`. On any dev machine with a stored key (e.g. `openrouter_api_key` in `integration_configs`), those tests got a real credential and **failed locally** — while CI's fresh DB has none so they passed, masking the flake. Found by the scoring-v2 milestone review; pre-existing since G-392.

The 7 (all openrouter, since that's the stored dev cred):
- `test_ai_provider.py`: `test_openrouter_without_key_raises`, `test_complete_missing_api_key_422`, `test_get_provider_missing_api_key_422`, `test_openrouter_entry_requires_api_key`
- `test_provider_uat.py`: `test_missing_config_raises_not_crashes[openrouter]`, `test_api_complete_returns_422_not_500[openrouter]`, `test_api_provider_returns_422_not_500[openrouter]`

## Fix
Add an autouse `hermetic_db_credentials` fixture in `conftest.py` that patches `career_os.ai.factory._read_credential_from_db` → `""`, so provider-key resolution depends only on env-controlled test inputs. Covers every provider's DB fallback, not just openrouter. A test needing a stored credential can re-patch in its body (none currently do).

## Test plan
- [x] The 7 previously-failing tests now pass (94/94 in the two files)
- [x] Full suite: 4012 passed / 26 skipped, no regression (verified nothing relies on the real DB credential read)
- [x] ruff clean

Closes G-1354.