### PR TITLE
feat(G-1351): occupation matcher — family/title→tier classifier + in-package taxonomy consumer (Phase B)

### DIFF
--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -134,6 +134,40 @@ from career_os.cli.scoring import scoring_app  # noqa: E402
 
 app.add_typer(scoring_app, name="scoring")
 
+# ESCO occupations taxonomy subcommand group (G-1351 Phase B)
+occupations_app = typer.Typer(
+    name="occupations",
+    help="ESCO occupations taxonomy.",
+    no_args_is_help=True,
+)
+app.add_typer(occupations_app, name="occupations")
+
+
+@occupations_app.command("load")
+def occupations_load(
+    force: bool = typer.Option(
+        False, "--force", help="Re-scan the bundled fixture even if already populated."
+    ),
+) -> None:
+    """Populate esco_occupations from the bundled ESCO fixture (idempotent)."""
+    from career_os.services.occupation_taxonomy import populate_occupations
+
+    db = _get_session()
+    try:
+        result = populate_occupations(db, force=force)
+        if result["already_loaded"]:
+            console.print(
+                f"[yellow]Already loaded:[/yellow] {result['skipped']} occupations present. "
+                "Use --force to re-scan."
+            )
+        else:
+            console.print(
+                f"[green]Loaded[/green] {result['inserted']} occupations "
+                f"({result['skipped']} skipped)."
+            )
+    finally:
+        db.close()
+
 
 # ---------------------------------------------------------------------------
 # Database helpers

--- a/src/career_os/cli/main.py
+++ b/src/career_os/cli/main.py
@@ -150,6 +150,8 @@ def occupations_load(
     ),
 ) -> None:
     """Populate esco_occupations from the bundled ESCO fixture (idempotent)."""
+    from sqlalchemy.exc import SQLAlchemyError
+
     from career_os.services.occupation_taxonomy import populate_occupations
 
     db = _get_session()
@@ -165,6 +167,16 @@ def occupations_load(
                 f"[green]Loaded[/green] {result['inserted']} occupations "
                 f"({result['skipped']} skipped)."
             )
+    except SQLAlchemyError:
+        # G-1351 review F8: a fresh DB without migrations applied (missing
+        # esco_occupations table) must get a friendly message, not a raw
+        # traceback.
+        console.print(
+            "[red]Error:[/red] esco_occupations table not found. Run "
+            "`alembic upgrade head` (or start the app once, which auto-migrates) "
+            "before loading occupations."
+        )
+        raise typer.Exit(code=1) from None
     finally:
         db.close()
 

--- a/src/career_os/services/occupation_matcher.py
+++ b/src/career_os/services/occupation_matcher.py
@@ -7,45 +7,63 @@ title, and the old skills cache had no occupation concepts at all).
 
 Two resolvers feed a pure classifier:
 
-* ``map_family_to_occupation`` — job_family -> ``ESCOOccupation``, via a
+* ``map_family_to_occupation`` — job_family -> occupation ref, via a
   hand-checked overlay (exact, fixture-verified ``concept_uri`` pins for the
-  families that have a genuine ESCO match) plus a conservative fuzzy fallback
-  on ``preferred_label`` only.
-* ``normalize_title_to_occupation`` — free-text JD title -> ``ESCOOccupation``,
+  families that have a genuine ESCO match, casefolded for case-insensitive
+  lookup — G-1351 review F5) plus a conservative fuzzy fallback on
+  ``preferred_label`` only.
+* ``normalize_title_to_occupation`` — free-text JD title -> occupation ref,
   via conservative rapidfuzz n-gram matching over ``preferred_label`` +
-  ``alt_labels``.
+  ``alt_labels`` (minus a curated denylist of ESCO alt-labels that collide
+  with the wrong occupation for our domain — G-1351 review F2).
 
 ``match_occupation`` combines both into a tier: ``same_occupation``,
 ``same_isco_group``, ``no_match``, or ``unknown``. CRITICAL: ``unknown``
 always carries ``score=None`` — never the fake ``0.0`` that made the old axis
 inert and indistinguishable from a real "no match" (``no_match``, which IS
-``0.0``).
+``0.0``). ``match_occupation`` is also self-sufficient (G-1351 review F1): if
+``esco_occupations`` is empty (a normal server deployment that never ran
+``kestrel occupations load``), it lazily populates the table from the bundled
+fixture once, rather than returning ``unknown`` forever.
 
 Naive fuzzy matching over short titles is unsafe (verified failures during
 planning: "Senior Backend Engineer" -> "nurse assistant" via a loose scorer
 picking up the substring "sen"; "data engineer" -> "data scientist" at 100
 via a loose WRatio-style scorer). This module uses ``token_sort_ratio`` with a
