### PR TITLE
fix(G-1412): code-scanning backlog — CodeQL highs, workflow token permissions, SHA/digest pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     name: Backend (Python 3.11)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
           cache: pip
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-coverage
           path: coverage.xml
@@ -115,7 +115,7 @@ jobs:
         # no fix yet, add the vuln ID to .pip-audit-ignore (one per line,
         # with a comment) as a temporary escape hatch.
         run: |
-          pip install pip-audit
+          pip install pip-audit==2.10.1
           ignore_args=()
           if [ -f .pip-audit-ignore ]; then
             while IFS= read -r line; do
@@ -147,7 +147,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Run actionlint directly (pinned official image) instead of the reviewdog
       # wrapper. reviewdog fetches the PR diff via the GitHub API to scope
       # findings; with this repo's read-only token it can 403 ("Resource not
@@ -155,7 +155,7 @@ jobs:
       # unrelated to workflow lint. A direct run needs no diff, token, or extra
       # permissions and fails only on real lint errors.
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.7
+        uses: docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # 1.7.7
         with:
           args: -color
         env:
@@ -170,8 +170,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
           cache: npm
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -258,13 +258,13 @@ jobs:
           fetch-depth: 0  # Full history for accurate blame / new code detection
 
       - name: Download backend coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: backend-coverage
         continue-on-error: true  # Missing coverage shouldn't block the scan
 
       - name: Download frontend coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-coverage
           path: frontend/coverage

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,13 +39,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Run Claude Code (intake + review)
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Least-privilege ceiling for the whole workflow; the claude job below grants
+# itself the broader scopes it actually needs (PR/issue comments, OIDC token
+# for claude-code-action). (G-1412)
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         language: [python, javascript-typescript]
     steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v4
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
 
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+        run: npm install --no-save @commitlint/cli@21.2.1 @commitlint/config-conventional@21.2.0
 
       - name: Lint commits
         run: |

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -72,13 +72,18 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   daily-scan:
     if: github.event_name == 'workflow_dispatch' || vars.DAILY_SCAN_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # contents:write is needed by the "Commit digest to repo" step, which
+    # git-commits + pushes tracking/daily-scan-*.md straight to main. No
+    # other write scope is used by this job. (G-1412)
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -87,10 +87,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -98,7 +98,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m venv .venv
-          .venv/bin/pip install --upgrade pip
+          # pip<26.0 is flagged by CVE-2026-1703 (pip-audit); same floor as
+          # ci.yml/nightly.yml (G-1412).
+          .venv/bin/pip install --upgrade 'pip>=26.0'
           .venv/bin/pip install -e ".[dev]"
 
       - name: Prepare directories
@@ -257,7 +259,7 @@ jobs:
 
       - name: Upload digest as artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daily-scan-${{ github.run_number }}
           path: |
@@ -267,7 +269,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pipeline-logs-${{ github.run_number }}
           path: logs/

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
@@ -16,6 +15,12 @@ jobs:
     # whoever triggered the run (e.g. a re-run) and is spoofable
     # (zizmor bot-conditions).
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # contents:write + pull-requests:write are both required by
+    # `gh pr merge --auto --squash` (enabling auto-merge / merging touches
+    # both the PR and the target branch). Scoped to this job only. (G-1412)
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # This uses the default GITHUB_TOKEN, elevated via the permissions block
       # (which applies even to Dependabot-triggered runs). Known tradeoff:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,12 +13,16 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-push:
     name: Build and push image
     runs-on: ubuntu-latest
+    # packages:write is needed to push the built image to GHCR (docker/login-action
+    # + docker/build-push-action below). Scoped to this job only. (G-1412)
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 2 * * *'  # 2am UTC daily
   workflow_dispatch:  # manual trigger
 
+# Least-privilege ceiling; scoring-eval below re-declares its own read-only
+# grant (kept as-is), call-smoke/nightly-status need no write access. (G-1412)
+permissions:
+  contents: read
+
 jobs:
   call-smoke:
     uses: ./.github/workflows/smoke.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,8 +20,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,9 +24,9 @@ jobs:
       contents: read
       id-token: write # Mint the OIDC token for trusted publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
 
@@ -37,11 +37,11 @@ jobs:
 
       - name: Build wheel
         run: |
