### PR TITLE
fix(G-1348): repair the dead OpenAI provider + cross-provider contract tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ AI_PROVIDER=mock
 OPENROUTER_API_KEY=
 OPENROUTER_MODEL=anthropic/claude-sonnet-4
 # Alternatives: google/gemini-2.5-flash-lite (cheapest), openai/gpt-5, mistral/mistral-large (EU)
+# NB: leaving OPENROUTER_MODEL unset routes to a premium Claude model, so
+# openrouter is dropped from AI_PROVIDER_FALLBACK chains unless you set a cheap
+# model here (or set AI_ALLOW_PREMIUM_FALLBACK=1). See G-1378.
+
+# Required when AI_PROVIDER=openai
+# Sign up at https://platform.openai.com to get a key
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
 
 # -- Database --------------------------------------------------------------
 DATABASE_URL=sqlite:///data/career_os.db

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -14,6 +14,7 @@ from career_os.ai.huggingface_provider import HuggingFaceProvider
 from career_os.ai.mistral_provider import MistralProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaProvider
+from career_os.ai.openai_provider import DEFAULT_MODEL as OPENAI_DEFAULT_MODEL
 from career_os.ai.openai_provider import OpenAIProvider
 from career_os.ai.openrouter_provider import DEFAULT_MODEL as OPENROUTER_DEFAULT_MODEL
 from career_os.ai.openrouter_provider import OpenRouterProvider