-high cutoff, case/punctuation-insensitive comparison, and a length-guard that
-rejects a short/generic candidate matching an unrelated label — an unresolved
-title returns ``None`` (-> ``unknown``) rather than a wrong tier.
+high cutoff, case/punctuation-insensitive comparison, a length-guard that
+rejects a short/generic candidate matching an unrelated label, a unigram
+restriction that disallows single-word candidates on titles longer than 2
+words (G-1351 review F4 — kills the "Representative" hijack of "Sales
+Development Representative" while still resolving "Chef"), and a curated
+alt-label denylist (G-1351 review F2) — an unresolved title returns ``None``
+(-> ``unknown``) rather than a wrong tier.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 from rapidfuzz import fuzz, process, utils
 from sqlalchemy.orm import Session
 
 from career_os.models.esco import ESCOOccupation
+from career_os.services.occupation_taxonomy import count_occupations, populate_occupations
 
 logger = logging.getLogger(__name__)
 
-# T-n1d-01 mitigation: cap n-gram generation to the first N words of a title,
-# mirroring cli/extract.py's MAX_WORDS_FOR_NGRAMS (T-02-02) DoS bound. Real JD
-# titles are a handful of words; this only guards against a maliciously huge
-# "title" string blowing up n-gram expansion.
-MAX_WORDS_FOR_NGRAMS = 500
+# T-n1d-01 mitigation (G-1351 review F3): cap n-gram generation to the first N
+# words of a title. Real JD titles are a handful of words (well under 10); the
+# original 500-word bound copied from cli/extract.py's full-text DoS guard was
+# the wrong analog for a short title field and still allowed a ~20s/call CPU
+# burn on a crafted 500-word "title". 20 is generous headroom over any real
+# title while making the n-gram expansion trivially cheap.
+MAX_WORDS_FOR_NGRAMS = 20
+
+# G-1351 review F3: cap raw title length before any processing (splitting,
+# n-gram generation, or the uncapped full-title candidate) so a crafted
+# multi-KB "title" string can never reach the matching loop at all.
+MAX_TITLE_CHARS = 300
 
 # Conservative, high-confidence cutoffs. A generic WRatio/low-cutoff match is
 # what caused the disaster cases above — token_sort_ratio + 90 is deliberately
@@ -62,6 +80,12 @@ MIN_CANDIDATE_LENGTH = 4
 # tying with — or beating — a longer, correct candidate's own exact match).
 LENGTH_GUARD_RATIO = 0.6
 
+# G-1351 review F4: a bare single-word n-gram candidate (e.g. "Representative"
+# out of "Sales Development Representative") is never trusted UNLESS the full
+# title itself is that short — this keeps a genuinely one/two-word title like
+# "Chef" working while killing the generic-unigram hijack of longer titles.
+MAX_WORDS_FOR_UNIGRAM_CANDIDATES = 2
+
 # ---------------------------------------------------------------------------
 # Hand-checked family -> occupation overlay
 # ---------------------------------------------------------------------------
@@ -76,6 +100,11 @@ LENGTH_GUARD_RATIO = 0.6
 FAMILY_OCCUPATION_OVERLAY: dict[str, str] = {
     # -- Technology --
     "SWE": "http://data.europa.eu/esco/occupation/f2b15a0e-e65a-438a-affb-29b9d50b77d1",  # software developer 2512.3
+    # Natural-language alias of "SWE" (G-1351 review F5): job_family is free
+    # text in some callers, not always the scoring-preset code, and the
+    # abbreviation alone doesn't fuzzy-match "software developer" closely
+    # enough (74.3 vs the 90 cutoff) to fall through correctly.
+    "Software Engineer": "http://data.europa.eu/esco/occupation/f2b15a0e-e65a-438a-affb-29b9d50b77d1",  # software developer 2512.3
     "TPM": "http://data.europa.eu/esco/occupation/8b6388a4-4904-471b-9331-d3b1211f5525",  # ICT project manager 1330.7
     "QA Engineer": "http://data.europa.eu/esco/occupation/106f79e4-6264-45f1-9e7a-297435cd684b",  # software tester 2519.6
     "QA Automation Engineer": "http://data.europa.eu/esco/occupation/106f79e4-6264-45f1-9e7a-297435cd684b",  # software tester
@@ -111,13 +140,191 @@ FAMILY_OCCUPATION_OVERLAY: dict[str, str] = {
     "Supply Chain Manager": "http://data.europa.eu/esco/occupation/aacc3918-b5d3-484b-9480-5d29aa550d74",  # supply chain manager 1324.3.4
 }
 
+# Casefolded overlay for case-insensitive lookup (G-1351 review F5): job_family
+# is free text in some callers ("swe", "Software Engineer" as well as the
+# canonical "SWE" scoring-preset code), matching scoring.py's
+# _weights_for_job_family case-insensitivity.
+_FAMILY_OCCUPATION_OVERLAY_CF: dict[str, str] = {
+    key.casefold(): uri for key, uri in FAMILY_OCCUPATION_OVERLAY.items()
+}
+
+# ---------------------------------------------------------------------------
+# Curated alt-label denylist (G-1351 review F2)
+# ---------------------------------------------------------------------------
+# Each entry below is an ESCO alt_label string (casefolded) that is a literal
+# or near-exact collision with an occupation OUTSIDE our domain, verified
+# against the real bundled fixture (see the F2 probe: every JOB_FAMILY_WEIGHTS
+# key run through normalize_title_to_occupation). Filtered out entirely when
+# building the title-matching surface — the affected occupations remain
+# reachable via their own preferred_label; only the misleading alt is removed.
+ALT_LABEL_DENYLIST: frozenset[str] = frozenset(
+    {
+        # Exact alt of "data scientist". "Data Engineer" has no genuine ESCO
+        # pin (see FAMILY_OCCUPATION_OVERLAY comment) — without this entry a
+        # "Data Engineer" JD title resolves same_occupation=1.0 against a
+        # "Data Scientist" family, which is wrong.
+        "data engineer",
+        # Exact alt of BOTH "foundry manager" and "maintenance and repair
+        # engineer" — neither is an engineering-management role in our
+        # domain's sense.
+        "engineering manager",
+        # Exact alt of 4 unrelated occupations (metal production manager,
+        # mine manager, financial markets back office administrator, business
+        # manager). Worse than a fuzzy near-miss: this is a literal string
+        # collision that non-deterministically shadowed the CORRECT
+        # "operations manager" occupation's own preferred_label in the
+        # candidate dict depending on DB row-insertion order — Operations
+        # Manager is one of our 30 pinned overlay families, so this was a
+        # same-title round-trip bug, not just a theoretical risk.
+        "operations manager",
+        # Plural alt of "bank account manager". ESCO has no generic "account
+        # manager" occupation, only specialized variants (bank/ICT/sales); the
+        # plural alt out-scores a plain "Account Manager" JD title via
+        # token_sort_ratio (96.8) even though bank-specific is the wrong
+        # domain for most of our job families.
+        "account managers",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _OccupationRef:
+    """Immutable snapshot of the ESCOOccupation columns match_occupation needs.
+
+    Deliberately NOT the live ORM row (G-1351 review F7): the match surface is
+    cached at module scope across calls (and, in tests, across independently
+    created/closed sessions with the same taxonomy row count). A cached live
+    ORM instance would go detached/expired once its originating session
+    closes; a plain-data snapshot has no such lifecycle to worry about.
+    """
+
+    concept_uri: str
+    preferred_label: str
+    isco_group: str | None
+
+
+@dataclass
+class _MatchSurface:
+    """Pre-built matching surface for a given taxonomy row count (G-1351 F7)."""
+
+    row_count: int
+    family_labels: list[str] = field(default_factory=list)
+    family_label_to_ref: dict[str, _OccupationRef] = field(default_factory=dict)
+    title_candidates: list[str] = field(default_factory=list)
+    title_candidate_to_ref: dict[str, _OccupationRef] = field(default_factory=dict)
+    pin_uri_to_ref: dict[str, _OccupationRef] = field(default_factory=dict)
+
+
+def _build_match_surface(db: Session, row_count: int) -> _MatchSurface:
+    """Query the full taxonomy once and build both matching surfaces.
+
+    Single full-table scan (previously duplicated per-call in both
+    ``map_family_to_occupation`` and ``normalize_title_to_occupation`` —
+    G-1351 review F7). Alt labels in ``ALT_LABEL_DENYLIST`` are dropped here
+    (G-1351 review F2) so every caller of the cached surface benefits.
+    """
+    rows = db.query(ESCOOccupation).all()
+
+    family_label_to_ref: dict[str, _OccupationRef] = {}
+    title_candidate_to_ref: dict[str, _OccupationRef] = {}
+    pin_uri_to_ref: dict[str, _OccupationRef] = {}
+
+    for row in rows:
+        ref = _OccupationRef(
+            concept_uri=row.concept_uri,
+            preferred_label=row.preferred_label,
+            isco_group=row.isco_group,
+        )
+        pin_uri_to_ref[row.concept_uri] = ref
+        # Family fuzzy fallback: preferred_label only (not alt_labels — those
+        # are for title matching, where more variants are acceptable; a
+        # family code should only fall back to a very close canonical
+        # occupation name).
+        family_label_to_ref.setdefault(row.preferred_label, ref)
+        # Title matching: preferred_label + non-denylisted alt_labels.
+        title_candidate_to_ref.setdefault(row.preferred_label, ref)
+        for alt in row.alt_labels_list:
+            if alt.casefold() in ALT_LABEL_DENYLIST:
+                continue
+            title_candidate_to_ref.setdefault(alt, ref)
+
+    return _MatchSurface(
+        row_count=row_count,
+        family_labels=list(family_label_to_ref.keys()),
+        family_label_to_ref=family_label_to_ref,
+        title_candidates=list(title_candidate_to_ref.keys()),
+        title_candidate_to_ref=title_candidate_to_ref,
+        pin_uri_to_ref=pin_uri_to_ref,
+    )
+
+
+# Module-level cache of the built matching surface (G-1351 review F7),
+# invalidated when the taxonomy row count changes. Identical data across DBs
+# at the same row count is acceptable — the taxonomy is a single-source
+# bundled fixture, so two DBs with the same count have the same content.
+_surface_cache: _MatchSurface | None = None
+
+
+def _get_match_surface(db: Session) -> _MatchSurface | None:
+    """Return the cached match surface, rebuilding only if the row count changed.
+
+    Returns ``None`` for an empty taxonomy (row_count == 0) so callers keep
+    their existing "empty taxonomy -> None" behavior without a wasted build.
+    """
+    global _surface_cache
+    row_count = count_occupations(db)
+    if row_count == 0:
+        return None
+    if _surface_cache is None or _surface_cache.row_count != row_count:
+        _surface_cache = _build_match_surface(db, row_count)
+    return _surface_cache
+
+
+# ---------------------------------------------------------------------------
+# F1: lazy self-populate so match_occupation is never inert by default
+# ---------------------------------------------------------------------------
+# Set once a lazy populate attempt has failed, so a persistently-broken
+# fixture/DB doesn't pay the populate-and-fail cost on every single
+# match_occupation call. Intentionally module-level, not per-call: this is a
+# "give up gracefully after one bad attempt" latch, not a per-request cache.
+_POPULATE_ATTEMPT_FAILED = False
+
+
+def _ensure_taxonomy_populated(db: Session) -> None:
+    """Lazily populate esco_occupations if empty (G-1351 review F1).
+
+    A normal server deployment never runs `kestrel occupations load`
+    manually; without this, match_occupation was permanently inert (always
+    `unknown`) in production — the exact 4a "honest but dead" failure shape
+    this ticket exists to fix. `populate_occupations` is idempotent and takes
+    ~1-2s for the bundled 2,942-row fixture, so calling it here is safe; the
+    row-count check makes every call after the first a cheap no-op.
+
+    Never raises: a populate failure degrades to `unknown` (via the empty
+    surface downstream) and flips `_POPULATE_ATTEMPT_FAILED` so it is not
+    retried on every subsequent call.
+    """
+    global _POPULATE_ATTEMPT_FAILED
+    if _POPULATE_ATTEMPT_FAILED:
+        return
+    try:
+        if count_occupations(db) == 0:
+            populate_occupations(db)
+    except Exception:
+        logger.warning(
+            "Lazy populate_occupations failed inside match_occupation; "
+            "degrading to unknown until a successful populate (manual "
+            "`kestrel occupations load` or a later process restart).",
+            exc_info=True,
+        )
+        _POPULATE_ATTEMPT_FAILED = True
+
 
 def _passes_length_guard(query: str, matched_label: str) -> bool:
     """Reject a match where query/label lengths are too disproportionate.
 
     Defense-in-depth alongside the high fuzzy cutoff: a bare abbreviation or a
-    generic single word should never be trusted to resolve a title, even if it
-    happens to clear the score threshold against some unrelated label.
+    generic single word should never be trusted to match anything on its own.
     """
     if len(query) < MIN_CANDIDATE_LENGTH:
         return False
@@ -128,33 +335,46 @@ def _passes_length_guard(query: str, matched_label: str) -> bool:
     return (shorter / longer) >= LENGTH_GUARD_RATIO
 
 
-def map_family_to_occupation(db: Session, family: str | None) -> ESCOOccupation | None:
-    """Resolve a job_family code/label to an ``ESCOOccupation``.
+def map_family_to_occupation(db: Session, family: str | None) -> _OccupationRef | None:
+    """Resolve a job_family code/label to an occupation ref.
 
-    Overlay lookup first (exact family key -> pinned concept_uri), then a
-    conservative fuzzy fallback on ``preferred_label`` only (high cutoff).
-    Unknown/garbage family strings, or families with no confident match,
-    return ``None`` rather than a wrong occupation.
+    Overlay lookup first (casefolded exact family key -> pinned concept_uri —
+    G-1351 review F5), then a conservative fuzzy fallback on ``preferred_label``
+    only (high cutoff). Unknown/garbage family strings, or families with no
+    confident match, return ``None`` rather than a wrong occupation. Does NOT
+    lazily populate an empty taxonomy itself (that's `match_occupation`'s job
+    — G-1351 review F1); called directly on an empty table this simply
+    returns ``None``.
     """
     if not family or not family.strip():
         return None
     family_key = family.strip()
 
-    pinned_uri = FAMILY_OCCUPATION_OVERLAY.get(family_key)
+    surface = _get_match_surface(db)
+    if surface is None:
+        return None
+
+    pinned_uri = _FAMILY_OCCUPATION_OVERLAY_CF.get(family_key.casefold())
     if pinned_uri:
-        return db.query(ESCOOccupation).filter(ESCOOccupation.concept_uri == pinned_uri).first()
+        ref = surface.pin_uri_to_ref.get(pinned_uri)
+        if ref is None:
+            # G-1351 review F9: a pin whose concept_uri isn't in the table
+            # would otherwise silently degrade to None — surface fixture/DB
+            # drift instead of hiding it.
+            logger.warning(
+                "FAMILY_OCCUPATION_OVERLAY pin %r for family %r not found in "
+                "esco_occupations — fixture/DB drift?",
+                pinned_uri,
+                family_key,
+            )
+        return ref
 
     # Conservative fuzzy fallback: preferred_label only (not alt_labels — those
     # are for title matching, where more variants are acceptable; a family
     # code should only fall back to a very close canonical occupation name).
-    rows = db.query(ESCOOccupation).all()
-    if not rows:
-        return None
-    label_to_row = {row.preferred_label: row for row in rows}
-    labels = list(label_to_row.keys())
     result = process.extractOne(
         family_key,
-        labels,
+        surface.family_labels,
         scorer=fuzz.token_sort_ratio,
         score_cutoff=FAMILY_FUZZY_THRESHOLD,
         processor=utils.default_process,
@@ -162,41 +382,44 @@ def map_family_to_occupation(db: Session, family: str | None) -> ESCOOccupation 
     if not result:
         return None
     matched_label = result[0]
-    return label_to_row.get(matched_label)
+    return surface.family_label_to_ref.get(matched_label)
 
 
-def normalize_title_to_occupation(db: Session, jd_title: str | None) -> ESCOOccupation | None:
-    """Resolve a free-text JD title to an ``ESCOOccupation``.
+def normalize_title_to_occupation(db: Session, jd_title: str | None) -> _OccupationRef | None:
+    """Resolve a free-text JD title to an occupation ref.
 
-    Generates n-grams of the title (capped at MAX_WORDS_FOR_NGRAMS — T-n1d-01)
-    and fuzzy-matches each against every occupation's preferred_label AND
-    alt_labels via token_sort_ratio with a case/punctuation-insensitive
-    processor and a high cutoff. A length-guard rejects a candidate/matched-
-    label pair that is too disproportionate in length. Candidates are tried
-    longest-first so a specific multi-word match (e.g. "nurse assistant")
-    wins over a shorter, more generic single-word tie (e.g. "assistant").
-    Empty/whitespace title or an empty taxonomy -> ``None``.
+    Truncates to ``MAX_TITLE_CHARS`` before any processing (G-1351 review F3),
+    then generates n-grams of the (truncated) title, capped at
+    ``MAX_WORDS_FOR_NGRAMS``, and fuzzy-matches each against every
+    occupation's preferred_label AND non-denylisted alt_labels (G-1351 review
+    F2) via token_sort_ratio with a case/punctuation-insensitive processor and
+    a high cutoff. Single-word candidates are only allowed when the full
+    title itself is ``MAX_WORDS_FOR_UNIGRAM_CANDIDATES`` words or fewer
+    (G-1351 review F4). A length-guard rejects a candidate/matched-label pair
+    that is too disproportionate in length. Candidates are tried longest-first
+    so a specific multi-word match (e.g. "nurse assistant") wins over a
+    shorter, more generic single-word tie (e.g. "assistant"). Empty/whitespace
+    title or an empty taxonomy -> ``None``.
     """
     if not jd_title or not jd_title.strip():
         return None
 
-    rows = db.query(ESCOOccupation).all()
-    if not rows:
+    title = jd_title.strip()[:MAX_TITLE_CHARS]
+
+    surface = _get_match_surface(db)
+    if surface is None:
         return None
 
-    candidate_to_row: dict[str, ESCOOccupation] = {}
-    for row in rows:
-        candidate_to_row.setdefault(row.preferred_label, row)
-        for alt in row.alt_labels_list:
-            candidate_to_row.setdefault(alt, row)
-    labels = list(candidate_to_row.keys())
-    if not labels:
+    words = title.split()[:MAX_WORDS_FOR_NGRAMS]
+    if not words:
         return None
+    allow_unigrams = len(words) <= MAX_WORDS_FOR_UNIGRAM_CANDIDATES
 
-    words = jd_title.split()[:MAX_WORDS_FOR_NGRAMS]
-    candidates: set[str] = {jd_title.strip()}
+    candidates: set[str] = {title}
     max_window = min(len(words), 5)
     for n in range(1, max_window + 1):
+        if n == 1 and not allow_unigrams:
+            continue
         for i in range(len(words) - n + 1):
             candidates.add(" ".join(words[i : i + n]))
 
@@ -204,14 +427,14 @@ def normalize_title_to_occupation(db: Session, jd_title: str | None) -> ESCOOccu
     # rather than letting a later, shorter generic word overwrite it.
     ordered_candidates = sorted(candidates, key=lambda c: (-len(c), c))
 
-    best_row: ESCOOccupation | None = None
+    best_ref: _OccupationRef | None = None
     best_score = -1.0
     for candidate in ordered_candidates:
         if len(candidate) < MIN_CANDIDATE_LENGTH:
             continue
         result = process.extractOne(
             candidate,
-            labels,
+            surface.title_candidates,
             scorer=fuzz.token_sort_ratio,
             score_cutoff=TITLE_MATCH_THRESHOLD,
             processor=utils.default_process,
@@ -223,13 +446,13 @@ def normalize_title_to_occupation(db: Session, jd_title: str | None) -> ESCOOccu
             continue
         if score > best_score:
             best_score = score
-            best_row = candidate_to_row.get(matched_label)
+            best_ref = surface.title_candidate_to_ref.get(matched_label)
 
-    return best_row
+    return best_ref
 
 
 def _classify(
-    family_occ: ESCOOccupation | None, title_occ: ESCOOccupation | None
+    family_occ: _OccupationRef | None, title_occ: _OccupationRef | None
 ) -> dict[str, str | float | None]:
     """Pure classifier: two resolved occupations (or None) -> a match tier.
 
@@ -255,11 +478,22 @@ def match_occupation(db: Session, candidate_family: str | None, jd_title: str | 
 
     Returns a dict with ``match`` (same_occupation | same_isco_group |
     no_match | unknown), ``score`` (1.0 | 0.5 | 0.0 | None), and the resolved
-    family/title URIs + labels for explainability. Defensive: any unexpected
-    failure degrades to the ``unknown`` result (never raises), mirroring
-    ``esco_features.py``'s swallow-and-rollback pattern.
+    family/title URIs + labels for explainability. Self-sufficient (G-1351
+    review F1): lazily populates ``esco_occupations`` from the bundled
+    fixture on first use if the table is empty, so a normal server deployment
+    that never runs `kestrel occupations load` still gets a real signal.
+
+    Defensive: any unexpected failure degrades to the ``unknown`` result
+    (never raises). CRITICAL (G-1351 review F6): unlike `esco_features.py`'s
+    swallow-and-rollback pattern, this function NEVER calls `db.rollback()` on
+    failure. It borrows the caller's session, and in the Phase C cascade will
+    run mid `score_job` with the caller's own uncommitted rows already added
+    to that session — rolling back here would silently discard those pending
+    writes. The swallow path only logs and returns `unknown`; it never
+    mutates transaction state.
     """
     try:
+        _ensure_taxonomy_populated(db)
         family_occ = map_family_to_occupation(db, candidate_family)
         title_occ = normalize_title_to_occupation(db, jd_title)
         result = _classify(family_occ, title_occ)
@@ -270,15 +504,12 @@ def match_occupation(db: Session, candidate_family: str | None, jd_title: str | 
         return result
     except Exception:
         logger.warning(
-            "match_occupation failed for family=%r title=%r (swallowed)",
+            "match_occupation failed for family=%r title=%r (swallowed, no "
+            "rollback — see docstring, G-1351 review F6)",
             candidate_family,
             jd_title,
             exc_info=True,
         )
-        try:
-            db.rollback()
-        except Exception:
-            logger.debug("match_occupation rollback also failed", exc_info=True)
         return {
             "match": "unknown",
             "score": None,

--- a/src/career_os/services/occupation_matcher.py
+++ b/src/career_os/services/occupation_matcher.py
@@ -1,0 +1,289 @@
+"""Occupation matcher: job_family <-> occupation, JD-title normalizer (G-1351 Phase B).
+
+The crux of Phase B: give the scorer a real title-vs-occupation signal instead
+of the 4a "inert axis" (see ``esco_features.py``'s module docstring for the
+history — the caller only has a job-family *code* like "TPM"/"SWE", not a
+title, and the old skills cache had no occupation concepts at all).
+
+Two resolvers feed a pure classifier:
+
+* ``map_family_to_occupation`` — job_family -> ``ESCOOccupation``, via a
+  hand-checked overlay (exact, fixture-verified ``concept_uri`` pins for the
+  families that have a genuine ESCO match) plus a conservative fuzzy fallback
+  on ``preferred_label`` only.
+* ``normalize_title_to_occupation`` — free-text JD title -> ``ESCOOccupation``,
+  via conservative rapidfuzz n-gram matching over ``preferred_label`` +
+  ``alt_labels``.
+
+``match_occupation`` combines both into a tier: ``same_occupation``,
+``same_isco_group``, ``no_match``, or ``unknown``. CRITICAL: ``unknown``
+always carries ``score=None`` — never the fake ``0.0`` that made the old axis
+inert and indistinguishable from a real "no match" (``no_match``, which IS
+``0.0``).
+
+Naive fuzzy matching over short titles is unsafe (verified failures during
+planning: "Senior Backend Engineer" -> "nurse assistant" via a loose scorer
+picking up the substring "sen"; "data engineer" -> "data scientist" at 100
+via a loose WRatio-style scorer). This module uses ``token_sort_ratio`` with a
+high cutoff, case/punctuation-insensitive comparison, and a length-guard that
+rejects a short/generic candidate matching an unrelated label — an unresolved
+title returns ``None`` (-> ``unknown``) rather than a wrong tier.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rapidfuzz import fuzz, process, utils
+from sqlalchemy.orm import Session
+
+from career_os.models.esco import ESCOOccupation
+
+logger = logging.getLogger(__name__)
+
+# T-n1d-01 mitigation: cap n-gram generation to the first N words of a title,
+# mirroring cli/extract.py's MAX_WORDS_FOR_NGRAMS (T-02-02) DoS bound. Real JD
+# titles are a handful of words; this only guards against a maliciously huge
+# "title" string blowing up n-gram expansion.
+MAX_WORDS_FOR_NGRAMS = 500
+
+# Conservative, high-confidence cutoffs. A generic WRatio/low-cutoff match is
+# what caused the disaster cases above — token_sort_ratio + 90 is deliberately
+# strict so an unresolved title/family returns None (unknown) rather than a
+# wrong tier.
+TITLE_MATCH_THRESHOLD = 90.0
+FAMILY_FUZZY_THRESHOLD = 90.0
+
+# Length-guard (T-n1d-02): a candidate shorter than this is a bare abbreviation
+# ("sen", "ui") and is never trusted to match anything on its own.
+MIN_CANDIDATE_LENGTH = 4
+# ...and even at/above that length, a match is only trusted when the query and
+# matched-label lengths are proportionate (kills a short/generic candidate
+# tying with — or beating — a longer, correct candidate's own exact match).
+LENGTH_GUARD_RATIO = 0.6
+
+# ---------------------------------------------------------------------------
+# Hand-checked family -> occupation overlay
+# ---------------------------------------------------------------------------
+# Each concept_uri below was grepped against the bundled fixture
+# (career_os.fixtures/esco_occupations_en.json.gz) and confirmed to exist with
+# the stated preferred_label before being pinned here. Families with no
+# genuinely-correct ESCO occupation (e.g. Backend/Frontend/DevOps/SRE/Platform/
+# ML/Data Engineer — verified during planning to have no exact preferred_label
+# or alt_label match) are deliberately left OUT: they fall through to the
+# conservative fuzzy fallback below, which will likely resolve to `unknown`.
+# That is the correct, honest behavior — never invent a wrong pin.
+FAMILY_OCCUPATION_OVERLAY: dict[str, str] = {
+    # -- Technology --
+    "SWE": "http://data.europa.eu/esco/occupation/f2b15a0e-e65a-438a-affb-29b9d50b77d1",  # software developer 2512.3
+    "TPM": "http://data.europa.eu/esco/occupation/8b6388a4-4904-471b-9331-d3b1211f5525",  # ICT project manager 1330.7
+    "QA Engineer": "http://data.europa.eu/esco/occupation/106f79e4-6264-45f1-9e7a-297435cd684b",  # software tester 2519.6
+    "QA Automation Engineer": "http://data.europa.eu/esco/occupation/106f79e4-6264-45f1-9e7a-297435cd684b",  # software tester
+    "SDET": "http://data.europa.eu/esco/occupation/106f79e4-6264-45f1-9e7a-297435cd684b",  # software tester
+    "Data Scientist": "http://data.europa.eu/esco/occupation/258e46f9-0075-4a2e-adae-1ff0477e0f30",  # data scientist 2511.3
+    "Data Analyst": "http://data.europa.eu/esco/occupation/d3edb8f8-3a06-47a0-8fb9-9b212c006aa2",  # data analyst 2511.2
+    "Database Administrator": "http://data.europa.eu/esco/occupation/8c57af09-719c-42b3-be40-6ed4946236cc",  # database administrator 2521.1
+    "Network Engineer": "http://data.europa.eu/esco/occupation/cf2b03cd-feb7-4f47-90f6-ff1ed6016d3d",  # ICT network engineer 2523.3
+    "Systems Administrator": "http://data.europa.eu/esco/occupation/9e2e6e1e-363b-4e1b-a673-7bc0f7343300",  # ICT system administrator 2522.1
+    "Product Manager": "http://data.europa.eu/esco/occupation/9f508305-80ce-4111-8722-f2c9b4a44890",  # product manager 1223.1
+    "Business Analyst": "http://data.europa.eu/esco/occupation/60082a99-d8ef-4e84-9290-78902681b6ed",  # business analyst 2421.1
+    "Sales Engineer": "http://data.europa.eu/esco/occupation/8529edc5-96ad-4cde-b34a-f86ad3753e4d",  # sales engineer 2433.4
+    # -- Design --
+    "Graphic Designer": "http://data.europa.eu/esco/occupation/69bcbb0a-8d80-4ecd-b0a4-9adea2a40de2",  # graphic designer 2166.10
+    "Creative Director": "http://data.europa.eu/esco/occupation/d2db926b-8b14-4686-9c98-fb0dc3a38cbb",  # creative director 2431.7
+    "Instructional Designer": "http://data.europa.eu/esco/occupation/a9c30651-ccbc-4a80-900c-7880615cdf6e",  # instructional designer 2359.8
+    "Architect": "http://data.europa.eu/esco/occupation/8c3f536e-ba66-4321-ba40-363dc39f129b",  # architect 2161.1
+    # -- Data / analytics --
+    "Statistician": "http://data.europa.eu/esco/occupation/ac8b3cd1-a127-4e6a-8208-5cfcf7111955",  # statistician 2120.6
+    "Market Research Analyst": "http://data.europa.eu/esco/occupation/66fb9704-0d56-4673-8e69-7823816b73e1",  # market research analyst 2431.11
+    # -- Finance --
+    "Financial Analyst": "http://data.europa.eu/esco/occupation/8d586ee9-0ab1-4155-a3b0-2ca786c8e48c",  # financial analyst 2413.1
+    "Investment Analyst": "http://data.europa.eu/esco/occupation/b7f47c25-bdf3-42fa-a68e-ad32754b2dba",  # investment analyst 2413.1.3
+    "Credit Analyst": "http://data.europa.eu/esco/occupation/075e4d25-74b3-46fb-9b6e-6b53cdb196e7",  # credit analyst 3312.2.1
+    "Bookkeeper": "http://data.europa.eu/esco/occupation/c3aae59e-1441-4b3e-bdd1-6da50dc7cf42",  # bookkeeper 3313.2
+    "Insurance Underwriter": "http://data.europa.eu/esco/occupation/e937449a-d9e0-4ab7-9ea5-4d3ac673be6d",  # insurance underwriter 3321.3
+    "Loan Officer": "http://data.europa.eu/esco/occupation/8e185c49-704e-49c0-8584-a7e0b618f628",  # loan officer 3312.5
+    # -- Legal / marketing / ops --
+    "Corporate Lawyer": "http://data.europa.eu/esco/occupation/fdfce14e-992d-4ff4-9f9d-7a353c75654e",  # corporate lawyer 2611.1.1
+    "Marketing Manager": "http://data.europa.eu/esco/occupation/6fcf4638-e7c7-4978-9302-9a7b63a3d57c",  # marketing manager 1221.3.2
+    "Brand Manager": "http://data.europa.eu/esco/occupation/de80bbf0-447d-4a6a-845a-fdba4e0dc30c",  # brand manager 2431.4
+    "Operations Manager": "http://data.europa.eu/esco/occupation/c6bd511a-d966-4df9-a48e-4f800354f268",  # operations manager 1321.1.3
+    "Supply Chain Manager": "http://data.europa.eu/esco/occupation/aacc3918-b5d3-484b-9480-5d29aa550d74",  # supply chain manager 1324.3.4
+}
+
+
+def _passes_length_guard(query: str, matched_label: str) -> bool:
+    """Reject a match where query/label lengths are too disproportionate.
+
+    Defense-in-depth alongside the high fuzzy cutoff: a bare abbreviation or a
+    generic single word should never be trusted to resolve a title, even if it
+    happens to clear the score threshold against some unrelated label.
+    """
+    if len(query) < MIN_CANDIDATE_LENGTH:
+        return False
+    shorter = min(len(query), len(matched_label))
+    longer = max(len(query), len(matched_label))
+    if longer == 0:
+        return False
+    return (shorter / longer) >= LENGTH_GUARD_RATIO
+
+
+def map_family_to_occupation(db: Session, family: str | None) -> ESCOOccupation | None:
+    """Resolve a job_family code/label to an ``ESCOOccupation``.
+
+    Overlay lookup first (exact family key -> pinned concept_uri), then a
+    conservative fuzzy fallback on ``preferred_label`` only (high cutoff).
+    Unknown/garbage family strings, or families with no confident match,
+    return ``None`` rather than a wrong occupation.
+    """
+    if not family or not family.strip():
+        return None
+    family_key = family.strip()
+
+    pinned_uri = FAMILY_OCCUPATION_OVERLAY.get(family_key)
+    if pinned_uri:
+        return db.query(ESCOOccupation).filter(ESCOOccupation.concept_uri == pinned_uri).first()
+
+    # Conservative fuzzy fallback: preferred_label only (not alt_labels — those
+    # are for title matching, where more variants are acceptable; a family
+    # code should only fall back to a very close canonical occupation name).
+    rows = db.query(ESCOOccupation).all()
+    if not rows:
+        return None
+    label_to_row = {row.preferred_label: row for row in rows}
+    labels = list(label_to_row.keys())
+    result = process.extractOne(
+        family_key,
+        labels,
+        scorer=fuzz.token_sort_ratio,
+        score_cutoff=FAMILY_FUZZY_THRESHOLD,
+        processor=utils.default_process,
+    )
+    if not result:
+        return None
+    matched_label = result[0]
+    return label_to_row.get(matched_label)
+
+
+def normalize_title_to_occupation(db: Session, jd_title: str | None) -> ESCOOccupation | None:
+    """Resolve a free-text JD title to an ``ESCOOccupation``.
+
+    Generates n-grams of the title (capped at MAX_WORDS_FOR_NGRAMS — T-n1d-01)
+    and fuzzy-matches each against every occupation's preferred_label AND
+    alt_labels via token_sort_ratio with a case/punctuation-insensitive
+    processor and a high cutoff. A length-guard rejects a candidate/matched-
+    label pair that is too disproportionate in length. Candidates are tried
+    longest-first so a specific multi-word match (e.g. "nurse assistant")
+    wins over a shorter, more generic single-word tie (e.g. "assistant").
+    Empty/whitespace title or an empty taxonomy -> ``None``.
+    """
+    if not jd_title or not jd_title.strip():
+        return None
+
+    rows = db.query(ESCOOccupation).all()
+    if not rows:
+        return None
+
+    candidate_to_row: dict[str, ESCOOccupation] = {}
+    for row in rows:
+        candidate_to_row.setdefault(row.preferred_label, row)
+        for alt in row.alt_labels_list:
+            candidate_to_row.setdefault(alt, row)
+    labels = list(candidate_to_row.keys())
+    if not labels:
+        return None
+
+    words = jd_title.split()[:MAX_WORDS_FOR_NGRAMS]
+    candidates: set[str] = {jd_title.strip()}
+    max_window = min(len(words), 5)
+    for n in range(1, max_window + 1):
+        for i in range(len(words) - n + 1):
+            candidates.add(" ".join(words[i : i + n]))
+
+    # Longest-first: on an equal-score tie, keep the more specific candidate
+    # rather than letting a later, shorter generic word overwrite it.
+    ordered_candidates = sorted(candidates, key=lambda c: (-len(c), c))
+
+    best_row: ESCOOccupation | None = None
+    best_score = -1.0
+    for candidate in ordered_candidates:
+        if len(candidate) < MIN_CANDIDATE_LENGTH:
+            continue
+        result = process.extractOne(
+            candidate,
+            labels,
+            scorer=fuzz.token_sort_ratio,
+            score_cutoff=TITLE_MATCH_THRESHOLD,
+            processor=utils.default_process,
+        )
+        if not result:
+            continue
+        matched_label, score, _ = result
+        if not _passes_length_guard(candidate, matched_label):
+            continue
+        if score > best_score:
+            best_score = score
+            best_row = candidate_to_row.get(matched_label)
+
+    return best_row
+
+
+def _classify(
+    family_occ: ESCOOccupation | None, title_occ: ESCOOccupation | None
+) -> dict[str, str | float | None]:
+    """Pure classifier: two resolved occupations (or None) -> a match tier.
+
+    CRITICAL: unresolved input (either side is None) is ``unknown`` with
+    ``score=None`` — never the fake ``0.0`` of the old inert axis. ``no_match``
+    is the only tier that carries a real ``0.0``.
+    """
+    if family_occ is None or title_occ is None:
+        return {"match": "unknown", "score": None}
+    if family_occ.concept_uri == title_occ.concept_uri:
+        return {"match": "same_occupation", "score": 1.0}
+    if (
+        family_occ.isco_group
+        and title_occ.isco_group
+        and family_occ.isco_group == title_occ.isco_group
+    ):
+        return {"match": "same_isco_group", "score": 0.5}
+    return {"match": "no_match", "score": 0.0}
+
+
+def match_occupation(db: Session, candidate_family: str | None, jd_title: str | None) -> dict:
+    """Pure feature: job_family + JD title -> occupation-match tier + score.
+
+    Returns a dict with ``match`` (same_occupation | same_isco_group |
+    no_match | unknown), ``score`` (1.0 | 0.5 | 0.0 | None), and the resolved
+    family/title URIs + labels for explainability. Defensive: any unexpected
+    failure degrades to the ``unknown`` result (never raises), mirroring
+    ``esco_features.py``'s swallow-and-rollback pattern.
+    """
+    try:
+        family_occ = map_family_to_occupation(db, candidate_family)
+        title_occ = normalize_title_to_occupation(db, jd_title)
+        result = _classify(family_occ, title_occ)
+        result["family_uri"] = family_occ.concept_uri if family_occ else None
+        result["family_label"] = family_occ.preferred_label if family_occ else None
+        result["title_uri"] = title_occ.concept_uri if title_occ else None
+        result["title_label"] = title_occ.preferred_label if title_occ else None
+        return result
+    except Exception:
+        logger.warning(
+            "match_occupation failed for family=%r title=%r (swallowed)",
+            candidate_family,
+            jd_title,
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            logger.debug("match_occupation rollback also failed", exc_info=True)
+        return {
+            "match": "unknown",
+            "score": None,
+            "family_uri": None,
+            "family_label": None,
+            "title_uri": None,
+            "title_label": None,
+        }

--- a/src/career_os/services/occupation_matcher.py
+++ b/src/career_os/services/occupation_matcher.py
@@ -308,8 +308,18 @@ def _ensure_taxonomy_populated(db: Session) -> None:
     if _POPULATE_ATTEMPT_FAILED:
         return
     try:
-        if count_occupations(db) == 0:
-            populate_occupations(db)
+        # Count AND populate on a SEPARATE session bound to the caller's
+        # engine/connection: populate_occupations commits, and committing the
+        # caller's borrowed session would persist the caller's own pending
+        # score_job writes mid-transaction (the commit-flavored twin of the
+        # F6 rollback hazard). Touching the caller's session here at all
+        # would also autoflush its pending writes and take a write lock,
+        # blocking the populate connection. On a connection-bound test
+        # session this degrades gracefully to a savepoint (SQLAlchemy
+        # conditional_savepoint join mode).
+        with Session(bind=db.get_bind()) as populate_session:
+            if count_occupations(populate_session) == 0:
+                populate_occupations(populate_session)
     except Exception:
         logger.warning(
             "Lazy populate_occupations failed inside match_occupation; "
@@ -490,7 +500,9 @@ def match_occupation(db: Session, candidate_family: str | None, jd_title: str | 
     run mid `score_job` with the caller's own uncommitted rows already added
     to that session — rolling back here would silently discard those pending
     writes. The swallow path only logs and returns `unknown`; it never
-    mutates transaction state.
+    mutates transaction state. The F1 lazy populate likewise runs on its OWN
+    session bound to the caller's engine — its commit can never persist the
+    caller's pending writes.
     """
     try:
         _ensure_taxonomy_populated(db)

--- a/src/career_os/services/occupation_taxonomy.py
+++ b/src/career_os/services/occupation_taxonomy.py
@@ -1,0 +1,109 @@
+"""In-package ESCO occupations fixture consumer (G-1351 Phase B).
+
+Loads the bundled ESCO occupations pillar fixture
+(``career_os.fixtures/esco_occupations_en.json.gz``) via ``importlib.resources``
+so that a pip/wheel install — which has no ``scripts/`` directory — can still
+populate the ``esco_occupations`` table. Fixes the 4a "inert axis" failure mode:
+without an in-package consumer, the occupation matcher (Phase B's crux,
+``occupation_matcher.py``) would have no taxonomy to match against on a wheel
+install, since ``scripts/load_esco_occupations.py`` is not shipped in the wheel.
+
+Mirrors ``scripts/load_esco_occupations.py``'s parse/insert shape (NOT imported
+from here — that module lives in ``scripts/``, which is absent in wheels) and
+``career_os.migration.demo_seed``'s ``importlib.resources`` fixture-load
+precedent.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from importlib.resources import files
+
+from sqlalchemy.orm import Session
+
+from career_os.models.esco import ESCOOccupation
+
+logger = logging.getLogger(__name__)
+
+FIXTURE_PACKAGE = "career_os.fixtures"
+FIXTURE_NAME = "esco_occupations_en.json.gz"
+
+
+def load_bundled_occupations() -> list[dict]:
+    """Load the bundled ESCO occupations fixture via ``importlib.resources``.
+
+    Works under an installed wheel (no filesystem path relative to ``scripts/``
+    required) as well as an editable install. Returns a list of row dicts with
+    keys: ``concept_uri``, ``preferred_label``, ``alt_labels``, ``description``,
+    ``occupation_code``, ``isco_group`` — matching the ``ESCOOccupation`` columns.
+    """
+    fixture_path = files(FIXTURE_PACKAGE).joinpath(FIXTURE_NAME)
+    with fixture_path.open("rb") as fh:
+        raw = gzip.decompress(fh.read())
+    payload = json.loads(raw.decode("utf-8"))
+    rows = payload["occupations"] if isinstance(payload, dict) else payload
+    logger.info("Loaded %d occupations from bundled fixture %s", len(rows), FIXTURE_NAME)
+    return rows
+
+
+def count_occupations(db: Session) -> int:
+    """Return the current row count of ``esco_occupations``."""
+    return db.query(ESCOOccupation).count()
+
+
+def populate_occupations(db: Session, *, force: bool = False) -> dict:
+    """Populate ``esco_occupations`` from the bundled fixture. Idempotent.
+
+    * Empty table: inserts every valid fixture row (dedup on ``concept_uri``;
+      rows with a blank ``concept_uri`` or ``preferred_label`` are skipped),
+      commits once, and returns
+      ``{"inserted": N, "skipped": M, "already_loaded": False}``.
+    * Populated table, ``force=False``: does nothing (no fixture re-read) and
+      returns ``{"inserted": 0, "skipped": <existing count>, "already_loaded": True}``.
+    * Populated table, ``force=True``: re-scans the fixture and inserts only
+      genuinely-missing rows (dedup against existing ``concept_uri`` values) —
+      never duplicates existing rows.
+
+    Does NOT create tables — the Alembic migration (and the test
+    ``create_all``) owns that; this function only queries and inserts.
+    """
+    existing_count = count_occupations(db)
+    if existing_count > 0 and not force:
+        return {"inserted": 0, "skipped": existing_count, "already_loaded": True}
+
+    rows = load_bundled_occupations()
+
+    # Single pre-loaded set of existing URIs avoids N per-row queries.
+    existing_uris = {uri for (uri,) in db.query(ESCOOccupation.concept_uri).all()}
+
+    inserted = 0
+    skipped = 0
+    seen_in_batch: set[str] = set()
+
+    for row in rows:
+        uri = (row.get("concept_uri") or "").strip()
+        label = (row.get("preferred_label") or "").strip()
+        if not uri or not label:
+            skipped += 1
+            continue
+        if uri in existing_uris or uri in seen_in_batch:
+            skipped += 1
+            continue
+        seen_in_batch.add(uri)
+        db.add(
+            ESCOOccupation(
+                concept_uri=uri,
+                preferred_label=label,
+                alt_labels=row.get("alt_labels") or None,
+                description=row.get("description") or None,
+                occupation_code=row.get("occupation_code") or None,
+                isco_group=row.get("isco_group") or None,
+            )
+        )
+        inserted += 1
+
+    db.commit()
+    logger.info("populate_occupations: inserted=%d skipped=%d (force=%s)", inserted, skipped, force)
+    return {"inserted": inserted, "skipped": skipped, "already_loaded": False}

--- a/tests/test_occupation_matcher.py
+++ b/tests/test_occupation_matcher.py
@@ -1,0 +1,199 @@
+"""Tests for the occupation matcher (G-1351 Phase B, the crux).
+
+Uses REAL family codes (from career_os.services.scoring.JOB_FAMILY_WEIGHTS)
+and REAL JD title strings against the real bundled ESCO occupations taxonomy
+(populated via occupation_taxonomy.populate_occupations — never seeded into
+the ESCO skills cache). Proves the classifier is not a constant, that `unknown`
+is strictly distinguishable from `no_match` (score=None vs score=0.0), and that
+the known disaster case ("Senior Backend Engineer" -> nursing) cannot recur.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from career_os.services.occupation_matcher import (
+    _classify,
+    map_family_to_occupation,
+    match_occupation,
+    normalize_title_to_occupation,
+)
+from career_os.services.occupation_taxonomy import populate_occupations
+
+
+def _populated(db_session: Session) -> Session:
+    populate_occupations(db_session)
+    return db_session
+
+
+# ---------------------------------------------------------------------------
+# Pure _classify unit tests — no DB needed
+# ---------------------------------------------------------------------------
+
+
+class _FakeOccupation:
+    def __init__(self, concept_uri: str, preferred_label: str, isco_group: str | None) -> None:
+        self.concept_uri = concept_uri
+        self.preferred_label = preferred_label
+        self.isco_group = isco_group
+
+
+def test_classify_same_occupation() -> None:
+    occ = _FakeOccupation("uri-1", "software developer", "2512")
+    result = _classify(occ, occ)
+    assert result == {"match": "same_occupation", "score": 1.0}
+
+
+def test_classify_same_isco_group() -> None:
+    a = _FakeOccupation("uri-1", "software developer", "2512")
+    b = _FakeOccupation("uri-2", "software architect", "2512")
+    result = _classify(a, b)
+    assert result == {"match": "same_isco_group", "score": 0.5}
+
+
+def test_classify_no_match() -> None:
+    a = _FakeOccupation("uri-1", "software developer", "2512")
+    b = _FakeOccupation("uri-2", "software tester", "2519")
+    result = _classify(a, b)
+    assert result == {"match": "no_match", "score": 0.0}
+
+
+def test_classify_unknown_family_none() -> None:
+    b = _FakeOccupation("uri-2", "software tester", "2519")
+    result = _classify(None, b)
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+
+
+def test_classify_unknown_title_none() -> None:
+    a = _FakeOccupation("uri-1", "software developer", "2512")
+    result = _classify(a, None)
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+
+
+def test_classify_unknown_both_none() -> None:
+    result = _classify(None, None)
+    assert result == {"match": "unknown", "score": None}
+
+
+# ---------------------------------------------------------------------------
+# map_family_to_occupation / normalize_title_to_occupation
+# ---------------------------------------------------------------------------
+
+
+def test_map_family_to_occupation_resolves_overlay_pin(db_session: Session) -> None:
+    db = _populated(db_session)
+    occ = map_family_to_occupation(db, "SWE")
+    assert occ is not None
+    assert occ.preferred_label == "software developer"
+
+
+def test_map_family_to_occupation_unmapped_family_returns_none(db_session: Session) -> None:
+    db = _populated(db_session)
+    # "Actuary" is a real JOB_FAMILY_WEIGHTS key with no overlay pin and no
+    # close-enough fuzzy match (verified during planning).
+    occ = map_family_to_occupation(db, "Actuary")
+    assert occ is None
+
+
+def test_map_family_to_occupation_empty_taxonomy_returns_none(db_session: Session) -> None:
+    # No populate_occupations call — table is empty.
+    occ = map_family_to_occupation(db_session, "SWE")
+    assert occ is None
+
+
+def test_normalize_title_to_occupation_resolves_real_title(db_session: Session) -> None:
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Senior Software Engineer")
+    assert occ is not None
+    assert occ.preferred_label == "software developer"
+
+
+def test_normalize_title_to_occupation_empty_title_returns_none(db_session: Session) -> None:
+    db = _populated(db_session)
+    assert normalize_title_to_occupation(db, "") is None
+    assert normalize_title_to_occupation(db, "   ") is None
+    assert normalize_title_to_occupation(db, None) is None
+
+
+# ---------------------------------------------------------------------------
+# match_occupation — the pure feature
+# ---------------------------------------------------------------------------
+
+
+def test_match_occupation_same_occupation(db_session: Session) -> None:
+    db = _populated(db_session)
+    result = match_occupation(db, "SWE", "Senior Software Engineer")
+    assert result["match"] == "same_occupation"
+    assert result["score"] == 1.0
+
+
+def test_match_occupation_no_match(db_session: Session) -> None:
+    db = _populated(db_session)
+    # Data Scientist family vs a Software Tester title: different, non-empty
+    # ISCO groups (2511 vs 2519) -> a genuine no_match, score 0.0.
+    result = match_occupation(db, "Data Scientist", "Software Tester")
+    assert result["match"] == "no_match"
+    assert result["score"] == 0.0
+
+
+def test_match_occupation_unknown_unmapped_family(db_session: Session) -> None:
+    db = _populated(db_session)
+    result = match_occupation(db, "Actuary", "Insurance Actuary")
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+
+
+def test_match_occupation_unknown_empty_taxonomy(db_session: Session) -> None:
+    # Empty esco_occupations table — no populate call.
+    result = match_occupation(db_session, "SWE", "Senior Software Engineer")
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+
+
+def test_match_occupation_disaster_guard_backend_engineer(db_session: Session) -> None:
+    """The 4a disaster case this ticket exists to prevent.
+
+    "Senior Backend Engineer" must NEVER resolve to an unrelated (e.g.
+    nursing) occupation. Backend Engineer has no confident ESCO pin, so the
+    family side resolves to None -> the whole result is `unknown`
+    (score=None) — never a fabricated wrong tier.
+    """
+    db = _populated(db_session)
+    result = match_occupation(db, "Backend Engineer", "Senior Backend Engineer")
+    assert result["match"] in ("same_occupation", "same_isco_group", "unknown")
+    if result["match"] == "unknown":
+        assert result["score"] is None
+    else:
+        assert result["score"] in (1.0, 0.5)
+    # The specific disaster: never resolve through to a nursing occupation.
+    assert result["title_label"] != "nurse assistant"
+
+
+def test_match_occupation_non_constancy(db_session: Session) -> None:
+    """Across distinct (family, title) pairs, the signal must vary.
+
+    This is the exact 4a failure mode: a matcher that always returns the
+    same tier (or always 0.0) carries no signal. At least 2 distinct tiers
+    must appear, including "unknown".
+    """
+    db = _populated(db_session)
+    pairs = [
+        ("SWE", "Senior Software Engineer"),  # same_occupation
+        ("Data Scientist", "Software Tester"),  # no_match
+        ("Actuary", "Insurance Actuary"),  # unknown (unmapped family)
+        ("Backend Engineer", "Senior Backend Engineer"),  # unknown (no pin)
+        ("TPM", "ICT Project Manager"),  # same_occupation
+    ]
+    tiers = {match_occupation(db, family, title)["match"] for family, title in pairs}
+    assert len(tiers) >= 2
+    assert "unknown" in tiers
+
+
+def test_match_occupation_no_occupation_rows_in_skills_table(db_session: Session) -> None:
+    """Guard: this test module must never seed occupation rows into the ESCO skills cache."""
+    from career_os.models.esco import ESCOSkill
+
+    _populated(db_session)
+    assert db_session.query(ESCOSkill).count() == 0

--- a/tests/test_occupation_matcher.py
+++ b/tests/test_occupation_matcher.py
@@ -6,24 +6,51 @@ and REAL JD title strings against the real bundled ESCO occupations taxonomy
 the ESCO skills cache). Proves the classifier is not a constant, that `unknown`
 is strictly distinguishable from `no_match` (score=None vs score=0.0), and that
 the known disaster case ("Senior Backend Engineer" -> nursing) cannot recur.
+
+Also covers the G-1351 3-pass review fixes (F1-F9): self-sufficient lazy
+populate (F1), the ambiguous-alt-label denylist (F2), the JD-title CPU cap
+(F3), the generic-unigram hijack guard (F4), case-insensitive overlay lookup
+(F5), the no-rollback swallow path (F6), the match-surface cache (F7), and the
+additional testing-gap coverage (F8).
 """
 
 from __future__ import annotations
 
+import time
+
+import pytest
 from sqlalchemy.orm import Session
 
+import career_os.services.occupation_matcher as occupation_matcher
 from career_os.services.occupation_matcher import (
     _classify,
     map_family_to_occupation,
     match_occupation,
     normalize_title_to_occupation,
 )
-from career_os.services.occupation_taxonomy import populate_occupations
+from career_os.services.occupation_taxonomy import count_occupations, populate_occupations
 
 
 def _populated(db_session: Session) -> Session:
     populate_occupations(db_session)
     return db_session
+
+
+@pytest.fixture(autouse=True)
+def _reset_matcher_module_state(monkeypatch):
+    """Reset module-level lazy-populate/cache state around every test.
+
+    Both `_POPULATE_ATTEMPT_FAILED` (F1) and `_surface_cache` (F7) are
+    intentionally module-level (they cache/latch across calls within a
+    process), but that makes them cross-test-contamination risks in a test
+    suite that runs many independent DBs in the same process. monkeypatch
+    restores the pre-test value after each test regardless of what the code
+    mutates it to during the test, so this keeps every test hermetic without
+    losing the module-level design the production code needs.
+    """
+    monkeypatch.setattr(occupation_matcher, "_POPULATE_ATTEMPT_FAILED", False)
+    monkeypatch.setattr(occupation_matcher, "_surface_cache", None)
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +125,8 @@ def test_map_family_to_occupation_unmapped_family_returns_none(db_session: Sessi
 
 
 def test_map_family_to_occupation_empty_taxonomy_returns_none(db_session: Session) -> None:
-    # No populate_occupations call — table is empty.
+    # No populate_occupations call — table is empty. map_family_to_occupation
+    # itself never lazily populates (that's match_occupation's job — F1).
     occ = map_family_to_occupation(db_session, "SWE")
     assert occ is None
 
@@ -115,6 +143,123 @@ def test_normalize_title_to_occupation_empty_title_returns_none(db_session: Sess
     assert normalize_title_to_occupation(db, "") is None
     assert normalize_title_to_occupation(db, "   ") is None
     assert normalize_title_to_occupation(db, None) is None
+
+
+# ---------------------------------------------------------------------------
+# F5 — case-insensitive overlay lookup
+# ---------------------------------------------------------------------------
+
+
+def test_map_family_to_occupation_case_insensitive_overlay(db_session: Session) -> None:
+    """'SWE', 'swe', 'Software Engineer', 'software engineer' all resolve to
+    the same occupation (concept_uri) — job_family is free text, and
+    scoring.py's _weights_for_job_family is already case-insensitive."""
+    db = _populated(db_session)
+    variants = ["SWE", "swe", "Software Engineer", "software engineer"]
+    resolved = [map_family_to_occupation(db, v) for v in variants]
+    assert all(occ is not None for occ in resolved)
+    uris = {occ.concept_uri for occ in resolved}
+    assert len(uris) == 1
+
+
+# ---------------------------------------------------------------------------
+# F3 — CPU DoS cap on crafted titles
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_title_to_occupation_caps_cpu_on_huge_title(db_session: Session) -> None:
+    """A 5,000-word junk title must complete fast and degrade safely."""
+    db = _populated(db_session)
+    junk_title = " ".join(f"word{i}" for i in range(5000))
+
+    start = time.perf_counter()
+    result = normalize_title_to_occupation(db, junk_title)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 2.0, f"normalize_title_to_occupation took {elapsed:.2f}s (expected < 2s)"
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# F4 — generic unigram hijack guard
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_title_to_occupation_unigram_hijack_guard(db_session: Session) -> None:
+    """'Sales Development Representative' must never resolve via the bare
+    unigram candidate 'Representative' hijacking an HR occupation."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Sales Development Representative")
+    if occ is not None:
+        assert "human resources" not in occ.preferred_label.lower()
+
+
+def test_normalize_title_to_occupation_short_title_still_resolves(db_session: Session) -> None:
+    """A genuinely short title ('Chef') must still resolve via its own unigram."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Chef")
+    assert occ is not None
+    assert occ.preferred_label == "chef"
+
+
+def test_normalize_title_to_occupation_backend_engineer_no_wrong_resolution(
+    db_session: Session,
+) -> None:
+    """'Senior Backend Engineer' must never resolve to an unrelated occupation
+    (the original 4a disaster case) even with the unigram guard in place."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Senior Backend Engineer")
+    if occ is not None:
+        assert occ.preferred_label != "nurse assistant"
+
+
+# ---------------------------------------------------------------------------
+# F2 — ambiguous ESCO alt-label denylist
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_title_denylist_blocks_data_engineer_as_data_scientist(
+    db_session: Session,
+) -> None:
+    """'data engineer' is a literal ESCO alt_label of 'data scientist' —
+    denylisted so a Data Engineer JD title never resolves to it."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Data Engineer")
+    if occ is not None:
+        assert occ.preferred_label != "data scientist"
+
+
+def test_normalize_title_denylist_blocks_engineering_manager_as_foundry_manager(
+    db_session: Session,
+) -> None:
+    """'engineering manager' is a literal ESCO alt_label of 'foundry manager' —
+    denylisted so an Engineering Manager JD title never resolves to it."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Engineering Manager")
+    if occ is not None:
+        assert occ.preferred_label != "foundry manager"
+
+
+def test_match_occupation_data_scientist_family_vs_data_engineer_title(
+    db_session: Session,
+) -> None:
+    """The exact disaster reproduction from the review: Data Scientist family
+    + Data Engineer title must NOT be same_occupation=1.0."""
+    db = _populated(db_session)
+    result = match_occupation(db, "Data Scientist", "Data Engineer")
+    assert result["match"] != "same_occupation"
+
+
+def test_match_occupation_operations_manager_self_match_restored(db_session: Session) -> None:
+    """Denylisting the 'operations manager' alt-label collision restores the
+    same-title round-trip for one of our 30 pinned overlay families — before
+    the fix, DB row-insertion order could non-deterministically shadow the
+    correct occupation with an unrelated one (metal production manager, mine
+    manager, financial markets back office administrator, business manager)."""
+    db = _populated(db_session)
+    result = match_occupation(db, "Operations Manager", "Operations Manager")
+    assert result["match"] == "same_occupation"
+    assert result["score"] == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -145,29 +290,19 @@ def test_match_occupation_unknown_unmapped_family(db_session: Session) -> None:
     assert result["score"] is None
 
 
-def test_match_occupation_unknown_empty_taxonomy(db_session: Session) -> None:
-    # Empty esco_occupations table — no populate call.
-    result = match_occupation(db_session, "SWE", "Senior Software Engineer")
-    assert result["match"] == "unknown"
-    assert result["score"] is None
-
-
 def test_match_occupation_disaster_guard_backend_engineer(db_session: Session) -> None:
     """The 4a disaster case this ticket exists to prevent.
 
     "Senior Backend Engineer" must NEVER resolve to an unrelated (e.g.
     nursing) occupation. Backend Engineer has no confident ESCO pin, so the
     family side resolves to None -> the whole result is `unknown`
-    (score=None) — never a fabricated wrong tier.
+    (score=None), deterministically (G-1351 review F8 tightened this from
+    accepting 3 of 4 tiers to the single correct tier).
     """
     db = _populated(db_session)
     result = match_occupation(db, "Backend Engineer", "Senior Backend Engineer")
-    assert result["match"] in ("same_occupation", "same_isco_group", "unknown")
-    if result["match"] == "unknown":
-        assert result["score"] is None
-    else:
-        assert result["score"] in (1.0, 0.5)
-    # The specific disaster: never resolve through to a nursing occupation.
+    assert result["match"] == "unknown"
+    assert result["score"] is None
     assert result["title_label"] != "nurse assistant"
 
 
@@ -197,3 +332,211 @@ def test_match_occupation_no_occupation_rows_in_skills_table(db_session: Session
 
     _populated(db_session)
     assert db_session.query(ESCOSkill).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# F1 — self-sufficient lazy populate
+# ---------------------------------------------------------------------------
+
+
+def test_match_occupation_lazy_populates_empty_taxonomy(db_session: Session) -> None:
+    """A fresh, never-populated DB — no populate_occupations call, no CLI —
+    must still get a REAL tier from match_occupation, not permanent
+    `unknown`. This is the core F1 fix: a normal server deployment never
+    manually runs `kestrel occupations load`."""
+    assert count_occupations(db_session) == 0
+
+    result = match_occupation(db_session, "SWE", "Senior Software Engineer")
+
+    assert result["match"] == "same_occupation"
+    assert result["score"] == 1.0
+    # Proves the lazy populate actually ran.
+    assert count_occupations(db_session) > 0
+
+
+def test_match_occupation_lazy_populate_failure_degrades_to_unknown(
+    db_session: Session, monkeypatch
+) -> None:
+    """A populate failure inside the lazy path must degrade to `unknown`
+    (score=None) rather than raising or leaving the caller with a wrong
+    fabricated result."""
+    assert count_occupations(db_session) == 0
+
+    def _boom(db):
+        raise RuntimeError("simulated populate failure")
+
+    monkeypatch.setattr(occupation_matcher, "populate_occupations", _boom)
+
+    result = match_occupation(db_session, "SWE", "Senior Software Engineer")
+
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+    assert occupation_matcher._POPULATE_ATTEMPT_FAILED is True
+
+
+def test_match_occupation_lazy_populate_not_retried_after_failure(
+    db_session: Session, monkeypatch
+) -> None:
+    """After a failed lazy-populate attempt, subsequent calls must not retry
+    populate_occupations on every single call (F1's "already attempted"
+    latch)."""
+    call_count = {"n": 0}
+
+    def _boom(db):
+        call_count["n"] += 1
+        raise RuntimeError("simulated populate failure")
+
+    monkeypatch.setattr(occupation_matcher, "populate_occupations", _boom)
+
+    match_occupation(db_session, "SWE", "Senior Software Engineer")
+    match_occupation(db_session, "SWE", "Senior Software Engineer")
+    match_occupation(db_session, "SWE", "Senior Software Engineer")
+
+    assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# F6 — swallow path never rolls back the caller's session
+# ---------------------------------------------------------------------------
+
+
+def test_match_occupation_swallow_path_does_not_rollback(db_session: Session, monkeypatch) -> None:
+    """match_occupation borrows the caller's session; a swallowed internal
+    failure must never call db.rollback() (it would silently discard the
+    caller's own pending uncommitted writes in the Phase C cascade)."""
+    db = _populated(db_session)
+
+    def _boom(db, family):
+        raise RuntimeError("simulated internal failure")
+
+    monkeypatch.setattr(occupation_matcher, "map_family_to_occupation", _boom)
+
+    rollback_calls = {"n": 0}
+    original_rollback = db.rollback
+
+    def _counting_rollback():
+        rollback_calls["n"] += 1
+        return original_rollback()
+
+    monkeypatch.setattr(db, "rollback", _counting_rollback)
+
+    result = match_occupation(db, "SWE", "Senior Software Engineer")
+
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+    assert rollback_calls["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# F7 — match-surface cache
+# ---------------------------------------------------------------------------
+
+
+def test_match_surface_cached_across_calls(db_session: Session, monkeypatch) -> None:
+    """Two consecutive match_occupation calls against an unchanged taxonomy
+    must only build the match surface once."""
+    db = _populated(db_session)
+
+    call_count = {"n": 0}
+    original_builder = occupation_matcher._build_match_surface
+
+    def _counting_builder(db, row_count):
+        call_count["n"] += 1
+        return original_builder(db, row_count)
+
+    monkeypatch.setattr(occupation_matcher, "_build_match_surface", _counting_builder)
+
+    match_occupation(db, "SWE", "Senior Software Engineer")
+    match_occupation(db, "SWE", "Senior Software Engineer")
+
+    assert call_count["n"] == 1
+
+
+def test_match_surface_second_call_is_fast(db_session: Session) -> None:
+    """The second call against a warm cache should be comfortably fast.
+
+    Generous bound to stay robust against CI jitter — this is a smoke guard
+    against a catastrophic per-call rebuild regression, not a tight
+    micro-benchmark (the deterministic call-count test above carries the
+    real regression-proofing weight).
+    """
+    db = _populated(db_session)
+    match_occupation(db, "SWE", "Senior Software Engineer")  # warm the cache
+
+    start = time.perf_counter()
+    match_occupation(db, "SWE", "Senior Software Engineer")
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, f"second call took {elapsed:.3f}s (expected < 0.5s)"
+
+
+# ---------------------------------------------------------------------------
+# F8 — additional testing-gap coverage
+# ---------------------------------------------------------------------------
+
+
+def test_match_occupation_same_isco_group_data_scientist_vs_data_analyst(
+    db_session: Session,
+) -> None:
+    """e2e same_isco_group with real fixture data: Data Scientist family vs a
+    Data Analyst title — both occupations share ISCO unit group 2511, but are
+    genuinely different occupations, so same_isco_group at 0.5 (not
+    same_occupation at 1.0, and not a fake 0.0)."""
+    db = _populated(db_session)
+    result = match_occupation(db, "Data Scientist", "Data Analyst")
+    assert result["match"] == "same_isco_group"
+    assert result["score"] == 0.5
+    assert result["family_label"] == "data scientist"
+    assert result["title_label"] == "data analyst"
+
+
+def test_populate_occupations_force_inserts_genuinely_missing_row(db_session: Session) -> None:
+    from career_os.models.esco import ESCOOccupation
+
+    first = populate_occupations(db_session)
+    assert first["inserted"] > 0
+
+    victim = db_session.query(ESCOOccupation).first()
+    victim_uri = victim.concept_uri
+    db_session.delete(victim)
+    db_session.commit()
+
+    forced = populate_occupations(db_session, force=True)
+
+    assert forced["inserted"] == 1
+    restored = (
+        db_session.query(ESCOOccupation).filter(ESCOOccupation.concept_uri == victim_uri).first()
+    )
+    assert restored is not None
+
+
+@pytest.mark.parametrize("family", [None, "", "   "])
+def test_match_occupation_empty_or_none_family_is_unknown(
+    db_session: Session, family: str | None
+) -> None:
+    db = _populated(db_session)
+    result = match_occupation(db, family, "Senior Software Engineer")
+    assert result["match"] == "unknown"
+    assert result["score"] is None
+
+
+def test_normalize_title_to_occupation_unicode_title_degrades_to_unknown(
+    db_session: Session,
+) -> None:
+    """A non-English title must degrade to `unknown` (no cross-language
+    mis-match) rather than raising or fabricating a wrong resolution."""
+    db = _populated(db_session)
+    occ = normalize_title_to_occupation(db, "Développeur logiciel")
+    # Either it stays unresolved (expected), or — if it happens to resolve —
+    # it must be a real occupation object, never a crash.
+    if occ is not None:
+        assert occ.preferred_label
+
+
+def test_normalize_title_to_occupation_exact_preferred_label_match(db_session: Session) -> None:
+    """An exact preferred_label as the JD title resolves to same_occupation
+    for the corresponding pinned family."""
+    db = _populated(db_session)
+    result = match_occupation(db, "SWE", "software developer")
+    assert result["match"] == "same_occupation"
+    assert result["score"] == 1.0

--- a/tests/test_occupation_matcher.py
+++ b/tests/test_occupation_matcher.py
@@ -395,6 +395,39 @@ def test_match_occupation_lazy_populate_not_retried_after_failure(
     assert call_count["n"] == 1
 
 
+def test_lazy_populate_does_not_commit_callers_pending_writes(tmp_path) -> None:
+    """The F1 lazy populate runs populate_occupations, which COMMITS — on the
+    caller's session that would persist the caller's own pending score_job
+    writes mid-transaction (the commit-flavored twin of the F6 rollback
+    hazard). It must run on its OWN session bound to the caller's engine.
+
+    Uses a file-backed engine-bound session (not the connection-bound
+    db_session fixture) because that is the production shape where the hazard
+    exists."""
+    from sqlalchemy import create_engine
+
+    from career_os.database import Base
+    from career_os.models.models import Profile
+
+    engine = create_engine(f"sqlite:///{tmp_path}/lazy_populate.db")
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as caller:
+        caller.add(Profile(name="pending-uncommitted"))  # pending, never committed
+
+        result = match_occupation(caller, "SWE", "Senior Software Engineer")
+
+        assert result["match"] == "same_occupation"  # lazy populate worked
+        caller.rollback()
+
+    with Session(engine) as check:
+        # The caller's pending write must NOT have been committed by the
+        # lazy populate; the taxonomy itself must have persisted.
+        assert check.query(Profile).count() == 0
+        assert count_occupations(check) > 0
+    engine.dispose()
+
+
 # ---------------------------------------------------------------------------
 # F6 — swallow path never rolls back the caller's session
 # ---------------------------------------------------------------------------

--- a/tests/test_occupation_taxonomy.py
+++ b/tests/test_occupation_taxonomy.py
@@ -1,0 +1,62 @@
+"""Tests for the in-package ESCO occupations fixture consumer (G-1351 Phase B).
+
+Uses the real bundled fixture (no mocks) — this is the wheel-install path the
+ticket exists to prove: a pip-installed user with no `scripts/` directory must
+still be able to populate `esco_occupations` via `importlib.resources`.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from career_os.services.occupation_taxonomy import (
+    count_occupations,
+    load_bundled_occupations,
+    populate_occupations,
+)
+
+MIN_FIXTURE_ROWS = 2900
+
+
+def test_load_bundled_occupations_returns_full_pillar() -> None:
+    rows = load_bundled_occupations()
+    assert len(rows) >= MIN_FIXTURE_ROWS
+    first = rows[0]
+    assert "concept_uri" in first
+    assert "preferred_label" in first
+
+
+def test_populate_occupations_inserts_full_fixture(db_session: Session) -> None:
+    assert count_occupations(db_session) == 0
+
+    result = populate_occupations(db_session)
+
+    assert result["inserted"] >= MIN_FIXTURE_ROWS
+    assert result["skipped"] == 0
+    assert result["already_loaded"] is False
+    assert count_occupations(db_session) == result["inserted"]
+
+
+def test_populate_occupations_is_idempotent(db_session: Session) -> None:
+    first = populate_occupations(db_session)
+    count_after_first = count_occupations(db_session)
+
+    second = populate_occupations(db_session)
+
+    assert second["inserted"] == 0
+    assert second["skipped"] == count_after_first
+    assert second["already_loaded"] is True
+    # No duplicates: row count unchanged.
+    assert count_occupations(db_session) == first["inserted"]
+
+
+def test_populate_occupations_force_does_not_duplicate(db_session: Session) -> None:
+    first = populate_occupations(db_session)
+    count_after_first = count_occupations(db_session)
+
+    forced = populate_occupations(db_session, force=True)
+
+    # force=True re-scans and finds nothing genuinely missing.
+    assert forced["inserted"] == 0
+    assert count_occupations(db_session) == count_after_first
+    assert count_occupations(db_session) == first["inserted"]

--- a/tests/test_occupation_taxonomy.py
+++ b/tests/test_occupation_taxonomy.py
@@ -3,12 +3,19 @@
 Uses the real bundled fixture (no mocks) — this is the wheel-install path the
 ticket exists to prove: a pip-installed user with no `scripts/` directory must
 still be able to populate `esco_occupations` via `importlib.resources`.
+
+Also covers the `kestrel occupations load` CLI command (G-1351 3-pass review
+F8): fresh DB, already-loaded, --force, and the friendly missing-table error.
 """
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from typer.testing import CliRunner
 
+from career_os.cli.main import app
+from career_os.database import Base
 from career_os.services.occupation_taxonomy import (
     count_occupations,
     load_bundled_occupations,
@@ -16,6 +23,8 @@ from career_os.services.occupation_taxonomy import (
 )
 
 MIN_FIXTURE_ROWS = 2900
+
+runner = CliRunner()
 
 
 def test_load_bundled_occupations_returns_full_pillar() -> None:
@@ -60,3 +69,99 @@ def test_populate_occupations_force_does_not_duplicate(db_session: Session) -> N
     assert forced["inserted"] == 0
     assert count_occupations(db_session) == count_after_first
     assert count_occupations(db_session) == first["inserted"]
+
+
+# ---------------------------------------------------------------------------
+# F8 — `kestrel occupations load` CLI coverage
+# ---------------------------------------------------------------------------
+
+
+def _set_sqlite_pragmas(dbapi_conn, connection_record) -> None:  # noqa: ANN001
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+def _make_engine_with_tables():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    event.listen(engine, "connect", _set_sqlite_pragmas)
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def test_occupations_load_cli_fresh_db(monkeypatch) -> None:
+    engine = _make_engine_with_tables()
+    testing_session_cls = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    import career_os.cli.main as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_get_session", lambda: testing_session_cls())
+
+    result = runner.invoke(app, ["occupations", "load"])
+
+    assert result.exit_code == 0
+    assert "Loaded" in result.output
+
+    session = testing_session_cls()
+    assert count_occupations(session) >= MIN_FIXTURE_ROWS
+    session.close()
+    engine.dispose()
+
+
+def test_occupations_load_cli_already_loaded(monkeypatch) -> None:
+    engine = _make_engine_with_tables()
+    testing_session_cls = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    import career_os.cli.main as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_get_session", lambda: testing_session_cls())
+
+    # First run: loads.
+    first = runner.invoke(app, ["occupations", "load"])
+    assert first.exit_code == 0
+
+    # Second run: already loaded, no re-scan.
+    second = runner.invoke(app, ["occupations", "load"])
+    assert second.exit_code == 0
+    assert "Already loaded" in second.output
+
+    engine.dispose()
+
+
+def test_occupations_load_cli_force(monkeypatch) -> None:
+    engine = _make_engine_with_tables()
+    testing_session_cls = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    import career_os.cli.main as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_get_session", lambda: testing_session_cls())
+
+    first = runner.invoke(app, ["occupations", "load"])
+    assert first.exit_code == 0
+
+    forced = runner.invoke(app, ["occupations", "load", "--force"])
+    assert forced.exit_code == 0
+    assert "Loaded" in forced.output
+
+    engine.dispose()
+
+
+def test_occupations_load_cli_missing_table_friendly_error(monkeypatch) -> None:
+    """A fresh DB without migrations applied (no esco_occupations table) must
+    print a friendly message and exit(1) — never a raw traceback."""
+    # No Base.metadata.create_all() — the table genuinely does not exist.
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    testing_session_cls = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    import career_os.cli.main as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_get_session", lambda: testing_session_cls())
+
+    result = runner.invoke(app, ["occupations", "load"])
+
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    assert "esco_occupations" in result.output.lower() or "table not found" in result.output
+
+    engine.dispose()


### PR DESCRIPTION
## Summary

Phase B (2/3) of the title→occupation scoring axis (G-1351, scoring F5). Phase A (#467) landed the `esco_occupations` taxonomy; this PR delivers the matcher that stands on it. Phase C (shadow cascade signal) follows separately.

### In-package fixture consumer — `services/occupation_taxonomy.py`
- `load_bundled_occupations()` reads the wheel-shipped `esco_occupations_en.json.gz` via `importlib.resources` — no `scripts/` dependency, so pip-installed users get a working taxonomy (fixes review WR-05; the 4a axis died exactly because wheels had no data path).
- `populate_occupations(session)` — idempotent on-demand table populate, `force=True` to re-seed.
- New `kestrel occupations load` CLI subcommand.

### Pure matcher — `services/occupation_matcher.py`
- `match_occupation(candidate_family, jd_title)` → `same_occupation | same_isco_group | no_match | unknown` + score.
- **`unknown` (score=None) is strictly distinct from `no_match` (score=0.0)** — including in the exception-fallback path. Never a fake constant 0 (the 4a failure mode).
- `FAMILY_OCCUPATION_OVERLAY`: 30 hand-checked family→concept pins, every `concept_uri` verified present in the bundled fixture. Families without a clean ESCO concept are deliberately left out (fall back to conservative fuzzy → likely `unknown`) rather than pinned wrong.
- JD-title normalizer: rapidfuzz over preferred+alt labels with n-gram windowing (mirrors `cli/extract.py`), `default_process` normalization, longest-first candidate ordering, high cutoff + length guard. Tuned against empirically-observed failure modes ("Senior Backend Engineer" must never resolve to "nurse assistant" via the `sen` substring; "data engineer" appears literally in "data scientist" alt-labels).

### Tests (22 new)
- Real caller path per the ticket's hard constraint: real `JOB_FAMILY_WEIGHTS` codes (SWE, TPM, Data Scientist, Backend Engineer, Actuary) + real JD title strings; no occupation rows seeded into the skills cache (grep-guarded + a dedicated row-count test).
- Non-constancy assertion (≥2 distinct tiers across a fixture of pairs) — the exact regression that killed 4a.
- Taxonomy: fixture load, idempotent populate, CLI smoke.

Out of scope (Phase C): `score_job`/distillation/cascade wiring.

## Validation
- `pytest tests/test_occupation_taxonomy.py tests/test_occupation_matcher.py tests/test_esco_occupations.py` — 33 passed
- `ruff check` + `ruff format --check` clean
- GSD `--validate` pipeline: plan-checker passed (1 iteration), post-execution verifier passed 5/5 must-haves (independently re-derived the overlay URI check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUYSexq5S3Pn5iksDK5HW1