-          pip install build
+          pip install build==1.5.0
           python -m build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -54,10 +54,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -22,13 +22,13 @@ jobs:
     name: Container build + Trivy scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true
@@ -37,7 +37,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: kestrel:ci
           format: table
@@ -52,8 +52,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
           cache: npm
@@ -71,7 +71,7 @@ jobs:
       - name: Accessibility smoke check
         continue-on-error: true
         run: |
-          npm install --no-save --legacy-peer-deps http-server @axe-core/cli
+          npm install --no-save --legacy-peer-deps http-server@14.1.1 @axe-core/cli@4.12.1
           npx http-server dist -p 4173 --silent &
           SERVER_PID=$!
           # Single-quote trap body so $SERVER_PID is evaluated at trap

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -8,6 +8,14 @@ on:
   check_suite:
     types: [completed]
 
+# Least-privilege ceiling; evaluate below grants itself the exact scopes its
+# gh CLI calls need. This workflow previously had NO permissions block at
+# all, meaning it ran on whatever the repo/org default GITHUB_TOKEN
+# permissions happened to be — flagged by OSSF Scorecard TokenPermissions.
+# (G-1412)
+permissions:
+  contents: read
+
 jobs:
   evaluate:
     name: Evaluate release readiness
@@ -16,6 +24,15 @@ jobs:
     if: |
       github.event_name == 'check_suite' ||
       contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    # contents:read — actions/checkout below.
+    # issues:read — `gh issue list` (blocker/release-broken check).
+    # pull-requests:write — `gh pr merge`/`gh pr comment`/`gh pr close`
+    # (merges of pull requests are covered by the pull-requests scope; no
+    # contents:write is needed for the merge itself). (G-1412)
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -34,7 +34,7 @@ jobs:
       issues: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Find release-please PR
         id: find-pr

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -24,13 +24,12 @@ jobs:
     if: |
       github.event_name == 'check_suite' ||
       contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
-    # contents:read — actions/checkout below.
+    # contents:write — `gh pr merge` (the merge endpoint writes a merge
+    # commit to the repo; pull-requests:write alone 403s the merge).
     # issues:read — `gh issue list` (blocker/release-broken check).
-    # pull-requests:write — `gh pr merge`/`gh pr comment`/`gh pr close`
-    # (merges of pull requests are covered by the pull-requests scope; no
-    # contents:write is needed for the merge itself). (G-1412)
+    # pull-requests:write — `gh pr comment`/`gh pr close`/auto-merge. (G-1412)
     permissions:
-      contents: read
+      contents: write
       issues: read
       pull-requests: write
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,20 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # release-please needs contents:write (release commits/tags) +
+    # pull-requests:write (release PRs). The job actually authenticates via
+    # the scoped GitHub App token below, not the default GITHUB_TOKEN, but
+    # the job-level grant is kept to match what the action can legitimately
+    # need if it ever falls back to the default token. (G-1412)
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Generate token
         id: app-token

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.release.outputs.tag != 'none'
         with:
           ref: ${{ steps.release.outputs.tag }}
@@ -79,7 +79,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create GitHub Issue for broken release
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -7,6 +7,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Least-privilege ceiling; alert-on-failure below grants itself issues:write
+# for filing/commenting on the release-broken tracking issue. This workflow
+# previously had NO permissions block at all — flagged by OSSF Scorecard
+# TokenPermissions. (G-1412)
+permissions:
+  contents: read
+
 jobs:
   verify-release:
     name: Verify latest release
@@ -66,6 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify-release]
     if: failure()
+    # issues:write — `gh issue create`/`gh issue comment` for the
+    # release-broken tracking issue. (G-1412)
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -32,13 +32,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 7
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,11 +16,11 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,7 +35,7 @@ jobs:
     name: Docker prod build + health
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build production image
         run: docker compose -f docker-compose.prod.yml build
@@ -77,7 +77,7 @@ jobs:
     name: Docker dev compose + proxy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build and start dev containers
         run: docker compose up -d --build
@@ -131,15 +131,15 @@ jobs:
     name: Wheel build + server start
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
           cache: pip
 
       - name: Build wheel
         run: |
-          pip install build
+          pip install build==1.5.0
           python -m build --wheel
 
       - name: Install wheel in clean venv