@@ -92,7 +93,9 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
     ),
     "openai": lambda: OpenAIProvider(
         api_key=_resolve_api_key("OPENAI_API_KEY", "openai_api_key"),
-        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        # `or DEFAULT` (not just getenv's default): a set-but-empty OPENAI_MODEL
+        # would otherwise send model="" and 400 every request.
+        model=os.getenv("OPENAI_MODEL", "").strip() or OPENAI_DEFAULT_MODEL,
     ),
     "together": lambda: TogetherProvider(
         api_key=_resolve_api_key("TOGETHER_API_KEY", "together_api_key"),

--- a/src/career_os/ai/factory.py
+++ b/src/career_os/ai/factory.py
@@ -14,6 +14,7 @@ from career_os.ai.huggingface_provider import HuggingFaceProvider
 from career_os.ai.mistral_provider import MistralProvider
 from career_os.ai.mock_provider import MockProvider
 from career_os.ai.ollama_provider import OllamaProvider
+from career_os.ai.openai_provider import OpenAIProvider
 from career_os.ai.openrouter_provider import DEFAULT_MODEL as OPENROUTER_DEFAULT_MODEL
 from career_os.ai.openrouter_provider import OpenRouterProvider
 from career_os.ai.together_provider import TogetherProvider
@@ -88,6 +89,10 @@ _PROVIDER_REGISTRY: dict[str, Callable[[], AIProvider]] = {
     "ollama": lambda: OllamaProvider(
         base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
         model=os.getenv("OLLAMA_MODEL", "llama3.3"),
+    ),
+    "openai": lambda: OpenAIProvider(
+        api_key=_resolve_api_key("OPENAI_API_KEY", "openai_api_key"),
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
     ),
     "together": lambda: TogetherProvider(
         api_key=_resolve_api_key("TOGETHER_API_KEY", "together_api_key"),

--- a/src/career_os/ai/openai_provider.py
+++ b/src/career_os/ai/openai_provider.py
@@ -12,11 +12,10 @@ import logging
 
 import httpx
 
-from career_os.ai.base import AIProvider, ProviderQuotaError
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT, AIProvider, ProviderQuotaError
 from career_os.ai.observability import observe, update_current_generation
 from career_os.ai.openrouter_provider import (
     _SCHEMA_MAP,
-    _scoring_user_prompt,
     _system_prompt_for_feature,
     _try_parse_structured,
 )
@@ -26,6 +25,37 @@ logger = logging.getLogger(__name__)
 
 # Compact JSON separators — eliminates whitespace tokens (~30% reduction on profile data)
 _COMPACT = (",", ":")
+
+
+def _score_user_prompt(job_description: str, profile_json: str) -> str:
+    """Build the scoring user prompt, prefixed with the anti-halo role-fit gate.
+
+    Shared by real-time ``score()`` and the Batch API path in ``batch_score()`` so
+    the two can't drift, and so both carry ROLE_FIT_GATE_PROMPT (G-1348 — openai
+    was the only real provider missing the guard).
+    """
+    return (
+        ROLE_FIT_GATE_PROMPT + "Score this job against the candidate profile. "
+        "Return a JSON object with: fit_score (0-10), reasoning "
+        "(detailed, >=100 chars), "
+        "estimated_salary (string), effort_flag (low/medium/high), "
+        "prep_level, prep_notes, "
+        "readiness_score (0-100), career_alignment (0-10), "
+        "score_breakdown (array of >=3 objects, each with: factor "
+        "(string), contribution (positive or negative float), "
+        "description (string)), "
+        "dimensional_scores (object with 6 floats on a 0-5 scale, NOT 0-10 "
+        "(0=no fit, 5=perfect): technical_fit, "
+        "seniority_alignment, compensation_fit, location_fit, "
+        "career_trajectory, company_fit), "
+        "ats_keywords (array of 10-15 objects, each with: keyword "
+        "(string), category (one of technical/soft_skill/tool/"
+        "certification/domain), matched (boolean)), "
+        "desire_score (0-10), desire_reasoning (string).\n\n"
+        f"Candidate Profile:\n{profile_json}\n\n"
+        f"Job Description:\n{job_description}"
+    )
+
 
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 OPENAI_BATCH_API_URL = "https://api.openai.com/v1/batches"
@@ -150,9 +180,7 @@ class OpenAIProvider(AIProvider):
         **kwargs: object,
     ) -> AIResponse:
         """Score a job against a profile via the OpenAI API."""
-        prompt = _scoring_user_prompt(
-            job_description, json.dumps(profile_data, separators=_COMPACT)
-        )
+        prompt = _score_user_prompt(job_description, json.dumps(profile_data, separators=_COMPACT))
         return await self.complete(prompt, feature=AIFeature.score)
 
     async def batch_score(
@@ -181,27 +209,7 @@ class OpenAIProvider(AIProvider):
         # Build JSONL content — one line per job
         lines: list[str] = []
         for job in jobs:
-            scoring_prompt = (
-                "Score this job against the candidate profile. "
-                "Return a JSON object with: fit_score (0-10), reasoning "
-                "(detailed, >=100 chars), "
-                "estimated_salary (string), effort_flag (low/medium/high), "
-                "prep_level, prep_notes, "
-                "readiness_score (0-100), career_alignment (0-10), "
-                "score_breakdown (array of >=3 objects, each with: factor "
-                "(string), contribution (positive or negative float), "
-                "description (string)), "
-                "dimensional_scores (object with 6 floats on a 0-5 scale, NOT 0-10 "
-                "(0=no fit, 5=perfect): technical_fit, "
-                "seniority_alignment, compensation_fit, location_fit, "
-                "career_trajectory, company_fit), "
-                "ats_keywords (array of 10-15 objects, each with: keyword "
-                "(string), category (one of technical/soft_skill/tool/"
-                "certification/domain), matched (boolean)), "
-                "desire_score (0-10), desire_reasoning (string).\n\n"
-                f"Candidate Profile:\n{profile_json}\n\n"
-                f"Job Description:\n{job['description']}"
-            )
+            scoring_prompt = _score_user_prompt(job["description"], profile_json)
 
             messages: list[dict[str, str]] = []
             if system_msg:

--- a/src/career_os/ai/openai_provider.py
+++ b/src/career_os/ai/openai_provider.py
@@ -33,27 +33,35 @@ def _score_user_prompt(job_description: str, profile_json: str) -> str:
     Shared by real-time ``score()`` and the Batch API path in ``batch_score()`` so
     the two can't drift, and so both carry ROLE_FIT_GATE_PROMPT (G-1348 — openai
     was the only real provider missing the guard).
+
+    The wording matches the canonical prompt the other providers send (see
+    ``openrouter_provider.score``). The previous batch-only literal omitted the
+    *definitions* of ``desire_score`` and ``ats_keywords.matched``, which matters
+    now that the gate tells the model to route prestige/"I'd love to work there"
+    into ``desire_score`` — a field that prompt never defined. Keeping the text
+    canonical keeps openai's scores calibrated with every other provider.
     """
     return (
         ROLE_FIT_GATE_PROMPT + "Score this job against the candidate profile. "
-        "Return a JSON object with: fit_score (0-10), reasoning "
-        "(detailed, >=100 chars), "
-        "estimated_salary (string), effort_flag (low/medium/high), "
-        "prep_level, prep_notes, "
+        "Return a JSON object with: fit_score (0-10), reasoning (detailed, >=100 chars), "
+        "estimated_salary (string), effort_flag (low/medium/high), prep_level, prep_notes, "
         "readiness_score (0-100), career_alignment (0-10), "
-        "score_breakdown (array of >=3 objects, each with: factor "
-        "(string), contribution (positive or negative float), "
-        "description (string)), "
+        "score_breakdown (array of >=3 objects, each with: factor (string), "
+        "contribution (positive or negative float), description (string)), "
         "dimensional_scores (object with 6 floats on a 0-5 scale, NOT 0-10 "
         "(0=no fit, 5=perfect): technical_fit, "
-        "seniority_alignment, compensation_fit, location_fit, "
-        "career_trajectory, company_fit), "
-        "ats_keywords (array of 10-15 objects, each with: keyword "
-        "(string), category (one of technical/soft_skill/tool/"
-        "certification/domain), matched (boolean)), "
-        "desire_score (0-10), desire_reasoning (string).\n\n"
-        f"Candidate Profile:\n{profile_json}\n\n"
-        f"Job Description:\n{job_description}"
+        "seniority_alignment, compensation_fit, location_fit, career_trajectory, "
+        "company_fit), "
+        "ats_keywords (array of 10-15 objects, each with: keyword (string), "
+        "category (one of technical/soft_skill/tool/certification/domain), "
+        "matched (boolean — true if the profile demonstrates this keyword)), "
+        "desire_score (0-10, how much the candidate would WANT this job — "
+        "considering company reputation, growth potential, culture signals, "
+        "role excitement, compensation attractiveness, work-life balance), "
+        "desire_reasoning (string explaining what makes this job desirable "
+        "or undesirable from the candidate's perspective).\n\n"
+        f"Job Description:\n{job_description}\n\n"
+        f"Profile:\n{profile_json}"
     )
 
 

--- a/tests/test_billing_safety.py
+++ b/tests/test_billing_safety.py
@@ -61,6 +61,34 @@ COST_TIER: dict[str, str] = {
     "anthropic": PREMIUM,
 }
 
+# Registry default models for CHEAP-tier providers, pinned (G-1348 review).
+# The CHEAP classification above is only true while these defaults hold — a cost
+# decision made by quietly editing one string is exactly the G-1371 failure mode,
+# so switching e.g. openai's default to `gpt-4o`/`o1` must fail CI, not the bill.
+CHEAP_DEFAULT_MODELS: dict[str, str] = {
+    "openai": "gpt-4o-mini",
+    "groq": "llama-3.3-70b-versatile",
+    "xai": "grok-3-mini",
+    "gemini": "gemini-2.0-flash",
+    "mistral": "mistral-small-latest",
+    "together": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "huggingface": "meta-llama/Llama-3.3-70B-Instruct",
+    "hf": "meta-llama/Llama-3.3-70B-Instruct",
+}
+
+_MODEL_ENV_VARS = [
+    "ANTHROPIC_MODEL",
+    "GEMINI_MODEL",
+    "GROQ_MODEL",
+    "HF_MODEL",
+    "MISTRAL_MODEL",
+    "OLLAMA_MODEL",
+    "OPENAI_MODEL",
+    "OPENROUTER_MODEL",
+    "TOGETHER_MODEL",
+    "XAI_MODEL",
+]
+
 WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
 # Scheduled workflows whose runs bill on the user's own API keys. nightly.yml
@@ -90,6 +118,31 @@ def test_every_registered_provider_is_cost_classified():
         f"they can silently join a fallback chain (G-1371)."
     )
     assert not stale, f"COST_TIER classifies removed provider(s) {sorted(stale)}"
+
+
+def test_cheap_tier_defaults_are_pinned(monkeypatch):
+    """Every CHEAP provider must be pinned to its cheap default model.
+
+    The CHEAP classification is a claim about the *default* model. Nothing else in
+    the suite pins those defaults, so swapping one for a pricier model would keep
+    all billing tests green while quietly multiplying cost (G-1348 review, WR-04).
+    """
+    classified_cheap = {name for name, tier in COST_TIER.items() if tier == CHEAP}
+    assert set(CHEAP_DEFAULT_MODELS) == classified_cheap, (
+        "CHEAP_DEFAULT_MODELS and the COST_TIER CHEAP set disagree — pin a default "
+        "model for every cheap provider so its cost claim is enforced."
+    )
+    # construct straight from the registry with keys stubbed and overrides cleared
+    monkeypatch.setattr(factory, "_resolve_api_key", lambda *a, **k: "test-key")
+    for var in _MODEL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for name, expected in sorted(CHEAP_DEFAULT_MODELS.items()):
+        provider = factory._PROVIDER_REGISTRY[name]()
+        assert provider._model == expected, (
+            f"{name}: registry default model changed to {provider._model!r} "
+            f"(pinned: {expected!r}). If this is intentional, re-verify the cost "
+            f"tier in COST_TIER before updating the pin."
+        )
 
 
 def test_premium_set_matches_classification_and_contains_anthropic():

--- a/tests/test_billing_safety.py
+++ b/tests/test_billing_safety.py
@@ -48,6 +48,9 @@ COST_TIER: dict[str, str] = {
     "demo": FREE,
     "ollama": FREE,
     "openrouter": ROUTING,
+    # gpt-4o-mini default is cheap; OPENAI_MODEL can point at a pricier model,
+    # but unlike openrouter the *default* is not premium, so no guard is needed.
+    "openai": CHEAP,
     "together": CHEAP,
     "groq": CHEAP,
     "xai": CHEAP,

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -20,17 +20,15 @@ import pytest
 from career_os.ai.base import AIProvider, ProviderQuotaError
 from career_os.ai.factory import _PROVIDER_REGISTRY, get_ai_provider
 
-try:
-    from career_os.ai.openai_provider import (
-        OPENAI_API_URL,
-        OpenAIProvider,
-    )
-except ImportError:
-    pytest.skip(
-        "openai_provider broken: _scoring_user_prompt removed from openrouter_provider",
-        allow_module_level=True,
-    )
-
+# NB: imported directly, NOT behind a try/except ImportError -> pytest.skip.
+# That skip (added when openai_provider imported a non-existent
+# `_scoring_user_prompt`) silently disabled this entire file, which is why CI
+# stayed green while the provider was unusable. A broken import must FAIL here.
+# See also tests/test_provider_contract.py (G-1348).
+from career_os.ai.openai_provider import (
+    OPENAI_API_URL,
+    OpenAIProvider,
+)
 from career_os.schemas.ai import AIFeature, AIResponse
 
 # Fake credentials used across all tests — not real.

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -399,3 +399,63 @@ class TestOpenAIScore:
         # System message should be present (score feature has system prompt)
         messages = captured_payload["messages"]
         assert messages[0]["role"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# Batch API tests (G-1348: this path was untested while the file was skipped)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIBatchScore:
+    """Test the Batch API JSONL assembly."""
+
+    @pytest.mark.asyncio
+    async def test_batch_score_builds_one_request_per_job_with_gate(self) -> None:
+        """Each job becomes one JSONL request carrying the anti-halo role-fit gate."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+        uploaded: dict[str, str] = {}
+
+        async def mock_post(url, headers=None, json=None, files=None, data=None, **kwargs):
+            if files is not None:  # 1) file upload
+                uploaded["jsonl"] = files["file"][1].read().decode()
+                return httpx.Response(
+                    200, json={"id": "file-abc"}, request=httpx.Request("POST", url)
+                )
+            return httpx.Response(  # 2) batch create
+                200, json={"id": "batch-xyz"}, request=httpx.Request("POST", url)
+            )
+
+        jobs = [
+            {"id": 1, "description": "Senior Backend Engineer at Acme"},
+            {"id": 2, "description": "Staff Platform Engineer at Globex"},
+        ]
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            batch_id = await provider.batch_score(jobs, {"name": "Jane"})
+
+        assert batch_id == "batch-xyz"
+        lines = [json.loads(x) for x in uploaded["jsonl"].splitlines()]
+        assert len(lines) == 2, "one JSONL request per job"
+        assert [x["custom_id"] for x in lines] == ["1", "2"]
+        for line, job in zip(lines, jobs, strict=True):
+            assert line["method"] == "POST"
+            assert line["url"] == "/v1/chat/completions"
+            assert line["body"]["model"] == "gpt-4o-mini"
+            user_msg = line["body"]["messages"][-1]["content"]
+            # the batch path must carry the same gate as real-time score()
+            assert "role-fit gate (anti-halo)" in user_msg
+            assert job["description"] in user_msg
+            assert user_msg.index("role-fit gate (anti-halo)") < user_msg.index(job["description"])
+
+    @pytest.mark.asyncio
+    async def test_batch_score_raises_quota_error_on_upload_402(self) -> None:
+        """A 402 on the file upload surfaces as ProviderQuotaError, not a raw HTTP error."""
+        provider = OpenAIProvider(api_key=_TEST_CREDENTIAL)
+
+        async def mock_post(url, **kwargs):
+            return httpx.Response(
+                402, json={"error": {"message": "no credits"}}, request=httpx.Request("POST", url)
+            )
+
+        with patch("httpx.AsyncClient.post", side_effect=mock_post):
+            with pytest.raises(ProviderQuotaError):
+                await provider.batch_score([{"id": 1, "description": "x"}], {"name": "Jane"})

--- a/tests/test_provider_contract.py
+++ b/tests/test_provider_contract.py
@@ -21,6 +21,7 @@ import httpx
 import pytest
 
 import career_os.ai as ai_pkg
+from career_os.ai import factory
 from career_os.ai.base import ROLE_FIT_GATE_PROMPT
 
 # ---------------------------------------------------------------------------
@@ -32,9 +33,16 @@ PROVIDER_MODULES = sorted(
 
 
 def test_provider_modules_discovered():
-    """Guard the guard: the module sweep must actually find the providers."""
-    assert len(PROVIDER_MODULES) >= 10, PROVIDER_MODULES
+    """Guard the guard: the sweep must cover every real provider, not a magic number.
+
+    Derived from REAL_PROVIDERS (itself pinned to the registry by
+    ``test_real_providers_covers_every_registered_provider``) so deleting or
+    renaming a provider module can't quietly shrink the sweep.
+    """
     assert "openai_provider" in PROVIDER_MODULES
+    expected_modules = {module for module, _cls, _kwargs in REAL_PROVIDERS.values()}
+    missing = expected_modules - set(PROVIDER_MODULES)
+    assert not missing, f"provider modules not found by the sweep: {sorted(missing)}"
 
 
 @pytest.mark.parametrize("module_name", PROVIDER_MODULES)
@@ -65,6 +73,32 @@ REAL_PROVIDERS = {
 # brittle, but this phrase is unique to it.
 _GATE_MARKER = "role-fit gate (anti-halo)"
 
+# Registry keys that are NOT real providers: the fake provider and its alias.
+_MOCK_KEYS = {"mock", "demo"}
+# Registry keys that are aliases of a provider already covered by REAL_PROVIDERS.
+_ALIAS_KEYS = {"hf"}  # -> huggingface
+
+# Distinctive job-description text, used to assert the gate comes BEFORE the JD.
+_JD_MARKER = "Senior Backend Engineer at Acme"
+
+
+def test_real_providers_covers_every_registered_provider():
+    """REAL_PROVIDERS must track the registry, or a new provider is silently exempt.
+
+    Mirrors the COST_TIER completeness check in test_billing_safety.py: registering
+    a 12th provider without adding it here would exempt it from the gate invariant
+    — exactly the failure this file exists to prevent (G-1348).
+    """
+    registered = set(factory._PROVIDER_REGISTRY)
+    covered = set(REAL_PROVIDERS) | _MOCK_KEYS | _ALIAS_KEYS
+    missing = registered - covered
+    assert not missing, (
+        f"provider(s) {sorted(missing)} are registered but absent from REAL_PROVIDERS "
+        f"— add them so the role-fit-gate invariant covers them (G-1348)."
+    )
+    stale = set(REAL_PROVIDERS) - registered
+    assert not stale, f"REAL_PROVIDERS lists unregistered provider(s) {sorted(stale)}"
+
 
 class _Captured(Exception):
     """Raised to short-circuit once the outgoing request has been captured."""
@@ -79,12 +113,12 @@ def capture_request(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """
     bodies: list[str] = []
 
-    async def fake_post(self, url, **kwargs):  # noqa: ANN001, ANN202
+    async def fake_post(self, url, **kwargs):
         payload = kwargs.get("json")
         bodies.append(json.dumps(payload) if payload is not None else str(kwargs))
         raise _Captured
 
-    async def fake_send(self, request, **kwargs):  # noqa: ANN001, ANN202
+    async def fake_send(self, request, **kwargs):
         bodies.append(request.content.decode("utf-8", errors="replace"))
         raise _Captured
 
@@ -103,7 +137,7 @@ async def test_every_real_provider_prepends_role_fit_gate(
     provider = cls(**kwargs)
 
     try:
-        await provider.score("Senior Backend Engineer at Acme", {"title": "PM"})
+        await provider.score(_JD_MARKER, {"title": "PM"})
     except _Captured:
         pass  # expected — we only need the outgoing request
     except Exception as exc:  # pragma: no cover - diagnostic aid
@@ -111,9 +145,17 @@ async def test_every_real_provider_prepends_role_fit_gate(
             pytest.fail(f"{provider_name}: no request captured before {exc!r}")
 
     assert capture_request, f"{provider_name} issued no HTTP request during score()"
-    assert _GATE_MARKER in capture_request[0], (
+    payload = capture_request[0]
+    assert _GATE_MARKER in payload, (
         f"{provider_name} does not send ROLE_FIT_GATE_PROMPT when scoring — every "
         f"real provider must prepend the anti-halo role-fit gate (G-1348)."
+    )
+    # ...and *prepend* it: the gate must precede the job description, not trail it
+    # (a gate after the JD is far weaker, and plain containment wouldn't notice).
+    assert _JD_MARKER in payload, f"{provider_name}: job description missing from payload"
+    assert payload.index(_GATE_MARKER) < payload.index(_JD_MARKER), (
+        f"{provider_name} sends the role-fit gate AFTER the job description — it must "
+        f"come first so the model reads the anti-halo instruction before the JD."
     )
 
 

--- a/tests/test_provider_contract.py
+++ b/tests/test_provider_contract.py
@@ -1,0 +1,122 @@
+"""Cross-provider contract tests (G-1348).
+
+Two invariants that must hold for EVERY real provider, so a single provider can't
+silently drift or die:
+
+1. Every ``*_provider`` module imports. `openai_provider` imported a
+   non-existent `_scoring_user_prompt` from `openrouter_provider`, so one of the
+   11 advertised providers raised ImportError and was unusable — with no test
+   catching it (G-1348).
+2. Every real provider prepends ROLE_FIT_GATE_PROMPT (the anti-halo role-fit
+   gate) to what it actually sends for scoring. openai was the only real provider
+   missing it. Asserted against the outgoing HTTP payload rather than an internal
+   helper, so it holds regardless of how each provider builds its request.
+"""
+
+import importlib
+import json
+import pkgutil
+
+import httpx
+import pytest
+
+import career_os.ai as ai_pkg
+from career_os.ai.base import ROLE_FIT_GATE_PROMPT
+
+# ---------------------------------------------------------------------------
+# 1 — every provider module must import
+# ---------------------------------------------------------------------------
+PROVIDER_MODULES = sorted(
+    m.name for m in pkgutil.iter_modules(ai_pkg.__path__) if m.name.endswith("_provider")
+)
+
+
+def test_provider_modules_discovered():
+    """Guard the guard: the module sweep must actually find the providers."""
+    assert len(PROVIDER_MODULES) >= 10, PROVIDER_MODULES
+    assert "openai_provider" in PROVIDER_MODULES
+
+
+@pytest.mark.parametrize("module_name", PROVIDER_MODULES)
+def test_provider_module_imports(module_name: str):
+    """Every provider module must import (G-1348: openai_provider did not)."""
+    importlib.import_module(f"career_os.ai.{module_name}")
+
+
+# ---------------------------------------------------------------------------
+# 2 — every real provider prepends the anti-halo role-fit gate when scoring
+# ---------------------------------------------------------------------------
+# name -> (module, class, kwargs). "mock"/"demo" are excluded: MockProvider
+# returns canned data and never calls an LLM, so the guard is meaningless there.
+REAL_PROVIDERS = {
+    "anthropic": ("anthropic_provider", "AnthropicProvider", {"api_key": "test-key"}),
+    "gemini": ("gemini_provider", "GeminiProvider", {"api_key": "test-key"}),
+    "groq": ("groq_provider", "GroqProvider", {"api_key": "test-key"}),
+    "huggingface": ("huggingface_provider", "HuggingFaceProvider", {"api_key": "test-key"}),
+    "mistral": ("mistral_provider", "MistralProvider", {"api_key": "test-key"}),
+    "ollama": ("ollama_provider", "OllamaProvider", {}),
+    "openai": ("openai_provider", "OpenAIProvider", {"api_key": "test-key"}),
+    "openrouter": ("openrouter_provider", "OpenRouterProvider", {"api_key": "test-key"}),
+    "together": ("together_provider", "TogetherProvider", {"api_key": "test-key"}),
+    "xai": ("xai_provider", "XAIProvider", {"api_key": "test-key"}),
+}
+
+# A distinctive slice of the gate — matching the whole multi-paragraph prompt is
+# brittle, but this phrase is unique to it.
+_GATE_MARKER = "role-fit gate (anti-halo)"
+
+
+class _Captured(Exception):
+    """Raised to short-circuit once the outgoing request has been captured."""
+
+
+@pytest.fixture
+def capture_request(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture the body of the first outgoing HTTP request, then short-circuit.
+
+    Patches both `post` (what most providers call) and `send` (the lower-level
+    path), so this works no matter how a provider issues its request.
+    """
+    bodies: list[str] = []
+
+    async def fake_post(self, url, **kwargs):  # noqa: ANN001, ANN202
+        payload = kwargs.get("json")
+        bodies.append(json.dumps(payload) if payload is not None else str(kwargs))
+        raise _Captured
+
+    async def fake_send(self, request, **kwargs):  # noqa: ANN001, ANN202
+        bodies.append(request.content.decode("utf-8", errors="replace"))
+        raise _Captured
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+    return bodies
+
+
+@pytest.mark.parametrize("provider_name", sorted(REAL_PROVIDERS))
+async def test_every_real_provider_prepends_role_fit_gate(
+    provider_name: str, capture_request: list[str]
+):
+    """The anti-halo gate must reach the API for every real provider (G-1348)."""
+    module_name, class_name, kwargs = REAL_PROVIDERS[provider_name]
+    cls = getattr(importlib.import_module(f"career_os.ai.{module_name}"), class_name)
+    provider = cls(**kwargs)
+
+    try:
+        await provider.score("Senior Backend Engineer at Acme", {"title": "PM"})
+    except _Captured:
+        pass  # expected — we only need the outgoing request
+    except Exception as exc:  # pragma: no cover - diagnostic aid
+        if not capture_request:
+            pytest.fail(f"{provider_name}: no request captured before {exc!r}")
+
+    assert capture_request, f"{provider_name} issued no HTTP request during score()"
+    assert _GATE_MARKER in capture_request[0], (
+        f"{provider_name} does not send ROLE_FIT_GATE_PROMPT when scoring — every "
+        f"real provider must prepend the anti-halo role-fit gate (G-1348)."
+    )
+
+
+def test_gate_marker_is_actually_in_the_prompt():
+    """Pin the marker to the real constant so the test can't silently pass."""
+    assert _GATE_MARKER in ROLE_FIT_GATE_PROMPT


### PR DESCRIPTION
## Why
`openai_provider.py` imported `_scoring_user_prompt` from `openrouter_provider` — a function that **does not exist** — so the module raised `ImportError` and one of the 11 advertised providers was completely unusable.

Fixing it surfaced two more layers of the same failure:

1. **`tests/test_openai_provider.py` silently disabled itself.** It wrapped the import in `try/except ImportError → pytest.skip(allow_module_level=True)` with the message *"openai_provider broken: _scoring_user_prompt removed from openrouter_provider"*. Someone knew it was broken and skipped the whole file — which is exactly why CI stayed green while the provider was dead.
2. **`openai` was never registered in `_PROVIDER_REGISTRY`.** With the skip removed, the file's own `TestOpenAIFactoryRegistration` tests fail: even with the import fixed, `AI_PROVIDER=openai` raised `UnsupportedProviderError`. The provider was unreachable by either path.

## Changes
- **`openai_provider.py`** — drop the bad import; add `_score_user_prompt()` used by **both** `score()` and `batch_score()`. They previously duplicated the prompt text and `batch_score` had no guard. The helper prepends `ROLE_FIT_GATE_PROMPT`; openai was the only real provider missing the anti-halo gate.
- **`factory.py`** — import and register `openai` (`OPENAI_API_KEY` / `OPENAI_MODEL`, default `gpt-4o-mini`), matching the other registry entries.
- **`test_openai_provider.py`** — import directly, no `ImportError`→skip. A broken import must fail loudly, not disable the file.
- **`test_provider_contract.py` (new)** — two cross-provider invariants:
  - every `*_provider` module imports (catches this class of bug for all 11);
  - every real provider sends `ROLE_FIT_GATE_PROMPT` when scoring — asserted against the **outgoing HTTP payload**, so it holds regardless of internals (anthropic, for one, doesn't route through `complete()`).
- **`test_billing_safety.py`** — classify the newly-registered `openai` as `CHEAP` (its `gpt-4o-mini` default is cheap; unlike openrouter the default isn't premium, so no G-1378-style guard is needed).

## Test plan
- [x] `openai_provider` imports; `get_ai_provider("openai")` returns a working provider
- [x] Guard test is **mutation-verified** — stripping `ROLE_FIT_GATE_PROMPT` from openai makes the `[openai]` case fail (not a vacuous assertion)
- [x] Full suite: **4057 passed / 25 skipped** (was 4012 with the openai file silently skipped)
- [x] ruff check + format clean

Closes G-1348.