@@ -185,7 +185,7 @@ jobs:
     name: setup.sh --dry-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dry-run setup script
         run: bash setup.sh --dry-run

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -20,9 +20,9 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
   zizmor:
     name: zizmor
@@ -30,12 +30,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install zizmor==1.28.0
       - name: Run zizmor
         # Only block CI on high-severity findings. Pre-existing
         # `secrets-outside-env` warnings in publish*.yml (medium) and

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Build the React frontend
 # ---------------------------------------------------------------------------
-FROM node:22-alpine AS frontend-build
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS frontend-build
 
 WORKDIR /build
 
@@ -23,7 +23,7 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 # Stage 2: Python runtime — FastAPI + static frontend
 # ---------------------------------------------------------------------------
-FROM python:3.11-slim AS runtime
+FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93 AS runtime
 
 # Prevent Python from writing .pyc files and enable unbuffered output
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,6 @@
 # Frontend Dockerfile — React (Vite) + nginx
 # Stage 1: Build the React application
-FROM node:22-alpine AS build
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS build
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Serve with nginx
-FROM nginx:alpine
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
 
 # Install curl for health check
 RUN apk add --no-cache curl

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -13,6 +13,7 @@ Covers:
 import json
 import os
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import httpx
 import pytest
@@ -679,7 +680,9 @@ class TestBatchResultsUrlValidation:
         assert result["status"] == "ended"
         assert result["results"] == {}
         # The malicious results_url must never be fetched (no key leak).
-        assert not any("evil.example.com" in u for u in requested_urls)
+        # Hostname-precise check (not substring) so the assertion is exact
+        # about which host must never be contacted.
+        assert all(urlparse(u).hostname != "evil.example.com" for u in requested_urls)
 
     @pytest.mark.asyncio
     async def test_accepts_anthropic_results_url(self) -> None:

--- a/tests/test_dependency_config.py
+++ b/tests/test_dependency_config.py
@@ -4,6 +4,7 @@ Validates that the config files introduced for automated dependency
 tracking are well-formed and follow project conventions.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -61,9 +62,17 @@ class TestDependabotConfig:
         assert "@types/node" in npm_ignored, "@types/node majors must track the pinned Node runtime"
 
     def test_dockerfile_runtime_is_python_311(self):
-        """The runtime base image tracks the project's pinned Python."""
+        """The runtime base image tracks the project's pinned Python.
+
+        Accepts an optional @sha256 digest pin (G-1412 supply-chain
+        hardening) — the policy being guarded is the 3.11-slim tag itself.
+        """
         dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
-        assert "FROM python:3.11-slim AS runtime" in dockerfile, (
+        assert re.search(
+            r"^FROM python:3\.11-slim(@sha256:[0-9a-f]{64})? AS runtime$",
+            dockerfile,
+            flags=re.MULTILINE,
+        ), (
             "Runtime image must stay on python:3.11-slim until the deliberate "
             "upgrade ticket (G-1289) lands"
         )

--- a/tools/open_question_probe.py
+++ b/tools/open_question_probe.py
@@ -13,8 +13,22 @@ T3 browser-fill detects an unfilled required textarea live as the real backstop.
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 import httpx
 from batch_probe import parse_greenhouse_url
+
+
+def _is_greenhouse_host(url: str) -> bool:
+    """True iff the URL's host is greenhouse.io or a subdomain of it.
+
+    A substring test ("greenhouse.io" in url) also matches attacker-controlled
+    hosts like greenhouse.io.evil.com or evil.com/greenhouse.io (CodeQL
+    py/incomplete-url-substring-sanitization) — route on the parsed hostname.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    return host == "greenhouse.io" or host.endswith(".greenhouse.io")
+
 
 # Standard fields the pipeline can auto-populate (substring match on the lowercased
 # question label). A required textarea whose label hits one of these is NOT an essay.
@@ -133,7 +147,7 @@ def probe_open_questions(url: str, source: str, client: httpx.Client | None = No
     detects live required textareas as the backstop).
     """
     src = (source or "").lower().strip()
-    if src == "greenhouse" or "greenhouse.io" in (url or ""):
+    if src == "greenhouse" or _is_greenhouse_host(url or ""):
         parsed = parse_greenhouse_url(url or "")
         if parsed:
             return probe_greenhouse(parsed[0], parsed[1], client=client)

--- a/tools/tests/test_open_question_probe.py
+++ b/tools/tests/test_open_question_probe.py
@@ -89,3 +89,28 @@ def test_essay_prompt_containing_standard_word_flagged():
         qs = _STD + [{"label": label, "required": True, "fields": [{"type": "textarea"}]}]
         r = oqp.probe_greenhouse("acme", "1", client=_fake_client(qs))
         assert r["has_open_questions"] is True, f"{label!r} should be an essay"
+
+
+def test_is_greenhouse_host_exact_and_subdomains():
+    """Hostname routing accepts greenhouse.io and its subdomains only."""
+    assert oqp._is_greenhouse_host("https://boards.greenhouse.io/acme/jobs/123")
+    assert oqp._is_greenhouse_host("https://job-boards.eu.greenhouse.io/acme/jobs/1")
+    assert oqp._is_greenhouse_host("https://greenhouse.io/x")
+
+
+def test_is_greenhouse_host_rejects_lookalike_hosts():
+    """Substring lookalikes must not route to the Greenhouse probe (CodeQL
+    py/incomplete-url-substring-sanitization regression)."""
+    assert not oqp._is_greenhouse_host("https://greenhouse.io.evil.com/jobs/123")
+    assert not oqp._is_greenhouse_host("https://evil.com/greenhouse.io")
+    assert not oqp._is_greenhouse_host("https://notgreenhouse.io/jobs/1")
+    assert not oqp._is_greenhouse_host("")
+
+
+def test_probe_open_questions_lookalike_host_not_checked():
+    """A lookalike host with a gh_jid-style path must fall through to
+    checked=False instead of being probed as Greenhouse."""
+    result = oqp.probe_open_questions(
+        "https://greenhouse.io.evil.com/acme/jobs/123", source="other"
+    )
+    assert result["checked"] is False


### PR DESCRIPTION
## Summary

Closes the actionable code-scanning backlog surfaced by a full security sweep (ticket G-1412). Dependabot (9/9), secret scanning (0), and issues (0) were already clean; this addresses the code-scanning tab.

### CodeQL highs (2) — `py/incomplete-url-substring-sanitization`
- `tools/open_question_probe.py`: routed to the Greenhouse probe on `"greenhouse.io" in url`, which also matches `greenhouse.io.evil.com`. Now `_is_greenhouse_host()` parses the hostname (greenhouse.io + subdomains only); regression tests incl. lookalike-host fallthrough.
- `tests/test_anthropic_provider.py`: the no-key-leak assertion is now hostname-exact instead of substring.

### Scorecard TokenPermissions highs (~8 workflows)
Every workflow now has top-level `contents: read`; write scopes moved to the specific jobs that need them (release-please, docker-publish, dependabot-automerge, daily-scan) or added explicitly where the workflow silently relied on the permissive default token (release-gate, release-verify). Release automation semantics unchanged — including a hand-verified fix that the release-gate merge job keeps `contents: write` (`gh pr merge` writes a merge commit; `pull-requests: write` alone 403s).

### Scorecard PinnedDependencies (~70 alerts)
- All third-party actions pinned to full commit SHAs with `# vX.Y.Z` comments. Annotated tags peeled to commit SHAs (codeql-action, claude-code-action, trivy-action) and independently re-verified against the GitHub API.
- Docker base images digest-pinned (`node:22-alpine@sha256:…`, `python:3.11-slim@sha256:…`, actionlint container).
- Workflow tool installs versioned (pip-audit, build, zizmor, commitlint, http-server, axe-core CLI); daily-scan's pip aligned to the existing `pip>=26.0` CVE floor.
- Not pinnable (dismiss-with-reason candidates): `pip install -e .`/`.` of the project itself.

### Not in this PR (need owner decision — tracked in G-1412)
Scorecard repo-practice alerts: BranchProtection (admin settings change — proposal in ticket), CodeReview (solo-dev self-merge — dismiss candidate), Fuzzing + CII badge (won't-fix candidates).

## Validation
- 37 tests pass across the two touched test files; targeted lint clean.
- All 19 workflow YAMLs parse; permission grants cross-checked against each workflow's actual `gh`/API calls.
- Scorecard alerts close on its next weekly run — CodeQL alerts close on this PR's analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUYSexq5S3Pn5iksDK5HW1