### PR TITLE
feat(G-1391): browser extension Phase 1 — THE EYE (capture + inline score + gap + auto-log)

### DIFF
--- a/extension/__tests__/ScorePanel.test.tsx
+++ b/extension/__tests__/ScorePanel.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ScorePanel } from "@/components/ScorePanel";
+import type { CaptureResponse } from "@/lib/api/messages";
+
+// ---------------------------------------------------------------------------
+// ScorePanel is PURE (props-only, no chrome.*), so it tests with props alone —
+// exactly what lets it mount unchanged in the sidePanel or an overlay fallback.
+// ---------------------------------------------------------------------------
+
+const SCORED: CaptureResponse = {
+  ok: true,
+  jobId: "42",
+  discoveredJobId: 42,
+  fitScore: 7.5,
+  letterGrade: "B",
+  scoreBreakdown: [
+    { factor: "skills", score: 3, weight: 2 },
+    { label: "seniority", score: 5 },
+  ],
+  gap: "missing: Kubernetes, Go; seniority ✓",
+};
+
+describe("ScorePanel — score/breakdown/gap render", () => {
+  it("renders the letter grade, fit score, breakdown rows, and gap verbatim", () => {
+    render(<ScorePanel result={SCORED} onPromote={vi.fn()} />);
+
+    expect(screen.getByTestId("letter-grade")).toHaveTextContent("B");
+    expect(screen.getByTestId("fit-score")).toHaveTextContent("7.5");
+    expect(screen.getByText("skills")).toBeInTheDocument();
+    expect(screen.getByText("seniority")).toBeInTheDocument();
+    expect(screen.getByTestId("gap")).toHaveTextContent(
+      "missing: Kubernetes, Go; seniority ✓",
+    );
+  });
+
+  it("tolerates an undefined breakdown and still renders score + gap", () => {
+    const noBreakdown: CaptureResponse = { ...SCORED, scoreBreakdown: undefined };
+    render(<ScorePanel result={noBreakdown} onPromote={vi.fn()} />);
+
+    expect(screen.getByTestId("letter-grade")).toHaveTextContent("B");
+    expect(screen.getByTestId("gap")).toBeInTheDocument();
+    expect(screen.queryByTestId("breakdown")).not.toBeInTheDocument();
+  });
+
+  it("skips malformed breakdown items without throwing", () => {
+    const messy: CaptureResponse = {
+      ...SCORED,
+      scoreBreakdown: [null, 7, { nope: true }, { factor: "culture", score: 4 }],
+    };
+    render(<ScorePanel result={messy} onPromote={vi.fn()} />);
+
+    const rows = screen.getByTestId("breakdown").querySelectorAll("li");
+    expect(rows).toHaveLength(1);
+    expect(screen.getByText("culture")).toBeInTheDocument();
+  });
+});
+
+describe("ScorePanel — error state", () => {
+  it("renders an alert when the capture failed", () => {
+    render(<ScorePanel result={{ ok: false, error: "backend-unreachable" }} onPromote={vi.fn()} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("backend-unreachable");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("ScorePanel — Add to pipeline", () => {
+  it("invokes onPromote with the discoveredJobId and shows the added acknowledgement", async () => {
+    const onPromote = vi.fn().mockResolvedValue(undefined);
+    render(<ScorePanel result={SCORED} onPromote={onPromote} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /add to pipeline/i }));
+
+    expect(onPromote).toHaveBeenCalledWith(42);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /added/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("shows a retry state when onPromote rejects", async () => {
+    const onPromote = vi.fn().mockRejectedValue(new Error("bad-key"));
+    render(<ScorePanel result={SCORED} onPromote={onPromote} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /add to pipeline/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /failed/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("disables the button when there is no discoveredJobId", () => {
+    const noId: CaptureResponse = { ...SCORED, discoveredJobId: undefined };
+    render(<ScorePanel result={noId} onPromote={vi.fn()} />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/extension/__tests__/autolog.test.ts
+++ b/extension/__tests__/autolog.test.ts
@@ -98,6 +98,12 @@ describe("showConfirmationBanner — visible + dismissible, never silent", () =>
     expect(host?.shadowRoot?.textContent).toContain("Log this application to Kestrel?");
   });
 
+  it("names the job (title + company) when a jobLabel is provided (MED-02)", () => {
+    showConfirmationBanner({ onLog: vi.fn(), jobLabel: "Senior Backend Engineer · Acme" });
+    const host = document.getElementById("kestrel-autolog-banner");
+    expect(host?.shadowRoot?.textContent).toContain("Senior Backend Engineer · Acme");
+  });
+
   it("Dismiss removes the banner and sends nothing", () => {
     const onLog = vi.fn();
     const onDismiss = vi.fn();
@@ -182,17 +188,32 @@ describe("startAutolog — main() load path (HIGH-01 TDZ regression)", () => {
   // `ReferenceError: Cannot access 'observer' before initialization`, the banner
   // never rendered, and auto-log was dead on its headline flow. This drives the
   // real main() wiring (not just the pure helpers) so it can't regress.
-  it("renders the banner without throwing when a confirmation page is caught on load", () => {
-    installChrome({ ok: true, discoveredJobId: 5 });
+  it("renders the banner without throwing when a confirmation page is caught on load", async () => {
+    installChrome({
+      ok: true,
+      discoveredJobId: 5,
+      title: "Senior Backend Engineer",
+      company: "Acme",
+    });
     document.body.innerHTML = '<div id="application_confirmation">Thanks for applying</div>';
     const getContext = (): DetectionContext =>
       ctx({ url: "https://boards.greenhouse.io/acme/jobs/123/confirmation" });
 
+    // The TDZ regression (HIGH-01) throws synchronously inside startAutolog, so
+    // asserting "does not throw" still guards it even though the banner now
+    // renders after an async label read.
     let teardown: () => void = () => {};
     expect(() => {
       teardown = startAutolog(getContext);
     }).not.toThrow();
-    expect(document.getElementById("kestrel-autolog-banner")).not.toBeNull();
+
+    await vi.waitFor(() => {
+      expect(document.getElementById("kestrel-autolog-banner")).not.toBeNull();
+    });
+    // MED-02: the caught-on-load banner names the captured job.
+    const host = document.getElementById("kestrel-autolog-banner");
+    expect(host?.shadowRoot?.textContent).toContain("Senior Backend Engineer");
+    expect(host?.shadowRoot?.textContent).toContain("Acme");
     teardown();
   });
 

--- a/extension/__tests__/autolog.test.ts
+++ b/extension/__tests__/autolog.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DetectionContext,
+  buildAutologMessage,
+  detectApplicationSubmit,
+  logApplication,
+  showConfirmationBanner,
+} from "@/entrypoints/autolog.content";
+
+// ---------------------------------------------------------------------------
+// The detection heuristics are PURE (no network, no chrome) and run against
+// jsdom Document/URL fixtures. The banner + logApplication are exercised with a
+// small chrome fake.
+// ---------------------------------------------------------------------------
+
+function ctx(overrides: Partial<DetectionContext>): DetectionContext {
+  return {
+    host: "boards.greenhouse.io",
+    url: "https://boards.greenhouse.io/acme/jobs/123",
+    doc: document,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  const banner = document.getElementById("kestrel-autolog-banner");
+  banner?.remove();
+});
+
+describe("detectApplicationSubmit — fires on a real submit confirmation", () => {
+  it("Greenhouse: confirmation URL", () => {
+    expect(
+      detectApplicationSubmit(
+        ctx({ url: "https://boards.greenhouse.io/acme/jobs/123/confirmation" }),
+      ),
+    ).toBe("greenhouse");
+  });
+
+  it("Greenhouse: thank-you body text", () => {
+    document.body.textContent = "Thank you for applying to Acme!";
+    expect(detectApplicationSubmit(ctx({}))).toBe("greenhouse");
+  });
+
+  it("Lever: /thanks confirmation path", () => {
+    expect(
+      detectApplicationSubmit(
+        ctx({ host: "jobs.lever.co", url: "https://jobs.lever.co/acme/abc-uuid/thanks" }),
+      ),
+    ).toBe("lever");
+  });
+
+  it("Ashby: submitted DOM marker (SPA, no navigation)", () => {
+    document.body.innerHTML = '<div data-testid="application-submitted">ok</div>';
+    expect(
+      detectApplicationSubmit(
+        ctx({ host: "jobs.ashbyhq.com", url: "https://jobs.ashbyhq.com/acme/uuid/application" }),
+      ),
+    ).toBe("ashby");
+  });
+});
+
+describe("detectApplicationSubmit — never fires spuriously", () => {
+  it("does not fire on a Greenhouse application form before submit", () => {
+    document.body.innerHTML = '<form id="application_form"><input name="email" /></form>';
+    expect(
+      detectApplicationSubmit(ctx({ url: "https://boards.greenhouse.io/acme/jobs/123" })),
+    ).toBeNull();
+  });
+
+  it("does not fire on an unrelated host even with 'application submitted' text", () => {
+    document.body.textContent = "application submitted";
+    expect(
+      detectApplicationSubmit(ctx({ host: "www.example.com", url: "https://www.example.com/x" })),
+    ).toBeNull();
+  });
+});
+
+describe("showConfirmationBanner — visible + dismissible, never silent", () => {
+  function shadowButton(action: "log" | "dismiss"): HTMLButtonElement {
+    const host = document.getElementById("kestrel-autolog-banner");
+    const btn = host?.shadowRoot?.querySelector<HTMLButtonElement>(`[data-action='${action}']`);
+    if (!btn) {
+      throw new Error(`banner ${action} button not found`);
+    }
+    return btn;
+  }
+
+  it("injects a banner asking to log, in a shadow root with static text", () => {
+    showConfirmationBanner({ onLog: vi.fn() });
+    const host = document.getElementById("kestrel-autolog-banner");
+    expect(host).not.toBeNull();
+    expect(host?.shadowRoot?.textContent).toContain("Log this application to Kestrel?");
+  });
+
+  it("Dismiss removes the banner and sends nothing", () => {
+    const onLog = vi.fn();
+    const onDismiss = vi.fn();
+    showConfirmationBanner({ onLog, onDismiss });
+
+    shadowButton("dismiss").click();
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onLog).not.toHaveBeenCalled();
+    expect(document.getElementById("kestrel-autolog-banner")).toBeNull();
+  });
+
+  it("Log invokes onLog and removes the banner", () => {
+    const onLog = vi.fn();
+    showConfirmationBanner({ onLog });
+
+    shadowButton("log").click();
+
+    expect(onLog).toHaveBeenCalledOnce();
+    expect(document.getElementById("kestrel-autolog-banner")).toBeNull();
+  });
+});
+
+describe("logApplication — promotes the captured job through the worker", () => {
+  function installChrome(lastCapture?: unknown): ReturnType<typeof vi.fn> {
+    const store: Record<string, unknown> = {};
+    if (lastCapture !== undefined) {
+      store.lastCapture = lastCapture;
+    }
+    const sendMessage = vi.fn(async () => ({ ok: true }));
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      storage: {
+        session: {
+          get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
+        },
+      },
+      runtime: { sendMessage },
+    };
+    return sendMessage;
+  }
+
+  it("sends PROMOTE with the last captured discoveredJobId", async () => {
+    const sendMessage = installChrome({ ok: true, discoveredJobId: 99 });
+
+    await logApplication();
+
+    expect(sendMessage).toHaveBeenCalledWith({ type: "PROMOTE", discoveredJobId: 99 });
+  });
+
+  it("sends nothing when no job was captured (no silent create)", async () => {
+    const sendMessage = installChrome(undefined);
+
+    await logApplication();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("buildAutologMessage builds the PROMOTE message", () => {
+    expect(buildAutologMessage(7)).toEqual({ type: "PROMOTE", discoveredJobId: 7 });
+  });
+});

--- a/extension/__tests__/autolog.test.ts
+++ b/extension/__tests__/autolog.test.ts
@@ -5,6 +5,7 @@ import {
   detectApplicationSubmit,
   logApplication,
   showConfirmationBanner,
+  startAutolog,
 } from "@/entrypoints/autolog.content";
 
 // ---------------------------------------------------------------------------
@@ -156,5 +157,56 @@ describe("logApplication — promotes the captured job through the worker", () =
 
   it("buildAutologMessage builds the PROMOTE message", () => {
     expect(buildAutologMessage(7)).toEqual({ type: "PROMOTE", discoveredJobId: 7 });
+  });
+});
+
+describe("startAutolog — main() load path (HIGH-01 TDZ regression)", () => {
+  function installChrome(lastCapture?: unknown): void {
+    const store: Record<string, unknown> = {};
+    if (lastCapture !== undefined) {
+      store.lastCapture = lastCapture;
+    }
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      storage: {
+        session: {
+          get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
+        },
+      },
+      runtime: { sendMessage: vi.fn(async () => ({ ok: true })) },
+    };
+  }
+
+  // Regression guard for HIGH-01: on a full-navigation confirmation page the very
+  // first synchronous maybeConfirm() reaches observer.disconnect(). Before the
+  // fix `observer` was a `const` declared AFTER that call, so this path threw
+  // `ReferenceError: Cannot access 'observer' before initialization`, the banner
+  // never rendered, and auto-log was dead on its headline flow. This drives the
+  // real main() wiring (not just the pure helpers) so it can't regress.
+  it("renders the banner without throwing when a confirmation page is caught on load", () => {
+    installChrome({ ok: true, discoveredJobId: 5 });
+    document.body.innerHTML = '<div id="application_confirmation">Thanks for applying</div>';
+    const getContext = (): DetectionContext =>
+      ctx({ url: "https://boards.greenhouse.io/acme/jobs/123/confirmation" });
+
+    let teardown: () => void = () => {};
+    expect(() => {
+      teardown = startAutolog(getContext);
+    }).not.toThrow();
+    expect(document.getElementById("kestrel-autolog-banner")).not.toBeNull();
+    teardown();
+  });
+
+  it("does not render a banner on a pre-submit form (no confirmation signal)", () => {
+    installChrome({ ok: true, discoveredJobId: 5 });
+    document.body.innerHTML = '<form id="application_form"><input name="email" /></form>';
+    const getContext = (): DetectionContext =>
+      ctx({ url: "https://boards.greenhouse.io/acme/jobs/123" });
+
+    let teardown: () => void = () => {};
+    expect(() => {
+      teardown = startAutolog(getContext);
+    }).not.toThrow();
+    expect(document.getElementById("kestrel-autolog-banner")).toBeNull();
+    teardown();
   });
 });

--- a/extension/__tests__/background.test.ts
+++ b/extension/__tests__/background.test.ts
@@ -9,13 +9,18 @@ import { setBackendUrl } from "@/lib/storage";
 
 function installFakeStorage(): Record<string, unknown> {
   const store: Record<string, unknown> = {};
-  const local = {
+  // One backing object shared by `local` and `session`: the keys never collide
+  // (extensionToken/backendUrl vs lastCapture), so a single record keeps the
+  // fake tiny while letting tests assert `store.lastCapture` from session.set.
+  const area = {
     get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
     set: vi.fn(async (items: Record<string, unknown>) => {
       Object.assign(store, items);
     }),
   };
-  (globalThis as unknown as { chrome: unknown }).chrome = { storage: { local } };
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: { local: area, session: area },
+  };
   return store;
 }
 
@@ -134,6 +139,8 @@ describe("CAPTURE", () => {
       scoreBreakdown: [{ factor: "skills", score: 3 }],
       gap: "missing: Kubernetes, Go; seniority ✓",
     });
+    // The score is stashed in session storage for the sidePanel to read on open.
+    expect(store.lastCapture).toEqual(res);
   });
 
   it("forwards a raw_text payload and tolerates a null score_breakdown", async () => {
@@ -169,6 +176,41 @@ describe("CAPTURE", () => {
     expect(res.gap).toBe("no major keyword gaps; seniority ✓");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string).raw_text).toBe("Whole page text.");
+  });
+});
+
+describe("PROMOTE", () => {
+  it("errors and never calls fetch when there is no stored token", async () => {
+    const fetchMock = routeFetch({});
+
+    const res = await handleMessage({ type: "PROMOTE", discoveredJobId: 42 });
+
+    expect(res).toEqual({ ok: false, error: "not-paired" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("promotes a captured job through the worker and returns the application id", async () => {
+    store.extensionToken = "tok-xyz";
+    const fetchMock = routeFetch({
+      "/api/extension/promote": jsonResponse({ application_id: 7, status: "discovered" }),
+    });
+
+    const res = await handleMessage({ type: "PROMOTE", discoveredJobId: 42 });
+
+    expect(res).toEqual({ ok: true, applicationId: 7, status: "discovered" });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.credentials).toBe("omit");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-xyz");
+    expect(JSON.parse(init.body as string).discovered_job_id).toBe(42);
+  });
+
+  it("maps a 401 to bad-key", async () => {
+    store.extensionToken = "stale";
+    routeFetch({ "/api/extension/promote": jsonResponse({ detail: "no" }, 401) });
+
+    const res = await handleMessage({ type: "PROMOTE", discoveredJobId: 42 });
+
+    expect(res).toEqual({ ok: false, error: "bad-key" });
   });
 });
 

--- a/extension/__tests__/background.test.ts
+++ b/extension/__tests__/background.test.ts
@@ -107,7 +107,8 @@ describe("CAPTURE", () => {
 
     const res = await handleMessage({ type: "CAPTURE", payload: SAMPLE_PAYLOAD });
 
-    expect(res).toEqual({ ok: true, jobId: "job-1" });
+    // Captured identity (title/company) is echoed back for the auto-log banner.
+    expect(res).toEqual({ ok: true, jobId: "job-1", title: "Staff Engineer", company: "Acme" });
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(init.credentials).toBe("omit");
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-xyz");
@@ -133,6 +134,8 @@ describe("CAPTURE", () => {
     expect(res).toEqual({
       ok: true,
       jobId: "42",
+      title: "Staff Engineer",
+      company: "Acme",
       discoveredJobId: 42,
       fitScore: 7.5,
       letterGrade: "B",

--- a/extension/__tests__/background.test.ts
+++ b/extension/__tests__/background.test.ts
@@ -107,6 +107,69 @@ describe("CAPTURE", () => {
     expect(init.credentials).toBe("omit");
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-xyz");
   });
+
+  it("passes the score fields through when the backend scores the capture", async () => {
+    store.extensionToken = "tok-xyz";
+    routeFetch({
+      "/api/extension/capture": jsonResponse({
+        job_id: "42",
+        status: "scored",
+        scored: true,
+        discovered_job_id: 42,
+        fit_score: 7.5,
+        letter_grade: "B",
+        score_breakdown: [{ factor: "skills", score: 3 }],
+        gap: "missing: Kubernetes, Go; seniority ✓",
+      }),
+    });
+
+    const res = await handleMessage({ type: "CAPTURE", payload: SAMPLE_PAYLOAD });
+
+    expect(res).toEqual({
+      ok: true,
+      jobId: "42",
+      discoveredJobId: 42,
+      fitScore: 7.5,
+      letterGrade: "B",
+      scoreBreakdown: [{ factor: "skills", score: 3 }],
+      gap: "missing: Kubernetes, Go; seniority ✓",
+    });
+  });
+
+  it("forwards a raw_text payload and tolerates a null score_breakdown", async () => {
+    store.extensionToken = "tok-xyz";
+    const fetchMock = routeFetch({
+      "/api/extension/capture": jsonResponse({
+        job_id: "9",
+        status: "scored",
+        scored: true,
+        discovered_job_id: 9,
+        fit_score: 5,
+        letter_grade: "C",
+        score_breakdown: null,
+        gap: "no major keyword gaps; seniority ✓",
+      }),
+    });
+
+    const rawPayload: CapturePayload = {
+      url: "https://jobs.example.com/raw",
+      title: "",
+      company: "",
+      description: "Whole page text.",
+      raw_text: "Whole page text.",
+    };
+    const res = (await handleMessage({ type: "CAPTURE", payload: rawPayload })) as {
+      ok: boolean;
+      scoreBreakdown?: unknown[];
+      gap?: string;
+    };
+
+    expect(res.ok).toBe(true);
+    expect(res.scoreBreakdown).toBeUndefined();
+    expect(res.gap).toBe("no major keyword gaps; seniority ✓");
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).raw_text).toBe("Whole page text.");
+  });
 });
 
 describe("STATUS", () => {

--- a/extension/__tests__/extraction.test.ts
+++ b/extension/__tests__/extraction.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { extractJob, isJobPage } from "@/lib/extraction";
+
+// ---------------------------------------------------------------------------
+// Extraction is a pure function over a `Document`, so every case builds a
+// jsdom document via DOMParser (no network, no chrome runtime).
+// ---------------------------------------------------------------------------
+
+function doc(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}
+
+function jsonLdScript(payload: unknown): string {
+  return `<script type="application/ld+json">${JSON.stringify(payload)}</script>`;
+}
+
+describe("Tier 1: JSON-LD JobPosting", () => {
+  it("extracts a LinkedIn-style JobPosting with structured confidence", () => {
+    const d = doc(`
+      <html><head>
+        <link rel="canonical" href="https://www.linkedin.com/jobs/view/123" />
+        ${jsonLdScript({
+          "@context": "https://schema.org/",
+          "@type": "JobPosting",
+          title: "Senior Backend Engineer",
+          description: "<p>Build <strong>distributed</strong> systems in Go.</p>",
+          hiringOrganization: { "@type": "Organization", name: "Acme Corp" },
+          jobLocation: {
+            "@type": "Place",
+            address: { "@type": "PostalAddress", addressLocality: "Remote", addressRegion: "CA" },
+          },
+          baseSalary: {
+            "@type": "MonetaryAmount",
+            currency: "USD",
+            value: { "@type": "QuantitativeValue", minValue: 150000, maxValue: 180000, unitText: "YEAR" },
+          },
+        })}
+      </head><body></body></html>
+    `);
+
+    const job = extractJob(d);
+    expect(job.confidence).toBe("structured");
+    expect(job.title).toBe("Senior Backend Engineer");
+    expect(job.company).toBe("Acme Corp");
+    // HTML must be stripped to plain text.
+    expect(job.description).toBe("Build distributed systems in Go.");
+    expect(job.description).not.toContain("<");
+    expect(job.location).toBe("Remote, CA");
+    expect(job.salary).toContain("150000");
+    expect(job.salary).toContain("180000");
+    expect(job.url).toBe("https://www.linkedin.com/jobs/view/123");
+    expect(job.source).toBe("www.linkedin.com");
+  });
+
+  it("finds a JobPosting nested inside an @graph array", () => {
+    const d = doc(`
+      <html><head>
+        ${jsonLdScript({
+          "@context": "https://schema.org/",
+          "@graph": [
+            { "@type": "WebSite", name: "Greenhouse" },
+            {
+              "@type": "JobPosting",
+              title: "Product Manager",
+              description: "Own the roadmap.",
+              hiringOrganization: { name: "Boards Inc" },
+            },
+          ],
+        })}
+      </head><body></body></html>
+    `);
+
+    const job = extractJob(d);
+    expect(job.confidence).toBe("structured");
+    expect(job.title).toBe("Product Manager");
+    expect(job.company).toBe("Boards Inc");
+    expect(job.description).toBe("Own the roadmap.");
+  });
+
+  it("handles a hiringOrganization given as a bare string", () => {
+    const d = doc(
+      `<html><head>${jsonLdScript({
+        "@type": "JobPosting",
+        title: "Data Scientist",
+        description: "Models.",
+        hiringOrganization: "Stringly Co",
+      })}</head><body></body></html>`,
+    );
+    const job = extractJob(d);
+    expect(job.company).toBe("Stringly Co");
+    expect(job.confidence).toBe("structured");
+  });
+
+  it("recognizes an @type array that includes JobPosting", () => {
+    const d = doc(
+      `<html><head>${jsonLdScript({
+        "@type": ["JobPosting", "Thing"],
+        title: "SRE",
+        description: "Keep it up.",
+        hiringOrganization: { name: "Uptime LLC" },
+      })}</head><body></body></html>`,
+    );
+    const job = extractJob(d);
+    expect(job.title).toBe("SRE");
+    expect(job.company).toBe("Uptime LLC");
+  });
+});
+
+describe("Tier 2: OpenGraph / meta fallback", () => {
+  it("extracts title + company from OG tags when no JSON-LD is present", () => {
+    const d = doc(`
+      <html><head>
+        <meta property="og:title" content="Staff Frontend Engineer" />
+        <meta property="og:description" content="React and TypeScript all day." />
+        <meta property="og:site_name" content="Lever" />
+        <meta property="og:url" content="https://jobs.lever.co/acme/xyz" />
+      </head><body></body></html>
+    `);
+
+    const job = extractJob(d);
+    expect(job.confidence).toBe("structured");
+    expect(job.title).toBe("Staff Frontend Engineer");
+    expect(job.company).toBe("Lever");
+    expect(job.description).toBe("React and TypeScript all day.");
+    expect(job.url).toBe("https://jobs.lever.co/acme/xyz");
+    expect(job.source).toBe("jobs.lever.co");
+  });
+
+  it("degrades to raw when OG has a title but no derivable company", () => {
+    const d = doc(`
+      <html><head>
+        <meta property="og:title" content="Some Job" />
+      </head><body>Full posting body text about the role.</body></html>
+    `);
+
+    const job = extractJob(d);
+    expect(job.confidence).toBe("raw");
+    // Raw tier fills description with page text for the backend LLM fallback.
+    expect(job.description).toContain("Full posting body text");
+  });
+});
+
+describe("Tier 3: raw-text fallback", () => {
+  it("returns raw confidence with body text when nothing structured exists", () => {
+    const d = doc(`
+      <html><head><title>Careers</title></head>
+      <body><main>We are hiring a Widget Designer. Apply within.</main></body></html>
+    `);
+
+    const job = extractJob(d);
+    expect(job.confidence).toBe("raw");
+    expect(job.title).toBe("");
+    expect(job.company).toBe("");
+    expect(job.description).toContain("Widget Designer");
+  });
+
+  it("caps raw description length", () => {
+    const big = "x".repeat(50000);
+    const d = doc(`<html><body>${big}</body></html>`);
+    const job = extractJob(d);
+    expect(job.confidence).toBe("raw");
+    expect(job.description.length).toBeLessThanOrEqual(30000);
+  });
+});
+
+describe("defensive parsing", () => {
+  it("does not throw on malformed JSON-LD and falls through to a lower tier", () => {
+    const d = doc(`
+      <html><head>
+        <script type="application/ld+json">{ this is not valid json ]</script>
+        <meta property="og:title" content="Resilient Role" />
+        <meta property="og:site_name" content="Ashby" />
+      </head><body>fallback body</body></html>
+    `);
+
+    expect(() => extractJob(d)).not.toThrow();
+    const job = extractJob(d);
+    // Malformed JSON-LD ignored → OG tier wins.
+    expect(job.title).toBe("Resilient Role");
+    expect(job.company).toBe("Ashby");
+    expect(job.confidence).toBe("structured");
+  });
+
+  it("ignores a JSON-LD block that is valid JSON but not a JobPosting", () => {
+    const d = doc(
+      `<html><head>${jsonLdScript({ "@type": "BreadcrumbList", itemListElement: [] })}</head>` +
+        `<body>raw only body</body></html>`,
+    );
+    const job = extractJob(d);
+    expect(job.confidence).toBe("raw");
+    expect(job.description).toContain("raw only body");
+  });
+});
+
+describe("isJobPage", () => {
+  it("is true when a JSON-LD JobPosting is present", () => {
+    const d = doc(
+      `<html><head>${jsonLdScript({ "@type": "JobPosting", title: "X", hiringOrganization: { name: "Y" } })}</head><body></body></html>`,
+    );
+    expect(isJobPage(d)).toBe(true);
+  });
+
+  it("is false on a page with no JobPosting signal", () => {
+    const d = doc(`<html><body>just a blog</body></html>`);
+    expect(isJobPage(d)).toBe(false);
+  });
+});

--- a/extension/components/ScorePanel.tsx
+++ b/extension/components/ScorePanel.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import type { CaptureResponse } from "@/lib/api/messages";
+
+/**
+ * Surface-agnostic score/gap presentation for "the eye". PURE — it takes a
+ * capture result via props and emits an `onPromote` callback; it makes NO
+ * `chrome.*` calls, so it unit-tests with props alone and mounts unchanged in
+ * EITHER the MV3 sidePanel OR an in-page shadow-DOM overlay fallback (01-04
+ * LOCKED design decision).
+ *
+ * It renders Kestrel's fit score + letter grade, a defensively-narrowed score
+ * breakdown, the plain-language gap string, and a one-click "Add to pipeline"
+ * button that promotes the captured job through the caller's `onPromote`.
+ */
+
+/** The capture result this panel renders (the 01-03 CAPTURE response shape). */
+export type CaptureResult = CaptureResponse;
+
+export interface ScorePanelProps {
+  readonly result: CaptureResult;
+  readonly onPromote: (discoveredJobId: number) => Promise<void> | void;
+}
+
+/** One row of the score breakdown, narrowed from the untyped backend JSON. */
+interface BreakdownRow {
+  readonly label: string;
+  readonly score?: number;
+  readonly weight?: number;
+}
+
+/**
+ * Narrow one untyped `scoreBreakdown` item to a renderable row, or `null` if it
+ * is malformed. The backend factor dicts are `{factor|label|name, score, weight}`
+ * shaped, but the wire type is `unknown[]` — never trust it, narrow at the boundary.
+ */
+function narrowRow(item: unknown): BreakdownRow | null {
+  if (typeof item !== "object" || item === null) {
+    return null;
+  }
+  const rec = item as Record<string, unknown>;
+  const rawLabel = rec.factor ?? rec.label ?? rec.name;
+  if (typeof rawLabel !== "string" || rawLabel.trim() === "") {
+    return null;
+  }
+  return {
+    label: rawLabel,
+    score: typeof rec.score === "number" ? rec.score : undefined,
+    weight: typeof rec.weight === "number" ? rec.weight : undefined,
+  };
+}
+
+type PromoteState = "idle" | "pending" | "done" | "error";
+
+const PROMOTE_LABEL: Record<PromoteState, string> = {
+  idle: "Add to pipeline",
+  pending: "Adding…",
+  done: "Added ✓",
+  error: "Failed — retry",
+};
+
+export function ScorePanel({ result, onPromote }: ScorePanelProps) {
+  const [promoteState, setPromoteState] = useState<PromoteState>("idle");
+
+  if (!result.ok) {
+    return (
+      <section
+        style={{ padding: 16, fontFamily: "system-ui, sans-serif", color: "#842029" }}
+        role="alert"
+      >
+        <h1 style={{ fontSize: 15, margin: "0 0 6px" }}>Kestrel</h1>
+        <p style={{ fontSize: 13, margin: 0 }}>
+          {result.error === "not-paired"
+            ? "Not paired — open Options to pair first."
+            : `Capture failed${result.error ? ` (${result.error})` : ""}. Try again.`}
+        </p>
+      </section>
+    );
+  }
+
+  const rows = (result.scoreBreakdown ?? [])
+    .map(narrowRow)
+    .filter((row): row is BreakdownRow => row !== null);
+
+  const canPromote =
+    typeof result.discoveredJobId === "number" && promoteState !== "pending" && promoteState !== "done";
+
+  async function handlePromote() {
+    if (typeof result.discoveredJobId !== "number") {
+      return;
+    }
+    setPromoteState("pending");
+    try {
+      await onPromote(result.discoveredJobId);
+      setPromoteState("done");
+    } catch {
+      setPromoteState("error");
+    }
+  }
+
+  return (
+    <section style={{ padding: 16, fontFamily: "system-ui, sans-serif", color: "#1f2937" }}>
+      <h1 style={{ fontSize: 15, margin: "0 0 12px" }}>Kestrel score</h1>
+
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 12 }}>
+        <span style={{ fontSize: 34, fontWeight: 700, lineHeight: 1 }} data-testid="letter-grade">
+          {result.letterGrade ?? "—"}
+        </span>
+        {result.fitScore != null && (
+          <span style={{ fontSize: 15, color: "#4b5563" }} data-testid="fit-score">
+            fit {result.fitScore}
+          </span>
+        )}
+      </div>
+
+      {rows.length > 0 && (
+        <ul style={{ listStyle: "none", padding: 0, margin: "0 0 12px" }} data-testid="breakdown">
+          {rows.map((row, i) => (
+            <li
+              key={`${row.label}-${i}`}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 13,
+                padding: "3px 0",
+                borderBottom: "1px solid #f0f0f0",
+              }}
+            >
+              <span>{row.label}</span>
+              <span style={{ color: "#4b5563" }}>
+                {row.score != null ? row.score : "—"}
+                {row.weight != null ? ` ×${row.weight}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {result.gap && (
+        <p
+          style={{
+            fontSize: 13,
+            lineHeight: 1.4,
+            background: "#f9fafb",
+            border: "1px solid #eef0f2",
+            borderRadius: 6,
+            padding: "8px 10px",
+            margin: "0 0 14px",
+          }}
+          data-testid="gap"
+        >
+          {result.gap}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handlePromote}
+        disabled={!canPromote}
+        style={{
+          width: "100%",
+          padding: "9px 12px",
+          fontSize: 13,
+          fontWeight: 600,
+          border: 0,
+          borderRadius: 8,
+          background: canPromote ? "#1f2937" : "#9ca3af",
+          color: "#fff",
+          cursor: canPromote ? "pointer" : "default",
+        }}
+      >
+        {typeof result.discoveredJobId === "number"
+          ? PROMOTE_LABEL[promoteState]
+          : "Add to pipeline (capture first)"}
+      </button>
+    </section>
+  );
+}

--- a/extension/entrypoints/autolog.content.ts
+++ b/extension/entrypoints/autolog.content.ts
@@ -1,0 +1,239 @@
+import { defineContentScript } from "#imports";
+import type { ExtMessage } from "@/lib/api/messages";
+import { getLastDiscoveredJobId } from "@/lib/storage";
+
+/**
+ * Auto-log-on-submit for recognized ATSes (Greenhouse / Lever / Ashby). When the
+ * user submits an application, this script shows a VISIBLE, DISMISSIBLE banner
+ * ("Log this application to Kestrel?") and only writes to the pipeline if the
+ * user clicks Log. There is NO silent path — silent auto-logging (Simplify's
+ * anti-pattern, threat T-01D-01) is exactly what we refuse to do.
+ *
+ * SCOPE GUARD: this NEVER fills a form, submits a form, or reads field values.
+ * It reads submit/confirmation SIGNALS only (T-01D-03) and, on the user's
+ * confirmation, promotes the previously-captured job through the background
+ * worker — that is all "logging" means here.
+ */
+
+export type AtsId = "greenhouse" | "lever" | "ashby";
+
+export interface DetectionContext {
+  readonly host: string;
+  readonly url: string;
+  readonly doc: Document;
+}
+
+const BANNER_ID = "kestrel-autolog-banner";
+
+/** Which ATS (if any) a host belongs to. */
+function atsForHost(host: string): AtsId | null {
+  const h = host.toLowerCase();
+  if (h === "boards.greenhouse.io" || h.endsWith(".greenhouse.io") || h === "greenhouse.io") {
+    return "greenhouse";
+  }
+  if (h === "jobs.lever.co" || h.endsWith(".lever.co") || h === "lever.co") {
+    return "lever";
+  }
+  if (h === "jobs.ashbyhq.com" || h.endsWith(".ashbyhq.com") || h === "ashbyhq.com") {
+    return "ashby";
+  }
+  return null;
+}
+
+/** Lowercased body text, defensively (no throw on a detached document). */
+function bodyText(doc: Document): string {
+  return (doc.body?.textContent ?? "").toLowerCase();
+}
+
+/** Per-ATS post-submit confirmation signal. */
+function isConfirmed(ats: AtsId, ctx: DetectionContext): boolean {
+  const url = ctx.url.toLowerCase();
+  const text = bodyText(ctx.doc);
+  switch (ats) {
+    case "greenhouse":
+      return (
+        url.includes("/confirmation") ||
+        ctx.doc.querySelector("#application_confirmation") !== null ||
+        text.includes("thank you for applying") ||
+        text.includes("your application has been submitted")
+      );
+    case "lever":
+      return (
+        /\/(apply\/)?thanks\b/.test(url) ||
+        ctx.doc.querySelector("[data-qa='thanks'], .application-confirmation") !== null ||
+        text.includes("thank you for applying") ||
+        text.includes("application submitted")
+      );
+    case "ashby":
+      return (
+        url.includes("/application/success") ||
+        ctx.doc.querySelector(
+          "[data-testid='application-submitted'], .ashby-application-form-success",
+        ) !== null ||
+        text.includes("application submitted") ||
+        text.includes("thanks for applying")
+      );
+  }
+}
+
+/**
+ * PURE detection: returns the ATS whose application-submit confirmation is
+ * present on the current page, or `null`. Never fires on an unrelated host or a
+ * pre-submit application form (no confirmation signal yet).
+ */
+export function detectApplicationSubmit(ctx: DetectionContext): AtsId | null {
+  const ats = atsForHost(ctx.host);
+  if (!ats) {
+    return null;
+  }
+  return isConfirmed(ats, ctx) ? ats : null;
+}
+
+/** The runtime message an auto-log confirmation sends (promote the captured job). */
+export function buildAutologMessage(discoveredJobId: number): ExtMessage {
+  return { type: "PROMOTE", discoveredJobId };
+}
+
+export interface BannerHandle {
+  readonly host: HTMLElement;
+  readonly remove: () => void;
+}
+
+export interface BannerOptions {
+  readonly onLog: () => void;
+  readonly onDismiss?: () => void;
+}
+
+/**
+ * Inject the dismissible confirmation banner into a shadow root (so host-page CSS
+ * cannot bleed in and page content cannot inject markup — T-01D-04: static text
+ * only, never page-derived innerHTML). Returns a handle to remove it. Log and
+ * Dismiss both remove the banner; only Log invokes `onLog`.
+ */
+export function showConfirmationBanner(options: BannerOptions): BannerHandle {
+  const existing = document.getElementById(BANNER_ID);
+  if (existing) {
+    existing.remove();
+  }
+
+  const host = document.createElement("div");
+  host.id = BANNER_ID;
+  Object.assign(host.style, {
+    position: "fixed",
+    bottom: "20px",
+    left: "20px",
+    zIndex: "2147483647",
+  });
+  const shadow = host.attachShadow({ mode: "open" });
+
+  const card = document.createElement("div");
+  card.style.cssText =
+    "font: 500 13px system-ui, sans-serif; color: #111; background: #fff;" +
+    "border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px 14px;" +
+    "box-shadow: 0 4px 16px rgba(0,0,0,.18); display: flex; gap: 10px; align-items: center;";
+
+  const label = document.createElement("span");
+  label.textContent = "Log this application to Kestrel?";
+
+  const logBtn = document.createElement("button");
+  logBtn.type = "button";
+  logBtn.textContent = "Log";
+  logBtn.setAttribute("data-action", "log");
+  logBtn.style.cssText =
+    "font: 600 13px system-ui; padding: 6px 12px; border: 0; border-radius: 7px;" +
+    "background: #1f2937; color: #fff; cursor: pointer;";
+
+  const dismissBtn = document.createElement("button");
+  dismissBtn.type = "button";
+  dismissBtn.textContent = "Dismiss";
+  dismissBtn.setAttribute("data-action", "dismiss");
+  dismissBtn.style.cssText =
+    "font: 600 13px system-ui; padding: 6px 12px; border: 1px solid #d1d5db;" +
+    "border-radius: 7px; background: #fff; color: #374151; cursor: pointer;";
+
+  const handle: BannerHandle = {
+    host,
+    remove: () => host.remove(),
+  };
+
+  logBtn.addEventListener("click", () => {
+    options.onLog();
+    handle.remove();
+  });
+  dismissBtn.addEventListener("click", () => {
+    options.onDismiss?.();
+    handle.remove();
+  });
+
+  card.append(label, logBtn, dismissBtn);
+  shadow.appendChild(card);
+  document.body.appendChild(host);
+  return handle;
+}
+
+/**
+ * On the user's Log confirmation: promote the previously-captured job through the
+ * worker. If nothing was captured (no discoveredJobId in session), there is
+ * nothing to promote — we do nothing rather than guess (auto-log only LOGS a job
+ * the user already captured; it never creates from scraped form data).
+ */
+export async function logApplication(): Promise<void> {
+  const discoveredJobId = await getLastDiscoveredJobId();
+  if (typeof discoveredJobId !== "number") {
+    return;
+  }
+  await chrome.runtime.sendMessage(buildAutologMessage(discoveredJobId));
+}
+
+export default defineContentScript({
+  // Explicit ATS application-host allowlist — NEVER a wildcard or broad-host
+  // match. This script runs only on recognized ATS pages to watch for a submit.
+  matches: [
+    "*://boards.greenhouse.io/*",
+    "*://*.greenhouse.io/*",
+    "*://jobs.lever.co/*",
+    "*://*.ashbyhq.com/*",
+  ],
+  main() {
+    let bannerShown = false;
+
+    const ctx = (): DetectionContext => ({
+      host: location.hostname,
+      url: location.href,
+      doc: document,
+    });
+
+    const maybeConfirm = (): void => {
+      if (bannerShown || !document.body) {
+        return;
+      }
+      if (detectApplicationSubmit(ctx()) === null) {
+        return;
+      }
+      bannerShown = true;
+      observer.disconnect();
+      showConfirmationBanner({
+        onLog: () => void logApplication(),
+        onDismiss: () => {
+          bannerShown = false;
+        },
+      });
+    };
+
+    // 1) A full-navigation confirmation page (Greenhouse/Lever) is caught on load.
+    maybeConfirm();
+
+    // 2) An in-page/AJAX submit (Ashby SPA, Lever): re-check shortly after submit.
+    document.addEventListener(
+      "submit",
+      () => {
+        setTimeout(maybeConfirm, 800);
+      },
+      true,
+    );
+
+    // 3) SPA success states that swap DOM without navigation: observe until shown.
+    const observer = new MutationObserver(() => maybeConfirm());
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  },
+});

--- a/extension/entrypoints/autolog.content.ts
+++ b/extension/entrypoints/autolog.content.ts
@@ -1,6 +1,6 @@
 import { defineContentScript } from "#imports";
 import type { ExtMessage } from "@/lib/api/messages";
-import { getLastDiscoveredJobId } from "@/lib/storage";
+import { getLastCaptureLabel, getLastDiscoveredJobId } from "@/lib/storage";
 
 /**
  * Auto-log-on-submit for recognized ATSes (Greenhouse / Lever / Ashby). When the
@@ -102,6 +102,11 @@ export interface BannerHandle {
 export interface BannerOptions {
   readonly onLog: () => void;
   readonly onDismiss?: () => void;
+  /**
+   * "Title · Company" of the job being logged. Rendered as static text so the
+   * user can see WHAT is about to be logged (MED-02). Omitted → generic prompt.
+   */
+  readonly jobLabel?: string | null;
 }
 
 /**
@@ -133,7 +138,12 @@ export function showConfirmationBanner(options: BannerOptions): BannerHandle {
     "box-shadow: 0 4px 16px rgba(0,0,0,.18); display: flex; gap: 10px; align-items: center;";
 
   const label = document.createElement("span");
-  label.textContent = "Log this application to Kestrel?";
+  // Static textContent only (never innerHTML) — the job label is app-derived,
+  // but keeping it textContent preserves the T-01D-04 no-page-markup guarantee.
+  const jobLabel = options.jobLabel?.trim();
+  label.textContent = jobLabel
+    ? `Log "${jobLabel}" to Kestrel?`
+    : "Log this application to Kestrel?";
 
   const logBtn = document.createElement("button");
   logBtn.type = "button";
@@ -220,14 +230,24 @@ export function startAutolog(
     if (detectApplicationSubmit(getContext()) === null) {
       return;
     }
+    // Flip the guard synchronously (before the async label read) so a
+    // concurrent observer/submit callback can't double-show the banner.
     bannerShown = true;
     observer.disconnect();
-    showConfirmationBanner({
-      onLog: () => void logApplication(),
-      onDismiss: () => {
-        bannerShown = false;
-      },
-    });
+    // Read the captured job's identity, then render it in the banner so the user
+    // sees WHAT is about to be logged (MED-02). The label read is best-effort:
+    // on failure we still show the (generic) banner.
+    void getLastCaptureLabel()
+      .catch(() => null)
+      .then((jobLabel) => {
+        showConfirmationBanner({
+          jobLabel,
+          onLog: () => void logApplication(),
+          onDismiss: () => {
+            bannerShown = false;
+          },
+        });
+      });
   };
 
   const onSubmit = (): void => {

--- a/extension/entrypoints/autolog.content.ts
+++ b/extension/entrypoints/autolog.content.ts
@@ -185,6 +185,72 @@ export async function logApplication(): Promise<void> {
   await chrome.runtime.sendMessage(buildAutologMessage(discoveredJobId));
 }
 
+/**
+ * Wire up the three auto-log detection triggers (caught-on-load, post-submit,
+ * SPA DOM-swap). Extracted from `main()` so it is unit-testable under jsdom by
+ * injecting a `getContext` factory (the default reads `location`/`document`).
+ *
+ * ORDERING (HIGH-01): `observer` is created and assigned BEFORE the first
+ * `maybeConfirm()` call. On a full-navigation confirmation page (Greenhouse
+ * `/confirmation`, Lever `/thanks`) the content script runs fresh and
+ * `detectApplicationSubmit` returns non-null on that first synchronous call, so
+ * `maybeConfirm` reaches `observer.disconnect()` immediately. If `observer` were
+ * still in the temporal dead zone there it would throw
+ * `ReferenceError: Cannot access 'observer' before initialization`, unwinding
+ * `main()` and killing auto-log on its headline path. The `MutationObserver`
+ * callback only *calls* `maybeConfirm` on a later DOM mutation, so referencing
+ * `maybeConfirm` at observer-construction time is safe.
+ */
+export function startAutolog(
+  getContext: () => DetectionContext = () => ({
+    host: location.hostname,
+    url: location.href,
+    doc: document,
+  }),
+): () => void {
+  let bannerShown = false;
+
+  // Assigned before any maybeConfirm() call (see ORDERING note above).
+  const observer = new MutationObserver(() => maybeConfirm());
+
+  const maybeConfirm = (): void => {
+    if (bannerShown || !document.body) {
+      return;
+    }
+    if (detectApplicationSubmit(getContext()) === null) {
+      return;
+    }
+    bannerShown = true;
+    observer.disconnect();
+    showConfirmationBanner({
+      onLog: () => void logApplication(),
+      onDismiss: () => {
+        bannerShown = false;
+      },
+    });
+  };
+
+  const onSubmit = (): void => {
+    setTimeout(maybeConfirm, 800);
+  };
+
+  // SPA success states that swap DOM without navigation: observe until shown.
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+
+  // 1) A full-navigation confirmation page (Greenhouse/Lever) is caught on load.
+  maybeConfirm();
+
+  // 2) An in-page/AJAX submit (Ashby SPA, Lever): re-check shortly after submit.
+  document.addEventListener("submit", onSubmit, true);
+
+  // Teardown for tests / hot-reload; the live content script runs for the page
+  // lifetime and never needs it.
+  return () => {
+    observer.disconnect();
+    document.removeEventListener("submit", onSubmit, true);
+  };
+}
+
 export default defineContentScript({
   // Explicit ATS application-host allowlist — NEVER a wildcard or broad-host
   // match. This script runs only on recognized ATS pages to watch for a submit.
@@ -195,45 +261,6 @@ export default defineContentScript({
     "*://*.ashbyhq.com/*",
   ],
   main() {
-    let bannerShown = false;
-
-    const ctx = (): DetectionContext => ({
-      host: location.hostname,
-      url: location.href,
-      doc: document,
-    });
-
-    const maybeConfirm = (): void => {
-      if (bannerShown || !document.body) {
-        return;
-      }
-      if (detectApplicationSubmit(ctx()) === null) {
-        return;
-      }
-      bannerShown = true;
-      observer.disconnect();
-      showConfirmationBanner({
-        onLog: () => void logApplication(),
-        onDismiss: () => {
-          bannerShown = false;
-        },
-      });
-    };
-
-    // 1) A full-navigation confirmation page (Greenhouse/Lever) is caught on load.
-    maybeConfirm();
-
-    // 2) An in-page/AJAX submit (Ashby SPA, Lever): re-check shortly after submit.
-    document.addEventListener(
-      "submit",
-      () => {
-        setTimeout(maybeConfirm, 800);
-      },
-      true,
-    );
-
-    // 3) SPA success states that swap DOM without navigation: observe until shown.
-    const observer = new MutationObserver(() => maybeConfirm());
-    observer.observe(document.documentElement, { childList: true, subtree: true });
+    startAutolog();
   },
 });

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -58,7 +58,17 @@ export async function handleMessage(message: ExtMessage): Promise<ExtResponse> {
       if (!result.ok) {
         return { ok: false, error: result.error };
       }
-      return { ok: true, jobId: result.jobId };
+      // Pass the score fields through to the caller (popup / content script →
+      // the 01-04 panel surface renders them).
+      return {
+        ok: true,
+        jobId: result.jobId,
+        discoveredJobId: result.discoveredJobId,
+        fitScore: result.fitScore,
+        letterGrade: result.letterGrade,
+        scoreBreakdown: result.scoreBreakdown,
+        gap: result.gap,
+      };
     }
     case "STATUS": {
       const result = await client.status();

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -63,6 +63,11 @@ export async function handleMessage(message: ExtMessage): Promise<ExtResponse> {
       const response: ExtResponse = {
         ok: true,
         jobId: result.jobId,
+        // Echo the captured job identity so the auto-log banner can name it
+        // (MED-02). The backend response carries no title/company, so take them
+        // from the payload the user just captured.
+        title: message.payload.title || undefined,
+        company: message.payload.company || undefined,
         discoveredJobId: result.discoveredJobId,
         fitScore: result.fitScore,
         letterGrade: result.letterGrade,

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -1,7 +1,7 @@
 import { defineBackground } from "#imports";
 import * as client from "@/lib/api/client";
 import type { ExtMessage, ExtResponse, HealthState } from "@/lib/api/messages";
-import { getToken, setToken } from "@/lib/storage";
+import { getToken, setLastCapture, setToken } from "@/lib/storage";
 
 /**
  * Background service worker: the extension's networking spine. It owns the typed
@@ -60,7 +60,7 @@ export async function handleMessage(message: ExtMessage): Promise<ExtResponse> {
       }
       // Pass the score fields through to the caller (popup / content script →
       // the 01-04 panel surface renders them).
-      return {
+      const response: ExtResponse = {
         ok: true,
         jobId: result.jobId,
         discoveredJobId: result.discoveredJobId,
@@ -69,6 +69,23 @@ export async function handleMessage(message: ExtMessage): Promise<ExtResponse> {
         scoreBreakdown: result.scoreBreakdown,
         gap: result.gap,
       };
+      // Stash the score in ephemeral session storage so the sidePanel renders it
+      // on open (and live-updates via its onChanged subscription). The panel is
+      // opened from the user gesture in the listener below, not here.
+      await setLastCapture(response);
+      return response;
+    }
+    case "PROMOTE": {
+      // Add-to-pipeline: token required before any network call.
+      const token = await getToken();
+      if (!token) {
+        return { ok: false, error: "not-paired" };
+      }
+      const result = await client.promote(message.discoveredJobId);
+      if (!result.ok) {
+        return { ok: false, error: result.error };
+      }
+      return { ok: true, applicationId: result.applicationId, status: result.status };
     }
     case "STATUS": {
       const result = await client.status();
@@ -84,9 +101,43 @@ export async function handleMessage(message: ExtMessage): Promise<ExtResponse> {
   }
 }
 
+/**
+ * Open the sidePanel for the tab a CAPTURE originated from. This MUST run
+ * SYNCHRONOUSLY at the top of the message listener, BEFORE any `await`: the user
+ * gesture that fired the capture (the floating button click) propagates across
+ * `sendMessage`, but only if `chrome.sidePanel.open` is called before the event
+ * loop yields — otherwise the gesture is consumed and the call throws. If
+ * sidePanel is unavailable (older Chrome), we swallow the error; the in-page
+ * overlay/inline acknowledgement remains the documented fallback surface.
+ */
+function openSidePanelForCapture(message: ExtMessage, sender: chrome.runtime.MessageSender): void {
+  if (message.type !== "CAPTURE") {
+    return;
+  }
+  const tabId = sender.tab?.id;
+  const opener = (chrome as { sidePanel?: { open?: (opts: { tabId: number }) => unknown } })
+    .sidePanel?.open;
+  if (typeof tabId !== "number" || typeof opener !== "function") {
+    return;
+  }
+  try {
+    // Fire-and-forget: opening is best-effort and gesture-tied; the score itself
+    // is delivered via chrome.storage.session, read by the panel on load.
+    void Promise.resolve(opener({ tabId })).catch(() => {});
+  } catch {
+    // Gesture already consumed or API unavailable — fall back silently.
+  }
+}
+
 export default defineBackground(() => {
   chrome.runtime.onMessage.addListener(
-    (message: ExtMessage, _sender, sendResponse: (response: ExtResponse) => void) => {
+    (
+      message: ExtMessage,
+      sender: chrome.runtime.MessageSender,
+      sendResponse: (response: ExtResponse) => void,
+    ) => {
+      // Gesture-tied side-panel open happens FIRST, synchronously.
+      openSidePanelForCapture(message, sender);
       handleMessage(message)
         .then(sendResponse)
         .catch(() => sendResponse({ ok: false, error: "internal-error" }));

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -1,0 +1,133 @@
+import { defineContentScript } from "#imports";
+import type { CapturePayload, CaptureResponse } from "@/lib/api/messages";
+import { extractJob } from "@/lib/extraction";
+
+/**
+ * Content script for "the eye": on a recognized job posting it injects a single
+ * floating "Capture to Kestrel" button (in a shadow root, so host-page CSS can't
+ * bleed in and page CSS can't restyle ours). On click — or on a CAPTURE_ACTIVE_TAB
+ * request from the popup — it runs the tiered extractor and hands the payload to
+ * the background worker (the ONLY backend caller). This script NEVER fetches the
+ * backend and NEVER auto-fires: capture is strictly user-action-only.
+ *
+ * The score-bearing response is re-dispatched as a `kestrel:capture-result`
+ * DOM CustomEvent so the 01-04 panel surface can render it in either an overlay
+ * or the side panel without coupling to this script.
+ */
+
+const HOST_ID = "kestrel-capture-host";
+const RESULT_EVENT = "kestrel:capture-result";
+const ACTIVE_TAB_MESSAGE = "CAPTURE_ACTIVE_TAB";
+
+/** Build the wire payload from the current page via tiered extraction. */
+function buildPayload(): CapturePayload {
+  const job = extractJob(document);
+  return {
+    url: job.url,
+    title: job.title,
+    company: job.company,
+    description: job.description,
+    location: job.location,
+    salary: job.salary,
+    source: job.source,
+    // Raw tier: send the page text so the backend LLM parses it (01-02).
+    raw_text: job.confidence === "raw" ? job.description : null,
+  };
+}
+
+/** Extract → send CAPTURE through the worker → broadcast the result. */
+async function sendCapture(): Promise<CaptureResponse> {
+  let res: CaptureResponse;
+  try {
+    res = (await chrome.runtime.sendMessage({
+      type: "CAPTURE",
+      payload: buildPayload(),
+    })) as CaptureResponse;
+  } catch {
+    res = { ok: false, error: "worker-unavailable" };
+  }
+  document.dispatchEvent(new CustomEvent(RESULT_EVENT, { detail: res }));
+  return res;
+}
+
+/** Compact acknowledgement label for the floating button (01-04 owns the panel). */
+function labelFor(res: CaptureResponse): string {
+  if (!res.ok) {
+    return "Capture failed — retry";
+  }
+  if (res.fitScore != null && res.letterGrade) {
+    return `Scored ✓ ${res.letterGrade} · ${res.fitScore}`;
+  }
+  return "Captured ✓";
+}
+
+/** Inject the floating trigger button once, isolated inside a shadow root. */
+function mountButton(): void {
+  if (document.getElementById(HOST_ID) || !document.body) {
+    return;
+  }
+  const host = document.createElement("div");
+  host.id = HOST_ID;
+  Object.assign(host.style, {
+    position: "fixed",
+    bottom: "20px",
+    right: "20px",
+    zIndex: "2147483647",
+  });
+  const shadow = host.attachShadow({ mode: "open" });
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.textContent = "Capture to Kestrel";
+  btn.style.cssText =
+    "font: 600 13px system-ui, sans-serif; padding: 10px 14px; border: 0;" +
+    "border-radius: 8px; background: #1f2937; color: #fff; cursor: pointer;" +
+    "box-shadow: 0 2px 8px rgba(0,0,0,.25);";
+  btn.addEventListener("click", () => {
+    btn.disabled = true;
+    btn.textContent = "Capturing…";
+    void sendCapture().then((res) => {
+      btn.textContent = labelFor(res);
+      btn.disabled = false;
+    });
+  });
+
+  shadow.appendChild(btn);
+  document.body.appendChild(host);
+}
+
+/** Narrow an unknown runtime message to the popup's capture request. */
+function isActiveTabCapture(message: unknown): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { type?: unknown }).type === ACTIVE_TAB_MESSAGE
+  );
+}
+
+export default defineContentScript({
+  // Explicit ATS allowlist — never a wildcard or broad-host match. The content
+  // script only runs on these recognized job hosts; that IS the "host in
+  // allowlist" recognition signal, so the button mounts on every matched page.
+  matches: [
+    "*://*.linkedin.com/jobs/*",
+    "*://boards.greenhouse.io/*",
+    "*://*.greenhouse.io/*",
+    "*://jobs.lever.co/*",
+    "*://*.ashbyhq.com/*",
+  ],
+  main() {
+    mountButton();
+
+    // Popup path: the popup uses activeTab to ask the content script to capture
+    // the tab it is viewing. Extraction stays here (single source), routed
+    // through the same worker call.
+    chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+      if (isActiveTabCapture(message)) {
+        void sendCapture().then(sendResponse);
+        return true; // async response
+      }
+      return undefined;
+    });
+  },
+});

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import type { ExtResponse, HealthResponse, HealthState } from "@/lib/api/messages";
+import type {
+  CaptureResponse,
+  ExtResponse,
+  HealthResponse,
+  HealthState,
+} from "@/lib/api/messages";
 
 // One-line, human-readable label per health state. The popup proves the
 // React+WXT build and the background message round-trip only — it issues NO
@@ -16,8 +21,46 @@ function isHealthResponse(res: ExtResponse): res is HealthResponse {
   return "state" in res;
 }
 
+/** Result line for a capture attempt; the panel surface (01-04) renders detail. */
+function captureLabel(res: CaptureResponse): string {
+  if (!res.ok) {
+    if (res.error === "unsupported-page") {
+      return "Open a supported job posting (LinkedIn / Greenhouse / Lever / Ashby) to capture.";
+    }
+    if (res.error === "not-paired") {
+      return "Not paired — open Options to pair first.";
+    }
+    return "Capture failed. Try again.";
+  }
+  if (res.fitScore != null && res.letterGrade) {
+    return `Captured ✓ — fit ${res.letterGrade} (${res.fitScore}). Added to Kestrel.`;
+  }
+  return "Captured ✓ — added to Kestrel.";
+}
+
+/**
+ * Capture the active tab WITHOUT any broad host access: we use `activeTab` (the
+ * click on the toolbar action grants it) to message the content script running
+ * on the viewed page, which extracts + captures through the worker. The popup
+ * never fetches the backend directly.
+ */
+async function captureActiveTab(): Promise<CaptureResponse> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) {
+    return { ok: false, error: "unsupported-page" };
+  }
+  try {
+    return (await chrome.tabs.sendMessage(tab.id, { type: "CAPTURE_ACTIVE_TAB" })) as CaptureResponse;
+  } catch {
+    // No content script here → not a recognized job page.
+    return { ok: false, error: "unsupported-page" };
+  }
+}
+
 export function App() {
   const [status, setStatus] = useState<string>("Checking connection…");
+  const [capturing, setCapturing] = useState(false);
+  const [captureResult, setCaptureResult] = useState<string>("");
 
   useEffect(() => {
     let cancelled = false;
@@ -39,10 +82,44 @@ export function App() {
     };
   }, []);
 
+  async function onCapture() {
+    setCapturing(true);
+    setCaptureResult("");
+    try {
+      const res = await captureActiveTab();
+      setCaptureResult(captureLabel(res));
+    } catch {
+      setCaptureResult("Capture failed. Try again.");
+    } finally {
+      setCapturing(false);
+    }
+  }
+
   return (
     <main style={{ width: 280, padding: 16, fontFamily: "system-ui, sans-serif" }}>
       <h1 style={{ fontSize: 16, margin: "0 0 8px" }}>Kestrel</h1>
-      <p style={{ fontSize: 13, margin: 0, color: "#444" }}>{status}</p>
+      <p style={{ fontSize: 13, margin: "0 0 12px", color: "#444" }}>{status}</p>
+      <button
+        type="button"
+        onClick={onCapture}
+        disabled={capturing}
+        style={{
+          width: "100%",
+          padding: "9px 12px",
+          fontSize: 13,
+          fontWeight: 600,
+          border: 0,
+          borderRadius: 8,
+          background: capturing ? "#9ca3af" : "#1f2937",
+          color: "#fff",
+          cursor: capturing ? "default" : "pointer",
+        }}
+      >
+        {capturing ? "Capturing…" : "Capture this job"}
+      </button>
+      {captureResult && (
+        <p style={{ fontSize: 12, margin: "10px 0 0", color: "#374151" }}>{captureResult}</p>
+      )}
     </main>
   );
 }

--- a/extension/entrypoints/sidepanel/App.tsx
+++ b/extension/entrypoints/sidepanel/App.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { ScorePanel } from "@/components/ScorePanel";
+import type { CaptureResponse, PromoteResponse } from "@/lib/api/messages";
+import { getLastCapture, onLastCaptureChanged } from "@/lib/storage";
+
+/**
+ * sidePanel host — the PRIMARY score/gap surface (01-04 LOCKED decision). It
+ * reads the latest capture result from `chrome.storage.session` on mount,
+ * subscribes to changes (MV3 worker-restart safe), and mounts the surface-
+ * agnostic `ScorePanel`. Add-to-pipeline routes a PROMOTE message through the
+ * background worker (the sole backend caller) — the panel never fetches.
+ */
+export function App() {
+  const [result, setResult] = useState<CaptureResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const last = await getLastCapture();
+      if (!cancelled && last) {
+        setResult(last);
+      }
+    })();
+    const unsubscribe = onLastCaptureChanged((next) => setResult(next));
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  async function onPromote(discoveredJobId: number): Promise<void> {
+    const res = (await chrome.runtime.sendMessage({
+      type: "PROMOTE",
+      discoveredJobId,
+    })) as PromoteResponse;
+    if (!res.ok) {
+      throw new Error(res.error ?? "promote-failed");
+    }
+  }
+
+  if (!result) {
+    return (
+      <main style={{ padding: 16, fontFamily: "system-ui, sans-serif", color: "#4b5563" }}>
+        <h1 style={{ fontSize: 15, margin: "0 0 8px" }}>Kestrel</h1>
+        <p style={{ fontSize: 13, margin: 0 }}>
+          Capture a job posting to see its Kestrel fit score and gap here.
+        </p>
+      </main>
+    );
+  }
+
+  return <ScorePanel result={result} onPromote={onPromote} />;
+}

--- a/extension/entrypoints/sidepanel/index.html
+++ b/extension/entrypoints/sidepanel/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kestrel — Score</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/entrypoints/sidepanel/main.tsx
+++ b/extension/entrypoints/sidepanel/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("sidepanel root element missing");
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/extension/lib/api/client.ts
+++ b/extension/lib/api/client.ts
@@ -21,7 +21,17 @@ export type PairOutcome =
   | { ok: true; token: string; instance: InstanceInfo }
   | { ok: false; error: string };
 
-export type CaptureOutcome = { ok: true; jobId: string } | { ok: false; error: string };
+export type CaptureOutcome =
+  | {
+      ok: true;
+      jobId: string;
+      discoveredJobId?: number;
+      fitScore?: number;
+      letterGrade?: string;
+      scoreBreakdown?: unknown[];
+      gap?: string;
+    }
+  | { ok: false; error: string };
 
 export type StatusOutcome =
   | { ok: true; instance: InstanceInfo }
@@ -85,8 +95,25 @@ export async function capture(payload: CapturePayload): Promise<CaptureOutcome> 
   if (!result.response.ok) {
     return { ok: false, error: "capture-failed" };
   }
-  const data = (await result.response.json()) as { job_id: string };
-  return { ok: true, jobId: data.job_id };
+  const data = (await result.response.json()) as {
+    job_id: string;
+    discovered_job_id?: number;
+    fit_score?: number;
+    letter_grade?: string;
+    score_breakdown?: unknown[] | null;
+    gap?: string;
+  };
+  return {
+    ok: true,
+    jobId: data.job_id,
+    discoveredJobId: data.discovered_job_id,
+    fitScore: data.fit_score,
+    letterGrade: data.letter_grade,
+    // score_breakdown may be null when the provider returns none (01-02) —
+    // normalize to undefined so the panel can treat "missing" uniformly.
+    scoreBreakdown: data.score_breakdown ?? undefined,
+    gap: data.gap,
+  };
 }
 
 export async function status(): Promise<StatusOutcome> {

--- a/extension/lib/api/client.ts
+++ b/extension/lib/api/client.ts
@@ -33,6 +33,10 @@ export type CaptureOutcome =
     }
   | { ok: false; error: string };
 
+export type PromoteOutcome =
+  | { ok: true; applicationId?: number; status?: string }
+  | { ok: false; error: string };
+
 export type StatusOutcome =
   | { ok: true; instance: InstanceInfo }
   | { ok: false; status: number | null; error: string };
@@ -114,6 +118,33 @@ export async function capture(payload: CapturePayload): Promise<CaptureOutcome> 
     scoreBreakdown: data.score_breakdown ?? undefined,
     gap: data.gap,
   };
+}
+
+export async function promote(discoveredJobId: number): Promise<PromoteOutcome> {
+  const base = await getBackendUrl();
+  const token = await getToken();
+  const result = await request(`${base}/api/extension/promote`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token ?? ""}`,
+    },
+    body: JSON.stringify({ discovered_job_id: discoveredJobId }),
+  });
+  if (result.kind === "network") {
+    return { ok: false, error: "backend-unreachable" };
+  }
+  if (result.response.status === 401) {
+    return { ok: false, error: "bad-key" };
+  }
+  if (!result.response.ok) {
+    return { ok: false, error: "promote-failed" };
+  }
+  const data = (await result.response.json()) as {
+    application_id?: number;
+    status?: string;
+  };
+  return { ok: true, applicationId: data.application_id, status: data.status };
 }
 
 export async function status(): Promise<StatusOutcome> {

--- a/extension/lib/api/messages.ts
+++ b/extension/lib/api/messages.ts
@@ -54,6 +54,13 @@ export interface CaptureResponse {
   ok: boolean;
   jobId?: string;
   error?: string;
+  /**
+   * Captured job identity (echoed from the CapturePayload). Persisted in session
+   * `lastCapture` so the auto-log banner can name WHAT it is about to log
+   * (MED-02) instead of a bare "Log this application?".
+   */
+  title?: string;
+  company?: string;
   /** Score fields from the 01-02 backend; consumed by the 01-04 panel surface. */
   discoveredJobId?: number;
   fitScore?: number;

--- a/extension/lib/api/messages.ts
+++ b/extension/lib/api/messages.ts
@@ -35,6 +35,7 @@ export type ExtMessage =
   | { type: "PAIR"; pairingCode: string }
   | { type: "HEALTH" }
   | { type: "CAPTURE"; payload: CapturePayload }
+  | { type: "PROMOTE"; discoveredJobId: number }
   | { type: "STATUS" };
 
 export interface PairResponse {
@@ -67,5 +68,22 @@ export interface StatusResponse {
   error?: string;
 }
 
+/**
+ * Result of promoting a captured job to the pipeline via
+ * `POST /api/extension/promote` (from 01-02). Idempotent — a repeat promote of
+ * the same job returns the same `applicationId`.
+ */
+export interface PromoteResponse {
+  ok: boolean;
+  applicationId?: number;
+  status?: string;
+  error?: string;
+}
+
 /** Discriminated union of every response the background worker returns. */
-export type ExtResponse = PairResponse | HealthResponse | CaptureResponse | StatusResponse;
+export type ExtResponse =
+  | PairResponse
+  | HealthResponse
+  | CaptureResponse
+  | PromoteResponse
+  | StatusResponse;

--- a/extension/lib/api/messages.ts
+++ b/extension/lib/api/messages.ts
@@ -26,6 +26,8 @@ export interface CapturePayload {
   location?: string | null;
   salary?: string | null;
   source?: string | null;
+  /** Sent when structured extraction failed → backend LLM-parses it (01-02). */
+  raw_text?: string | null;
 }
 
 /** Discriminated union of every message the background worker accepts. */
@@ -51,6 +53,12 @@ export interface CaptureResponse {
   ok: boolean;
   jobId?: string;
   error?: string;
+  /** Score fields from the 01-02 backend; consumed by the 01-04 panel surface. */
+  discoveredJobId?: number;
+  fitScore?: number;
+  letterGrade?: string;
+  scoreBreakdown?: unknown[];
+  gap?: string;
 }
 
 export interface StatusResponse {

--- a/extension/lib/extraction/dom.ts
+++ b/extension/lib/extraction/dom.ts
@@ -1,0 +1,48 @@
+/**
+ * Small DOM/text helpers shared by the extraction tiers. All are defensive:
+ * they never throw on missing nodes and only READ the (untrusted) page DOM —
+ * page-provided strings are turned into plain text, never re-injected as HTML.
+ */
+
+/** Strip HTML tags and collapse whitespace to plain text (no innerHTML sink). */
+export function stripHtml(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Read a `<meta property=... | name=...>` content attribute, or "". */
+export function metaContent(doc: Document, selector: string): string {
+  const el = doc.querySelector(selector);
+  return el?.getAttribute("content")?.trim() ?? "";
+}
+
+/** Best-effort canonical URL for the page: location → canonical link → og:url. */
+export function pageUrl(doc: Document): string {
+  const href = doc.location?.href;
+  if (href && /^https?:\/\//i.test(href)) {
+    return href;
+  }
+  const canonical = doc.querySelector('link[rel="canonical"]')?.getAttribute("href");
+  if (canonical) {
+    return canonical;
+  }
+  return metaContent(doc, 'meta[property="og:url"]');
+}
+
+/** Host of a URL, or null when it cannot be parsed. */
+export function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}

--- a/extension/lib/extraction/index.ts
+++ b/extension/lib/extraction/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Tiered job extractor. Given a page `Document`, returns an {@link ExtractedJob}
+ * using the first tier that yields a usable result:
+ *
+ *   1. JSON-LD `JobPosting`  → structured (primary)
+ *   2. OpenGraph / meta      → structured when title + company derivable
+ *   3. raw visible page text → raw; the backend LLM parses it (01-02 fallback)
+ *
+ * Pure and defensive: it only READS the untrusted DOM, never throws on
+ * malformed markup, and never re-injects page-provided strings as HTML.
+ */
+
+import { hostOf, pageUrl } from "./dom";
+import { fromJsonLd, hasJobPosting } from "./jsonld";
+import { fromOpenGraph } from "./opengraph";
+import { rawBodyText } from "./rawtext";
+import type { ExtractedJob } from "./types";
+
+export type { ExtractedJob } from "./types";
+export { hasJobPosting } from "./jsonld";
+
+/** True when the document looks like a job posting (JSON-LD JobPosting present). */
+export function isJobPage(doc: Document): boolean {
+  return hasJobPosting(doc);
+}
+
+export function extractJob(doc: Document): ExtractedJob {
+  const url = pageUrl(doc);
+  const source = hostOf(url);
+  const base = { url, source };
+
+  // Tier 1: JSON-LD JobPosting.
+  const jsonLd = fromJsonLd(doc);
+  if (jsonLd && (jsonLd.title || jsonLd.company)) {
+    return {
+      title: jsonLd.title ?? "",
+      company: jsonLd.company ?? "",
+      description: jsonLd.description || rawBodyText(doc),
+      location: jsonLd.location ?? null,
+      salary: jsonLd.salary ?? null,
+      confidence: "structured",
+      ...base,
+    };
+  }
+
+  // Tier 2: OpenGraph / meta — structured only when title AND company derive.
+  const og = fromOpenGraph(doc);
+  if (og && og.title && og.company) {
+    return {
+      title: og.title,
+      company: og.company,
+      description: og.description || rawBodyText(doc),
+      location: og.location ?? null,
+      salary: og.salary ?? null,
+      confidence: "structured",
+      ...base,
+    };
+  }
+
+  // Tier 3: raw text for the backend LLM fallback.
+  return {
+    title: "",
+    company: "",
+    description: rawBodyText(doc),
+    location: null,
+    salary: null,
+    confidence: "raw",
+    ...base,
+  };
+}

--- a/extension/lib/extraction/jsonld.ts
+++ b/extension/lib/extraction/jsonld.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier 1 — JSON-LD. Parses `<script type="application/ld+json">` blocks for a
+ * schema.org `JobPosting` (directly, inside an array, or inside an `@graph`).
+ * Every parse is wrapped in try/catch: malformed JSON is ignored, never thrown.
+ */
+
+import { stripHtml } from "./dom";
+import type { PartialJob } from "./types";
+
+type Json = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Json {
+  return typeof value === "object" && value !== null;
+}
+
+/** True if a node's `@type` is or includes "JobPosting". */
+function isJobPosting(node: unknown): node is Json {
+  if (!isRecord(node)) {
+    return false;
+  }
+  const type = node["@type"];
+  if (typeof type === "string") {
+    return type === "JobPosting";
+  }
+  if (Array.isArray(type)) {
+    return type.includes("JobPosting");
+  }
+  return false;
+}
+
+/** Flatten a parsed JSON-LD value into candidate nodes (unwrapping @graph). */
+function candidates(parsed: unknown): unknown[] {
+  const out: unknown[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (isRecord(value)) {
+      out.push(value);
+      if (Array.isArray(value["@graph"])) {
+        (value["@graph"] as unknown[]).forEach(visit);
+      }
+    }
+  };
+  visit(parsed);
+  return out;
+}
+
+/** Every JobPosting node found across all JSON-LD scripts in the document. */
+function jobPostingNodes(doc: Document): Json[] {
+  const nodes: Json[] = [];
+  for (const script of doc.querySelectorAll('script[type="application/ld+json"]')) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(script.textContent ?? "");
+    } catch {
+      continue; // malformed JSON-LD → ignore, fall through to lower tiers
+    }
+    for (const node of candidates(parsed)) {
+      if (isJobPosting(node)) {
+        nodes.push(node);
+      }
+    }
+  }
+  return nodes;
+}
+
+/** True when the page carries at least one JSON-LD JobPosting. */
+export function hasJobPosting(doc: Document): boolean {
+  return jobPostingNodes(doc).length > 0;
+}
+
+function orgName(hiring: unknown): string {
+  if (typeof hiring === "string") {
+    return hiring.trim();
+  }
+  if (isRecord(hiring) && typeof hiring.name === "string") {
+    return hiring.name.trim();
+  }
+  return "";
+}
+
+function locationText(jobLocation: unknown): string {
+  const first = Array.isArray(jobLocation) ? jobLocation[0] : jobLocation;
+  if (!isRecord(first)) {
+    return "";
+  }
+  const address = isRecord(first.address) ? first.address : first;
+  const parts = [address.addressLocality, address.addressRegion, address.addressCountry]
+    .filter((p): p is string => typeof p === "string" && p.length > 0)
+    .map((p) => p.trim());
+  return parts.join(", ");
+}
+
+function salaryText(baseSalary: unknown): string {
+  if (!isRecord(baseSalary)) {
+    return "";
+  }
+  const currency =
+    typeof baseSalary.currency === "string"
+      ? baseSalary.currency
+      : typeof baseSalary.salaryCurrency === "string"
+        ? baseSalary.salaryCurrency
+        : "";
+  const value = isRecord(baseSalary.value) ? baseSalary.value : baseSalary;
+  const min = value.minValue ?? value.value;
+  const max = value.maxValue;
+  const unit = typeof value.unitText === "string" ? value.unitText : "";
+  let amount = "";
+  if (min != null && max != null) {
+    amount = `${min}-${max}`;
+  } else if (min != null) {
+    amount = `${min}`;
+  }
+  if (!amount) {
+    return "";
+  }
+  return [currency, amount].filter(Boolean).join(" ") + (unit ? `/${unit}` : "");
+}
+
+/** Extract structured fields from the first JSON-LD JobPosting, or null. */
+export function fromJsonLd(doc: Document): PartialJob | null {
+  const node = jobPostingNodes(doc)[0];
+  if (!node) {
+    return null;
+  }
+  return {
+    title: typeof node.title === "string" ? node.title.trim() : "",
+    company: orgName(node.hiringOrganization),
+    description: stripHtml(node.description),
+    location: locationText(node.jobLocation) || null,
+    salary: salaryText(node.baseSalary) || null,
+  };
+}

--- a/extension/lib/extraction/opengraph.ts
+++ b/extension/lib/extraction/opengraph.ts
@@ -1,0 +1,30 @@
+/**
+ * Tier 2 — OpenGraph / meta. Best-effort structured fields from `og:*` and
+ * common meta tags when no JSON-LD JobPosting exists. Company is the weakest
+ * signal (og:site_name is often the board, not the employer), so a page that
+ * yields a title but no company is left for the raw tier to decide.
+ */
+
+import { metaContent } from "./dom";
+import type { PartialJob } from "./types";
+
+/**
+ * Extract OG/meta fields. Returns null when there is no usable title signal at
+ * all. `company` may be "" — the caller decides confidence from title+company.
+ */
+export function fromOpenGraph(doc: Document): PartialJob | null {
+  const title =
+    metaContent(doc, 'meta[property="og:title"]') ||
+    metaContent(doc, 'meta[name="twitter:title"]');
+  if (!title) {
+    return null;
+  }
+  const description =
+    metaContent(doc, 'meta[property="og:description"]') ||
+    metaContent(doc, 'meta[name="description"]');
+  const company =
+    metaContent(doc, 'meta[property="og:site_name"]') ||
+    metaContent(doc, 'meta[name="author"]');
+
+  return { title, company, description, location: null, salary: null };
+}

--- a/extension/lib/extraction/rawtext.ts
+++ b/extension/lib/extraction/rawtext.ts
@@ -1,0 +1,15 @@
+/**
+ * Tier 3 — raw text. The last resort: hand the backend LLM the visible page
+ * text (capped) so it can parse company/title/JD itself. `innerText` is
+ * preferred in a real browser (respects visibility); jsdom lacks it, so we fall
+ * back to `textContent`.
+ */
+
+import { RAW_TEXT_CAP } from "./types";
+
+/** Trimmed, length-capped visible text of the page body. */
+export function rawBodyText(doc: Document): string {
+  const body = doc.body as (HTMLElement & { innerText?: string }) | null;
+  const text = body?.innerText ?? body?.textContent ?? "";
+  return text.replace(/\s+/g, " ").trim().slice(0, RAW_TEXT_CAP);
+}

--- a/extension/lib/extraction/types.ts
+++ b/extension/lib/extraction/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared shape produced by the tiered job extractor. `confidence` tells the
+ * caller whether the fields are structured (JSON-LD / OpenGraph) or a raw-text
+ * fallback that the backend must LLM-parse.
+ */
+export interface ExtractedJob {
+  company: string;
+  title: string;
+  description: string;
+  location: string | null;
+  salary: string | null;
+  url: string;
+  source: string | null;
+  confidence: "structured" | "raw";
+}
+
+/** Fields a structured tier can contribute; merged into a full ExtractedJob. */
+export type PartialJob = Partial<
+  Pick<ExtractedJob, "company" | "title" | "description" | "location" | "salary">
+>;
+
+/** Max characters of raw page text sent to the backend (mirrors extension_max_jd_chars=30000). */
+export const RAW_TEXT_CAP = 30000;

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -80,6 +80,21 @@ export async function getLastDiscoveredJobId(): Promise<number | undefined> {
 }
 
 /**
+ * A short "Title · Company" label for the last captured job, or `null` when
+ * neither is known. Used by the auto-log banner so the user can see WHAT is
+ * about to be logged and catch a stale/wrong correlation (MED-02).
+ */
+export async function getLastCaptureLabel(): Promise<string | null> {
+  const last = await getLastCapture();
+  const title = (last?.title ?? "").trim();
+  const company = (last?.company ?? "").trim();
+  if (title && company) {
+    return `${title} · ${company}`;
+  }
+  return title || company || null;
+}
+
+/**
  * Subscribe to session `lastCapture` changes; returns an unsubscribe fn. Guarded
  * so it is a no-op when `chrome.storage.session.onChanged` is unavailable.
  */

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -1,13 +1,18 @@
 /**
- * Thin, testable typed wrapper over `chrome.storage.local` for the two values
- * the extension persists: the backend URL and the paired extension token.
+ * Thin, testable typed wrapper over `chrome.storage` for the values the
+ * extension persists: the backend URL + paired token (durable `local`), and the
+ * latest capture result (ephemeral `session`, so the sidePanel survives an MV3
+ * worker restart and reads the score on mount).
  *
  * Security (T-00-10): reject a non-localhost `http://` backend URL. `http://` is
  * permitted ONLY for localhost/127.0.0.1; every other host must be `https://`.
  */
 
+import type { CaptureResponse } from "@/lib/api/messages";
+
 const KEY_BACKEND_URL = "backendUrl";
 const KEY_TOKEN = "extensionToken";
+const KEY_LAST_CAPTURE = "lastCapture";
 const DEFAULT_BACKEND_URL = "http://localhost:8100";
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
@@ -50,4 +55,45 @@ export async function getToken(): Promise<string | null> {
 
 export async function setToken(token: string | null): Promise<void> {
   await chrome.storage.local.set({ [KEY_TOKEN]: token });
+}
+
+// ---------------------------------------------------------------------------
+// Latest capture result — ephemeral session storage (cleared when the browser
+// closes). The background CAPTURE handler writes it; the sidePanel reads it on
+// mount and subscribes to changes so a fresh capture updates the panel live and
+// an MV3 worker restart never loses the last score.
+// ---------------------------------------------------------------------------
+
+export async function getLastCapture(): Promise<CaptureResponse | null> {
+  const result = await chrome.storage.session.get(KEY_LAST_CAPTURE);
+  return (result[KEY_LAST_CAPTURE] as CaptureResponse | undefined) ?? null;
+}
+
+export async function setLastCapture(result: CaptureResponse): Promise<void> {
+  await chrome.storage.session.set({ [KEY_LAST_CAPTURE]: result });
+}
+
+/** Read the last captured `discoveredJobId` (used by auto-log's promote path). */
+export async function getLastDiscoveredJobId(): Promise<number | undefined> {
+  const last = await getLastCapture();
+  return typeof last?.discoveredJobId === "number" ? last.discoveredJobId : undefined;
+}
+
+/**
+ * Subscribe to session `lastCapture` changes; returns an unsubscribe fn. Guarded
+ * so it is a no-op when `chrome.storage.session.onChanged` is unavailable.
+ */
+export function onLastCaptureChanged(callback: (result: CaptureResponse) => void): () => void {
+  const events = chrome.storage.session.onChanged;
+  if (!events) {
+    return () => {};
+  }
+  const listener = (changes: Record<string, chrome.storage.StorageChange>): void => {
+    const change = changes[KEY_LAST_CAPTURE];
+    if (change && change.newValue !== undefined) {
+      callback(change.newValue as CaptureResponse);
+    }
+  };
+  events.addListener(listener);
+  return () => events.removeListener(listener);
 }

--- a/extension/test/imports-stub.ts
+++ b/extension/test/imports-stub.ts
@@ -6,3 +6,10 @@
 export function defineBackground<T>(main: T): T {
   return main;
 }
+
+// Identity stub for content-script entrypoints so `autolog.content.ts` can be
+// imported to unit-test its exported pure helpers (the registered `main()` is
+// never invoked under vitest).
+export function defineContentScript<T>(def: T): T {
+  return def;
+}

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,21 +1,27 @@
 import { defineConfig } from "wxt";
 
 // WXT + React 19, Manifest V3 (WXT's default target).
-// Locked Phase-0 decisions: narrow permissions only, and NEVER a broad-host /
+// Locked Phase-0/1 decisions: narrow permissions only, and NEVER a broad-host or
 // wildcard permission. The background service worker is the sole backend caller;
 // the paired backend is reachable via localhost host_permissions only. No
 // telemetry ships here.
+//
+// The in-page floating trigger runs from the content script (entrypoints/content.ts),
+// whose EXPLICIT ATS `matches` allowlist (LinkedIn jobs / Greenhouse / Lever /
+// Ashby) WXT auto-registers into manifest content_scripts — no host_permissions
+// widening needed. The popup "Capture this job" path uses `activeTab` (granted by
+// the toolbar click) to message that content script; it never fetches the backend.
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   manifest: {
     name: "Kestrel",
     description:
       "Companion for your self-hosted Kestrel job search. Captures job posts to your own paired instance. No telemetry and no broad host access.",
-    // Nothing beyond activeTab + storage. Later phases add EXPLICIT ATS domains,
-    // never a wildcard host.
+    // Nothing beyond activeTab + storage. Recognized job hosts are reached via
+    // the content-script `matches` allowlist, never a wildcard host permission.
     permissions: ["activeTab", "storage"],
     // The paired Kestrel backend only. Remote hosts are added in later phases as
-    // explicit entries; Phase 0 talks to localhost exclusively.
+    // explicit entries; Phase 0/1 talk to localhost exclusively.
     host_permissions: ["http://localhost/*", "http://127.0.0.1/*"],
   },
 });

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -11,15 +11,23 @@ import { defineConfig } from "wxt";
 // Ashby) WXT auto-registers into manifest content_scripts — no host_permissions
 // widening needed. The popup "Capture this job" path uses `activeTab` (granted by
 // the toolbar click) to message that content script; it never fetches the backend.
+//
+// The score/gap surface is the MV3 `sidePanel` (01-04): WXT auto-detects the
+// `entrypoints/sidepanel/` entrypoint and registers `side_panel.default_path`.
+// `sidePanel` is the ONLY new permission — it grants a companion panel, NOT any
+// host access. A `chrome.sidePanel.open()` from a user-gesture message opens it.
+// The auto-log content script (entrypoints/autolog.content.ts) adds its own
+// EXPLICIT ATS application-host `matches` allowlist — again, no wildcard host.
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   manifest: {
     name: "Kestrel",
     description:
       "Companion for your self-hosted Kestrel job search. Captures job posts to your own paired instance. No telemetry and no broad host access.",
-    // Nothing beyond activeTab + storage. Recognized job hosts are reached via
-    // the content-script `matches` allowlist, never a wildcard host permission.
-    permissions: ["activeTab", "storage"],
+    // activeTab + storage + sidePanel only. Recognized job hosts are reached via
+    // the content-script `matches` allowlist, never a wildcard host permission;
+    // sidePanel is a companion-UI grant, not host access.
+    permissions: ["activeTab", "storage", "sidePanel"],
     // The paired Kestrel backend only. Remote hosts are added in later phases as
     // explicit entries; Phase 0/1 talk to localhost exclusively.
     host_permissions: ["http://localhost/*", "http://127.0.0.1/*"],

--- a/src/career_os/api/extension.py
+++ b/src/career_os/api/extension.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
 from career_os import __version__
+from career_os.api.oauth import limiter
 from career_os.schemas.extension import (
     CaptureRequest,
     CaptureResponse,
@@ -61,9 +62,19 @@ def require_extension_token(
     return token
 
 
-@router.post("/pair", response_model=PairResponse)
-def pair(payload: PairRequest) -> PairResponse:
-    """Validate a pairing code and mint a dedicated extension token."""
+@router.post(
+    "/pair",
+    response_model=PairResponse,
+    responses={429: {"description": "Too many pairing attempts"}},
+)
+@limiter.limit("5/minute")
+def pair(request: Request, payload: PairRequest) -> PairResponse:
+    """Validate a pairing code and mint a dedicated extension token.
+
+    Rate-limited to 5 attempts/min/IP (shared slowapi limiter, same instance the
+    app wires to ``app.state.limiter``) to kill brute-force of the 6-digit code —
+    T-01A-01. slowapi requires the ``request: Request`` first parameter.
+    """
     if not verify_pairing_code(payload.pairing_code):
         raise HTTPException(status_code=401, detail="Invalid or expired pairing code")
     return PairResponse(token=mint_extension_token(), instance=_instance_info())

--- a/src/career_os/api/extension.py
+++ b/src/career_os/api/extension.py
@@ -139,8 +139,10 @@ async def capture(
     except ScoringError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive 500
+        # Never surface internal exception text to the client (SECURITY F-4); the
+        # real error is logged server-side via logger.exception.
         logger.exception("Extension capture failed")
-        raise HTTPException(status_code=500, detail=f"Capture error: {exc}") from exc
+        raise HTTPException(status_code=500, detail="Capture failed") from exc
 
     breakdown: list | None = None
     if scored.score_breakdown:
@@ -189,8 +191,9 @@ def promote(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive 500
         db.rollback()
+        # Generic client detail; internal error stays server-side (SECURITY F-4).
         logger.exception("Extension promote failed")
-        raise HTTPException(status_code=500, detail=f"Promote error: {exc}") from exc
+        raise HTTPException(status_code=500, detail="Promote failed") from exc
 
     return PromoteResponse(application_id=app.id, status=app.status)
 

--- a/src/career_os/api/extension.py
+++ b/src/career_os/api/extension.py
@@ -1,38 +1,64 @@
-"""Browser-extension API routes: pair, capture (stub), status (Phase 0 / G-1390).
+"""Browser-extension API routes: pair, capture, promote, status (G-1390 / G-1391).
 
 The extension authenticates with a DEDICATED token (see services.extension_pairing)
 that is separate from the global AUTH_API_KEY and required even when AUTH_ENABLED is
-off. `/pair` is the bootstrap (code-gated, no token yet); `/capture` and `/status`
-require a valid extension token via the `require_extension_token` dependency.
+off. `/pair` is the bootstrap (code-gated, no token yet); `/capture`, `/promote`
+and `/status` require a valid extension token via `require_extension_token`.
 
-Phase 0 is foundation ONLY: `/capture` is a STUB that accepts a normalized payload
-and returns an id — it does NO scoring and touches NO database. Wiring capture to
-the scoring service is Phase 1 (which is why the scoring service is deliberately
-never imported here; there is a structural test guarding that).
+Part B (G-1391): `/capture` is now real — it dedupes + scores the captured job by
+REUSING `services.extension_capture.capture_and_score` (which calls
+`services.scoring.score_job`; the prompt is never reimplemented here). `/promote`
+adds a captured job to the pipeline via the shared
+`services.discovery.promote_discovered_job_to_application` service.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Annotated
-from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy.orm import Session
 
 from career_os import __version__
+from career_os.ai.base import ProviderQuotaError
+from career_os.ai.openrouter_provider import CreditsExhaustedError
 from career_os.api.oauth import limiter
+from career_os.database import get_db
 from career_os.schemas.extension import (
     CaptureRequest,
     CaptureResponse,
     InstanceInfo,
     PairRequest,
     PairResponse,
+    PromoteRequest,
+    PromoteResponse,
     StatusResponse,
+)
+from career_os.schemas.scoring import score_to_letter_grade
+from career_os.services.discovery import (
+    DiscoveredJobNotFoundError,
+    promote_discovered_job_to_application,
+)
+from career_os.services.extension_capture import (
+    CaptureIncompleteError,
+    CaptureTooLargeError,
+    build_plain_language_gap,
+    capture_and_score,
 )
 from career_os.services.extension_pairing import (
     consume_pairing_code,
     mint_extension_token,
     verify_extension_token,
 )
+from career_os.services.scoring import (
+    ProfileIncompleteError,
+    ProfileNotFoundError,
+    ScoringError,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/extension", tags=["extension"])
 
@@ -81,18 +107,90 @@ def pair(request: Request, payload: PairRequest) -> PairResponse:
 
 
 @router.post("/capture", response_model=CaptureResponse)
-def capture(
+async def capture(
     payload: CaptureRequest,
     _token: Annotated[str, Depends(require_extension_token)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> CaptureResponse:
-    """STUB: accept a captured job and return an id. No scoring, no DB write.
+    """Dedupe + score a captured job, returning its score, breakdown and gap.
 
-    Phase 1 wires this to the scoring service (via the discovery adapters
-    normalization path). Until then it is intentionally inert so the extension
-    channel can be built and tested end-to-end with zero product/LLM cost.
+    Scoring is delegated to ``services.extension_capture.capture_and_score`` which
+    reuses ``services.scoring.score_job`` — the prompt is NOT reimplemented here.
+    Domain exceptions map to HTTP mirroring ``api/scoring.py`` (T-01B-04: the
+    response is an explicit Pydantic model, never a raw ORM dump).
     """
-    job_id = str(uuid4())
-    return CaptureResponse(job_id=job_id, status="accepted", scored=False)
+    profile_id = payload.profile_id or 1
+    try:
+        dj, scored = await capture_and_score(db, payload, profile_id=profile_id)
+    except CaptureTooLargeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    except CaptureIncompleteError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ProfileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProfileIncompleteError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (CreditsExhaustedError, ProviderQuotaError) as exc:
+        raise HTTPException(
+            status_code=402, detail=f"AI provider credits exhausted: {exc}"
+        ) from exc
+    except ScoringError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive 500
+        logger.exception("Extension capture failed")
+        raise HTTPException(status_code=500, detail=f"Capture error: {exc}") from exc
+
+    breakdown: list | None = None
+    if scored.score_breakdown:
+        try:
+            parsed = json.loads(scored.score_breakdown)
+            breakdown = parsed if isinstance(parsed, list) else None
+        except (json.JSONDecodeError, ValueError):
+            breakdown = None
+
+    return CaptureResponse(
+        job_id=str(dj.id),
+        status="scored",
+        scored=True,
+        discovered_job_id=dj.id,
+        fit_score=scored.fit_score,
+        letter_grade=score_to_letter_grade(scored.fit_score),
+        score_breakdown=breakdown,
+        gap=build_plain_language_gap(scored),
+    )
+
+
+@router.post("/promote", response_model=PromoteResponse)
+def promote(
+    payload: PromoteRequest,
+    _token: Annotated[str, Depends(require_extension_token)],
+    db: Annotated[Session, Depends(get_db)],
+) -> PromoteResponse:
+    """Add a captured DiscoveredJob to the pipeline (idempotent one-click promote).
+
+    Delegates to the shared ``promote_discovered_job_to_application`` service with
+    ``source="extension"``; a second call for the same job returns the same
+    Application (the DiscoveredJob↔Application link is ``DiscoveredJob.application_id``).
+    """
+    profile_id = 1
+    try:
+        app = promote_discovered_job_to_application(
+            db,
+            profile_id=profile_id,
+            discovered_job_id=payload.discovered_job_id,
+            source="extension",
+            notes=None,
+        )
+        db.commit()
+    except DiscoveredJobNotFoundError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive 500
+        db.rollback()
+        logger.exception("Extension promote failed")
+        raise HTTPException(status_code=500, detail=f"Promote error: {exc}") from exc
+
+    return PromoteResponse(application_id=app.id, status=app.status)
 
 
 @router.get("/status", response_model=StatusResponse)

--- a/src/career_os/api/extension.py
+++ b/src/career_os/api/extension.py
@@ -119,7 +119,9 @@ async def capture(
     Domain exceptions map to HTTP mirroring ``api/scoring.py`` (T-01B-04: the
     response is an explicit Pydantic model, never a raw ORM dump).
     """
-    profile_id = payload.profile_id or 1
+    # Profile is fixed server-side to the single-user default; never honor a
+    # client-supplied profile_id (MED-01 / SECURITY F-2). Matches /promote.
+    profile_id = 1
     try:
         dj, scored = await capture_and_score(db, payload, profile_id=profile_id)
     except CaptureTooLargeError as exc:

--- a/src/career_os/api/extension.py
+++ b/src/career_os/api/extension.py
@@ -29,9 +29,9 @@ from career_os.schemas.extension import (
     StatusResponse,
 )
 from career_os.services.extension_pairing import (
+    consume_pairing_code,
     mint_extension_token,
     verify_extension_token,
-    verify_pairing_code,
 )
 
 router = APIRouter(prefix="/api/extension", tags=["extension"])
@@ -75,7 +75,7 @@ def pair(request: Request, payload: PairRequest) -> PairResponse:
     app wires to ``app.state.limiter``) to kill brute-force of the 6-digit code —
     T-01A-01. slowapi requires the ``request: Request`` first parameter.
     """
-    if not verify_pairing_code(payload.pairing_code):
+    if not consume_pairing_code(payload.pairing_code):
         raise HTTPException(status_code=401, detail="Invalid or expired pairing code")
     return PairResponse(token=mint_extension_token(), instance=_instance_info())
 

--- a/src/career_os/cli/extension.py
+++ b/src/career_os/cli/extension.py
@@ -1,10 +1,11 @@
-"""CLI commands for browser-extension pairing (Phase 0 / G-1390).
+"""CLI commands for browser-extension pairing (Phase 0 / G-1390, hardened G-1391).
 
-`kestrel extension pair` surfaces the current pairing code so the user can read it
-from their own running instance and type it into the extension's options page once.
-This is the chosen bootstrap surface (a future web-UI panel can render the same
-code): possession of the code proves local access to the instance, and submitting
-it to POST /api/extension/pair mints the extension's dedicated token.
+`kestrel extension pair` MINTS a fresh single-use pairing code the user reads from
+their own running instance and types into the extension's options page once. Each
+invocation generates a new random code (invalidating any previous one) and persists
+only its hash + a short expiry; submitting the code to POST /api/extension/pair
+consumes it and mints the extension's dedicated token. Possession of the code proves
+local access to the instance.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from career_os.config import settings
-from career_os.services.extension_pairing import current_pairing_code
+from career_os.services.extension_pairing import mint_pairing_code
 
 console = Console()
 
@@ -27,18 +28,18 @@ extension_app = typer.Typer(
 
 @extension_app.command("pair")
 def pair() -> None:
-    """Print the current pairing code for the browser extension."""
-    code = current_pairing_code()
-    window_minutes = settings.extension_pairing_window_seconds // 60
+    """Mint and print a fresh single-use pairing code for the browser extension."""
+    code = mint_pairing_code()
+    ttl_minutes = max(1, settings.extension_pairing_ttl_seconds // 60)
 
     console.print(
         Panel(
             f"[bold cyan]{code}[/bold cyan]\n\n"
             f"Enter this code in the Kestrel browser extension's options page to\n"
-            f"pair it with this instance. The code is valid for about "
-            f"[bold]{window_minutes} minute(s)[/bold]; run this command again for a\n"
-            f"fresh one. Pairing mints a dedicated token stored by the extension —\n"
-            f"it never uses or reveals your AUTH_API_KEY.",
+            f"pair it with this instance. The code is [bold]single-use[/bold] and expires in\n"
+            f"about [bold]{ttl_minutes} minute(s)[/bold]; run this command again for a fresh one.\n"
+            f"Pairing mints a dedicated token stored by the extension — it never\n"
+            f"uses or reveals your AUTH_API_KEY.",
             title="[bold]Extension Pairing Code[/bold]",
             border_style="cyan",
         )

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -46,12 +46,11 @@ class Settings(BaseSettings):
     # (D-2). extension_token_secret seeds the stateless HMAC token/pairing-code
     # scheme; when empty it is auto-generated and persisted to
     # {data_dir}/.extension_secret so tokens survive a backend restart (see
-    # services.extension_pairing). extension_pairing_window_seconds is the pairing
-    # code's validity window (a code stays valid across one boundary). The CORS
-    # regex ADDS concrete chrome-extension:// origins (Chrome extension IDs are 32
-    # chars in a–p) without widening the existing credentialed frontend CORS list.
+    # services.extension_pairing). Pairing now uses a single-use nonce minted by
+    # `kestrel extension pair` (G-1391), not a time-window code. The CORS regex
+    # ADDS concrete chrome-extension:// origins (Chrome extension IDs are 32 chars
+    # in a–p) without widening the existing credentialed frontend CORS list.
     extension_token_secret: str = ""
-    extension_pairing_window_seconds: int = 300
     extension_cors_regex: str = r"^chrome-extension://[a-p]{32}$"
     # Extension token max-age (G-1391 / Part A hardening). A minted token embeds
     # its issued-ts; verify_extension_token rejects one older than this many days

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     # mints a one-time code whose sha256+expiry is persisted to
     # {data_dir}/.extension_pairing (0600); the code is consumed on first use.
     extension_pairing_ttl_seconds: int = 120
+    # Max JD/raw-text length accepted by /api/extension/capture (G-1391 / Part B,
+    # SECURITY T-01B-01). Description/raw_text longer than this is rejected with a
+    # 413 BEFORE any LLM extraction or scoring call, bounding paid-LLM cost/DoS.
+    extension_max_jd_chars: int = 30000
 
     # Cache settings
     cache_enabled: bool = True

--- a/src/career_os/config.py
+++ b/src/career_os/config.py
@@ -53,6 +53,14 @@ class Settings(BaseSettings):
     extension_token_secret: str = ""
     extension_pairing_window_seconds: int = 300
     extension_cors_regex: str = r"^chrome-extension://[a-p]{32}$"
+    # Extension token max-age (G-1391 / Part A hardening). A minted token embeds
+    # its issued-ts; verify_extension_token rejects one older than this many days
+    # (→ 401 re-pair). 0 (or negative) disables the age check (signature-only).
+    extension_token_ttl_days: int = 30
+    # Single-use pairing-nonce validity (G-1391 / Part A). `kestrel extension pair`
+    # mints a one-time code whose sha256+expiry is persisted to
+    # {data_dir}/.extension_pairing (0600); the code is consumed on first use.
+    extension_pairing_ttl_seconds: int = 120
 
     # Cache settings
     cache_enabled: bool = True

--- a/src/career_os/schemas/extension.py
+++ b/src/career_os/schemas/extension.py
@@ -34,7 +34,11 @@ class CaptureRequest(BaseModel):
 
     Two entry modes: structured fields (title+company scraped by the client) OR
     ``raw_text`` only (the backend runs one LLM extraction to fill the fields).
-    ``profile_id`` defaults to the single-user self-hosted profile (1).
+
+    There is deliberately NO ``profile_id`` field: the owning profile is fixed
+    server-side to the single-user default (1), matching ``/promote``. A
+    client-supplied ``profile_id`` must never be trusted (MED-01 / SECURITY F-2)
+    — accepting one let a paired token write/score into an arbitrary profile.
     """
 
     url: str = ""
@@ -48,7 +52,6 @@ class CaptureRequest(BaseModel):
         default=None,
         description="Unstructured page text for the LLM-extraction fallback",
     )
-    profile_id: int = Field(default=1, description="Owning profile (single-user default 1)")
 
 
 class CaptureResponse(BaseModel):

--- a/src/career_os/schemas/extension.py
+++ b/src/career_os/schemas/extension.py
@@ -30,23 +30,51 @@ class PairResponse(BaseModel):
 
 
 class CaptureRequest(BaseModel):
-    """Normalized job payload captured by the extension (Phase 0 stub target)."""
+    """Job payload captured by the extension (Part B — now really scored).
 
-    url: str
-    title: str
-    company: str
-    description: str
+    Two entry modes: structured fields (title+company scraped by the client) OR
+    ``raw_text`` only (the backend runs one LLM extraction to fill the fields).
+    ``profile_id`` defaults to the single-user self-hosted profile (1).
+    """
+
+    url: str = ""
+    title: str = ""
+    company: str = ""
+    description: str = ""
     location: str | None = None
     salary: str | None = None
     source: str | None = None
+    raw_text: str | None = Field(
+        default=None,
+        description="Unstructured page text for the LLM-extraction fallback",
+    )
+    profile_id: int = Field(default=1, description="Owning profile (single-user default 1)")
 
 
 class CaptureResponse(BaseModel):
-    """Stub capture response — accepted with an id, but NOT scored in Phase 0."""
+    """Capture response — the deduped DiscoveredJob id plus its fresh score + gap."""
 
     job_id: str
     status: str = "accepted"
     scored: bool = False
+    discovered_job_id: int | None = None
+    fit_score: float | None = None
+    letter_grade: str | None = None
+    score_breakdown: list | None = None
+    gap: str | None = None
+
+
+class PromoteRequest(BaseModel):
+    """Body for POST /api/extension/promote — add a captured job to the pipeline."""
+
+    discovered_job_id: int = Field(..., description="DiscoveredJob to promote to an Application")
+
+
+class PromoteResponse(BaseModel):
+    """Result of promoting a captured job — the linked Application id + status."""
+
+    application_id: int
+    status: str
 
 
 class StatusResponse(BaseModel):

--- a/src/career_os/services/discovery.py
+++ b/src/career_os/services/discovery.py
@@ -43,6 +43,10 @@ class SearchProfileNotFoundError(Exception):
     """Raised when a search profile is not found."""
 
 
+class DiscoveredJobNotFoundError(Exception):
+    """Raised when a referenced DiscoveredJob does not exist for the profile."""
+
+
 # ---------------------------------------------------------------------------
 # Deduplication
 # ---------------------------------------------------------------------------
@@ -227,6 +231,62 @@ def _dedup_and_filter(all_raw_jobs, sp_filters):
     }
 
 
+def promote_discovered_job_to_application(
+    db: Session,
+    *,
+    profile_id: int,
+    discovered_job_id: int,
+    source: str,
+    notes: str | None = None,
+) -> Application:
+    """Create (or return the existing) Application linked to a DiscoveredJob.
+
+    Reusable add-to-pipeline: discovery calls it with ``source="discovery"`` and
+    the auto-discovered note (keeping its historical Application byte-identical);
+    the extension's ``/promote`` route calls it with ``source="extension"``.
+
+    Idempotent — if the DiscoveredJob already has an ``application_id``, the
+    existing Application is returned unchanged. Otherwise a new Application
+    mirroring the job's company/role/url/salary is created, linked via
+    ``DiscoveredJob.application_id``, and returned.
+
+    Raises ``DiscoveredJobNotFoundError`` when the job does not exist for the
+    profile. Flushes but does not commit (the caller controls the transaction).
+    """
+    dj = (
+        db.query(DiscoveredJob)
+        .filter(
+            DiscoveredJob.id == discovered_job_id,
+            DiscoveredJob.profile_id == profile_id,
+        )
+        .first()
+    )
+    if dj is None:
+        raise DiscoveredJobNotFoundError(
+            f"DiscoveredJob {discovered_job_id} not found for profile {profile_id}"
+        )
+
+    if dj.application_id is not None:
+        existing = db.query(Application).filter(Application.id == dj.application_id).first()
+        if existing is not None:
+            return existing
+
+    app = Application(
+        profile_id=profile_id,
+        company=dj.company,
+        role=dj.title,
+        url=dj.url,
+        source=source,
+        status="discovered",
+        salary_range=dj.salary_range,
+        notes=notes,
+    )
+    db.add(app)
+    db.flush()
+    dj.application_id = app.id
+    return app
+
+
 def _create_discovered_job(db: Session, profile_id: int, merged: dict, key: tuple):
     """Create a new DiscoveredJob + linked Application in a savepoint.
 
@@ -254,19 +314,17 @@ def _create_discovered_job(db: Session, profile_id: int, merged: dict, key: tupl
             db.add(dj)
             db.flush()
 
-            app = Application(
+            # Create the linked pipeline entry via the shared promote service so
+            # discovery and the extension produce an IDENTICAL Application shape.
+            # source/notes are passed explicitly to keep this path byte-identical
+            # to its historical inline form ("discovery" + the auto-discovered note).
+            promote_discovered_job_to_application(
+                db,
                 profile_id=profile_id,
-                company=merged["company"],
-                role=merged["title"],
-                url=merged["url"],
+                discovered_job_id=dj.id,
                 source="discovery",
-                status="discovered",
-                salary_range=merged["salary_range"],
                 notes=f"Auto-discovered from: {', '.join(merged['sources'])}",
             )
-            db.add(app)
-            db.flush()
-            dj.application_id = app.id
 
             # D-13: Auto-clear demo data when first real job arrives
             from career_os.services.applications import _auto_clear_demo_data

--- a/src/career_os/services/extension_capture.py
+++ b/src/career_os/services/extension_capture.py
@@ -38,6 +38,11 @@ _SENIORITY_OK_THRESHOLD = 5.0
 # Cap the number of missing keywords surfaced in the plain-language gap so the
 # string stays glanceable in the extension panel.
 _MAX_MISSING_KEYWORDS = 5
+# Per-field cap for the short structured fields (title/company/location/salary).
+# The big-text cap (settings.extension_max_jd_chars) only bounds
+# description/raw_text, but title+company flow into the scoring prompt too, so a
+# multi-megabyte title would bypass the DoS/cost bound (SECURITY F-1 / LOW-01).
+_MAX_FIELD_CHARS = 1000
 
 
 class CaptureTooLargeError(ValueError):
@@ -219,6 +224,20 @@ async def capture_and_score(
         for candidate in ((payload.description or ""), (payload.raw_text or "")):
             if len(candidate) > cap:
                 raise CaptureTooLargeError(f"Captured text exceeds the {cap}-character limit")
+
+    # Bound the short structured fields too, BEFORE any LLM/scoring call: title +
+    # company reach the scoring prompt, so an oversize one bypasses the JD cap
+    # (SECURITY F-1). Checked against a tighter per-field limit.
+    for field_name, field_value in (
+        ("title", payload.title),
+        ("company", payload.company),
+        ("location", payload.location),
+        ("salary", payload.salary),
+    ):
+        if field_value and len(field_value) > _MAX_FIELD_CHARS:
+            raise CaptureTooLargeError(
+                f"Captured {field_name} exceeds the {_MAX_FIELD_CHARS}-character limit"
+            )
 
     title = (payload.title or "").strip()
     company = (payload.company or "").strip()

--- a/src/career_os/services/extension_capture.py
+++ b/src/career_os/services/extension_capture.py
@@ -1,0 +1,294 @@
+"""Extension capture orchestration (G-1391 / Part B — "the eye" backend).
+
+Turns a job captured by the browser extension into a *scored* ``DiscoveredJob``
+by REUSING the existing services, never reimplementing scoring or its prompt:
+
+- dedupe/normalization from ``services.discovery`` (``_normalize`` + the
+  ``(profile_id, title, company, location)`` unique key),
+- scoring from ``services.scoring.score_job`` (the single source of the prompt),
+- a single ``AI_PROVIDER`` completion to extract structured fields when the
+  client could only scrape raw text.
+
+Cost/DoS is bounded per SECURITY T-01B-01: the JD/raw-text is size-capped
+(``settings.extension_max_jd_chars``) BEFORE any LLM or scoring call, and the
+raw-text extraction makes at most ONE provider call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy.orm import Session
+
+from career_os.ai.base import AIFeature
+from career_os.ai.factory import get_ai_provider
+from career_os.config import settings
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.scoring import ScoredJob
+from career_os.schemas.extension import CaptureRequest
+from career_os.services.discovery import _normalize
+from career_os.services.scoring import score_job
+
+logger = logging.getLogger(__name__)
+
+# Dimensional sub-scores are on a 0-10 scale; "mid" is the neutral midpoint used
+# to decide whether seniority is a match for the plain-language gap.
+_SENIORITY_OK_THRESHOLD = 5.0
+# Cap the number of missing keywords surfaced in the plain-language gap so the
+# string stays glanceable in the extension panel.
+_MAX_MISSING_KEYWORDS = 5
+
+
+class CaptureTooLargeError(ValueError):
+    """Raised when the captured JD/raw-text exceeds settings.extension_max_jd_chars.
+
+    A ``ValueError`` subclass so the route maps it to HTTP 413 (SECURITY
+    T-01B-01) while callers can still catch it precisely.
+    """
+
+
+class CaptureIncompleteError(ValueError):
+    """Raised when a payload has neither structured (title+company) nor raw text."""
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction fallback (raw-text-only payloads)
+# ---------------------------------------------------------------------------
+
+_EXTRACTION_PROMPT = """\
+Extract the job posting fields from the text below and return ONLY a JSON object
+with these keys: "company", "title", "description", "location", "salary".
+Use an empty string for any field you cannot determine. Do not add commentary.
+
+Job posting text:
+---
+{raw_text}
+---
+"""
+
+
+def _parse_extraction_json(content: str) -> dict:
+    """Parse the provider's extraction reply into a dict, tolerating loose formatting.
+
+    Strips common Markdown code fences and, failing a clean parse, extracts the
+    first ``{...}`` object. Never raises — returns ``{}`` when nothing parses so
+    the caller can fall back to raw text.
+    """
+    text = (content or "").strip()
+    if text.startswith("```"):
+        # Drop a leading ```json / ``` fence and any trailing fence.
+        text = text.split("```", 2)
+        text = text[1] if len(text) > 1 else ""
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip().rstrip("`").strip()
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Last resort: grab the first brace-delimited object.
+    start, end = text.find("{"), text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            parsed = json.loads(text[start : end + 1])
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return {}
+
+
+async def _extract_fields_via_llm(raw_text: str) -> dict:
+    """Extract {company,title,description,location,salary} from raw text.
+
+    Makes EXACTLY ONE ``provider.complete`` call. On an unparseable reply it
+    falls back to using the raw text as the description so scoring can proceed.
+    """
+    provider = get_ai_provider()
+    response = await provider.complete(
+        _EXTRACTION_PROMPT.format(raw_text=raw_text),
+        feature=AIFeature.complete,
+    )
+    fields = _parse_extraction_json(response.content)
+    return {
+        "company": str(fields.get("company") or "").strip(),
+        "title": str(fields.get("title") or "").strip(),
+        "description": str(fields.get("description") or "").strip() or raw_text,
+        "location": str(fields.get("location") or "").strip(),
+        "salary": str(fields.get("salary") or "").strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dedupe: find-or-create the DiscoveredJob
+# ---------------------------------------------------------------------------
+
+
+def _find_or_create_discovered_job(db: Session, profile_id: int, fields: dict) -> DiscoveredJob:
+    """Return the existing DiscoveredJob for this (profile, title/company/location) or create one.
+
+    Reuses discovery's ``_normalize`` for the dedup key so a captured job dedupes
+    against the exact same unique tuple discovery uses. On a hit, a blank stored
+    description is enriched with the freshly-captured one.
+    """
+    title = (fields.get("title") or "").strip() or "Unknown"
+    company = (fields.get("company") or "").strip() or "Unknown"
+    location = (fields.get("location") or "").strip()
+    title_norm = _normalize(title)
+    company_norm = _normalize(company)
+    location_norm = _normalize(location)
+
+    existing = (
+        db.query(DiscoveredJob)
+        .filter(
+            DiscoveredJob.profile_id == profile_id,
+            DiscoveredJob.title_normalized == title_norm,
+            DiscoveredJob.company_normalized == company_norm,
+            DiscoveredJob.location_normalized == location_norm,
+        )
+        .first()
+    )
+    if existing is not None:
+        if not (existing.description or "").strip() and (fields.get("description") or "").strip():
+            existing.description = fields["description"]
+        db.flush()
+        return existing
+
+    source = (fields.get("source") or "").strip() or "extension"
+    url = (fields.get("url") or "").strip()
+    dj = DiscoveredJob(
+        profile_id=profile_id,
+        title=title,
+        company=company,
+        location=location,
+        url=url or None,
+        description=(fields.get("description") or "").strip() or None,
+        salary_range=(fields.get("salary") or "").strip() or None,
+        remote=bool(fields.get("remote", False)),
+        posted_at=None,
+        title_normalized=title_norm,
+        company_normalized=company_norm,
+        location_normalized=location_norm,
+        sources=json.dumps([source]),
+        source_urls=json.dumps([url] if url else []),
+    )
+    db.add(dj)
+    db.flush()
+    return dj
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+async def capture_and_score(
+    db: Session, payload: CaptureRequest, *, profile_id: int
+) -> tuple[DiscoveredJob, ScoredJob]:
+    """Normalize + dedupe + (optionally LLM-extract) + score a captured job.
+
+    Returns ``(DiscoveredJob, ScoredJob)``. Raises ``CaptureTooLargeError`` (→413)
+    for oversize input BEFORE any LLM/scoring call, ``CaptureIncompleteError``
+    (→400) when nothing usable is present, and propagates scoring exceptions
+    (``ProfileIncompleteError``, ``CreditsExhaustedError``/``ProviderQuotaError``,
+    ``ScoringError``) for the route to map.
+    """
+    cap = settings.extension_max_jd_chars
+    if cap and cap > 0:
+        for candidate in ((payload.description or ""), (payload.raw_text or "")):
+            if len(candidate) > cap:
+                raise CaptureTooLargeError(f"Captured text exceeds the {cap}-character limit")
+
+    title = (payload.title or "").strip()
+    company = (payload.company or "").strip()
+    description = (payload.description or "").strip()
+    location = payload.location
+    salary = payload.salary
+    source = payload.source
+
+    # Raw-text-only path: the client couldn't scrape structured fields. Exactly
+    # one LLM call fills them in before dedupe + scoring.
+    if not (title and company):
+        raw_text = (payload.raw_text or "").strip() or description
+        if not raw_text:
+            raise CaptureIncompleteError("Capture needs either title+company or raw_text to score")
+        extracted = await _extract_fields_via_llm(raw_text)
+        title = title or extracted["title"]
+        company = company or extracted["company"]
+        description = description or extracted["description"]
+        location = location or extracted["location"] or None
+        salary = salary or extracted["salary"] or None
+
+    fields = {
+        "title": title,
+        "company": company,
+        "location": location or "",
+        "description": description,
+        "salary": salary or "",
+        "url": payload.url,
+        "source": source,
+    }
+    dj = _find_or_create_discovered_job(db, profile_id, fields)
+
+    scored = await score_job(
+        db,
+        profile_id,
+        job_description=description or dj.description or "",
+        job_url=payload.url,
+        job_title=dj.title,
+        job_company=dj.company,
+        discovered_job_id=dj.id,
+    )
+    db.refresh(dj)
+    return dj, scored
+
+
+# ---------------------------------------------------------------------------
+# Plain-language gap
+# ---------------------------------------------------------------------------
+
+
+def _coerce_json_list(value: object) -> list:
+    """Return a list from a JSON string / list / None. Never raises."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, ValueError):
+            return []
+    return []
+
+
+def build_plain_language_gap(scored: ScoredJob) -> str:
+    """Build a glanceable gap string, e.g. "missing: Kubernetes, Go; seniority ✓".
+
+    Derived from ``ats_keywords`` (unmatched → listed missing, capped) and
+    ``dim_seniority_alignment`` (≥ mid → "seniority ✓"). Defensive against
+    JSON-string / None / malformed fields — never raises.
+    """
+    missing: list[str] = []
+    for kw in _coerce_json_list(getattr(scored, "ats_keywords", None)):
+        if isinstance(kw, dict) and not kw.get("matched", False):
+            keyword = str(kw.get("keyword") or "").strip()
+            if keyword:
+                missing.append(keyword)
+        if len(missing) >= _MAX_MISSING_KEYWORDS:
+            break
+
+    parts: list[str] = []
+    if missing:
+        parts.append("missing: " + ", ".join(missing))
+    else:
+        parts.append("no major keyword gaps")
+
+    seniority = getattr(scored, "dim_seniority_alignment", None)
+    if isinstance(seniority, int | float):
+        if seniority >= _SENIORITY_OK_THRESHOLD:
+            parts.append("seniority ✓")
+        else:
+            parts.append("seniority gap")
+
+    return "; ".join(parts)

--- a/src/career_os/services/extension_capture.py
+++ b/src/career_os/services/extension_capture.py
@@ -178,6 +178,26 @@ def _find_or_create_discovered_job(db: Session, profile_id: int, fields: dict) -
     return dj
 
 
+def _latest_fresh_score(db: Session, profile_id: int, discovered_job_id: int) -> ScoredJob | None:
+    """Return the newest non-stale ScoredJob for this discovered job, or None.
+
+    A capture that re-hits an already-scored job reuses this instead of paying
+    for another LLM scoring call and writing a duplicate ScoredJob row (MED-03).
+    Stale scores (weights/profile changed → ``is_stale``) are ignored so a
+    re-capture correctly re-scores when the existing score is no longer valid.
+    """
+    return (
+        db.query(ScoredJob)
+        .filter(
+            ScoredJob.profile_id == profile_id,
+            ScoredJob.discovered_job_id == discovered_job_id,
+            ScoredJob.is_stale.is_(False),
+        )
+        .order_by(ScoredJob.created_at.desc())
+        .first()
+    )
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -230,6 +250,16 @@ async def capture_and_score(
         "source": source,
     }
     dj = _find_or_create_discovered_job(db, profile_id, fields)
+
+    # Re-capture short-circuit (MED-03): if this job was already scored and the
+    # score is still fresh, return it instead of making another paid LLM scoring
+    # call and inserting a duplicate ScoredJob row. A brand-new capture has no
+    # prior score, so this only triggers on a genuine dedupe hit.
+    existing_score = _latest_fresh_score(db, profile_id, dj.id)
+    if existing_score is not None:
+        db.commit()  # persist any description enrichment from the dedupe hit
+        db.refresh(dj)
+        return dj, existing_score
 
     scored = await score_job(
         db,

--- a/src/career_os/services/extension_pairing.py
+++ b/src/career_os/services/extension_pairing.py
@@ -4,13 +4,15 @@ Phase 0 / G-1390. The browser extension authenticates with a DEDICATED token tha
 is entirely separate from the global ``AUTH_API_KEY`` (locked decision D-1) and is
 required even when ``AUTH_ENABLED`` is off (D-2). The flow:
 
-1. The user reads a short-lived, 6-digit pairing code from their own running
-   instance (``kestrel extension pair`` / a future web-UI surface). The code is an
-   HMAC of a server-side secret over a time window, so possession of the code
-   proves local access to the instance.
-2. The extension submits the code to ``POST /api/extension/pair``; the backend
-   validates it and mints a distinct, stateless HMAC token the extension stores and
-   sends as ``Authorization: Bearer <token>`` on every subsequent call.
+1. The user mints a fresh, single-use 6-digit pairing code from their own running
+   instance (``kestrel extension pair`` / a future web-UI surface). Only its
+   sha256 + a short expiry is persisted (``{data_dir}/.extension_pairing``, 0600);
+   possession of the code proves local access to the instance (G-1391 hardening —
+   replaces the always-valid time-windowed code).
+2. The extension submits the code to ``POST /api/extension/pair`` (rate-limited);
+   the backend consumes (deletes) the nonce and mints a distinct, stateless HMAC
+   token the extension stores and sends as ``Authorization: Bearer <token>`` on
+   every subsequent call. The token carries a configurable max-age (TTL).
 
 **Stateless by design (no DB table, no Alembic migration).** These are pure
 functions over a persisted secret — trivially unit-testable and avoiding a
@@ -36,6 +38,7 @@ import base64
 import binascii
 import hashlib
 import hmac
+import json
 import os
 import secrets
 import time
@@ -128,44 +131,95 @@ def _b64url_decode(value: str) -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# Pairing code — HMAC(secret, window), truncated to 6 digits
+# Pairing code — single-use nonce (G-1391 / Part A hardening)
+#
+# The Phase 0 model was an always-valid, HMAC-over-a-time-window code: an
+# attacker who could reach /pair had a standing target. This replaces it with a
+# user-initiated, single-use nonce: `kestrel extension pair` mints a random
+# 6-digit code and persists ONLY its sha256 + an expiry to
+# {data_dir}/.extension_pairing (0600, mirroring .extension_secret). /pair
+# consumes (deletes) the file on first success, so a code works exactly once and
+# for at most ``extension_pairing_ttl_seconds``. No DB table, no migration.
 # ---------------------------------------------------------------------------
 
-
-def _current_window() -> int:
-    """Return the current pairing time window index."""
-    window_seconds = settings.extension_pairing_window_seconds or 300
-    return int(time.time()) // window_seconds
+_PAIRING_FILENAME = ".extension_pairing"
 
 
-def _code_for_window(window: int) -> str:
-    """Derive the 6-digit zero-padded code for a given window."""
-    digest = hmac.new(get_extension_secret(), str(window).encode(), hashlib.sha256).digest()
-    return f"{int.from_bytes(digest[:4], 'big') % 1_000_000:06d}"
+def _pairing_path() -> Path:
+    return Path(settings.data_dir) / _PAIRING_FILENAME
 
 
-def current_pairing_code() -> str:
-    """Return the current 6-digit pairing code."""
-    return _code_for_window(_current_window())
+def _write_pairing_file(payload: str) -> None:
+    """Atomically write the nonce file 0600, overwriting any prior nonce.
+
+    Write to a private (O_CREAT|O_EXCL, 0600) temp file then ``os.replace`` over
+    the target: the swap is atomic and the result always carries the 0600 mode
+    (never a world-readable window). Mint is user-initiated + single-writer, so
+    clobbering a previous unconsumed code is the intended behavior.
+    """
+    path = _pairing_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
-def verify_pairing_code(code: str | None) -> bool:
-    """Accept the code for the current AND previous window; reject everything else.
+def mint_pairing_code() -> str:
+    """Mint a fresh single-use 6-digit pairing code and persist its hash+expiry.
 
-    Checking the previous window keeps a code valid across a window boundary so a
-    user who reads a code near the end of a window can still submit it. Comparison
-    is timing-safe.
+    Returns the plaintext code (shown once to the user); the file stores only
+    ``sha256(code)`` so a leak of the file never reveals the code. Overwrites any
+    prior nonce, so each CLI invocation invalidates the previous code.
+    """
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    payload = json.dumps(
+        {
+            "hash": hashlib.sha256(code.encode()).hexdigest(),
+            "expires": time.time() + settings.extension_pairing_ttl_seconds,
+        }
+    )
+    _write_pairing_file(payload)
+    return code
+
+
+def consume_pairing_code(code: str | None) -> bool:
+    """Return True once for the matching, non-expired code, then delete the file.
+
+    Single-use: a second call with the same code returns False (the file is gone).
+    Returns False for empty/None input, a missing file, an expired entry (which is
+    also cleaned up), or a wrong code. On a wrong code the file is left in place so
+    the legitimate user can retry until expiry. Comparison is timing-safe.
     """
     if not code:
         return False
-    candidate = str(code)
-    window = _current_window()
-    valid = False
-    # Evaluate both windows unconditionally (no short-circuit) to keep timing flat.
-    for w in (window, window - 1):
-        if hmac.compare_digest(candidate, _code_for_window(w)):
-            valid = True
-    return valid
+    path = _pairing_path()
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        stored_hash = str(data["hash"])
+        expires = float(data["expires"])
+    except (ValueError, KeyError, TypeError, OSError):
+        return False
+    if time.time() > expires:
+        path.unlink(missing_ok=True)  # stale nonce — clean up, reject
+        return False
+    candidate = hashlib.sha256(str(code).encode()).hexdigest()
+    if hmac.compare_digest(candidate, stored_hash):
+        path.unlink(missing_ok=True)  # single-use: consume on success
+        return True
+    return False
+
+
+def reset_pairing_state() -> None:
+    """Delete any persisted pairing nonce (test helper / explicit un-pair)."""
+    _pairing_path().unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/career_os/services/extension_pairing.py
+++ b/src/career_os/services/extension_pairing.py
@@ -181,10 +181,14 @@ def mint_extension_token() -> str:
 
 
 def verify_extension_token(token: str | None) -> bool:
-    """Return True iff the token's signature verifies under the current secret.
+    """Return True iff the token verifies under the current secret AND is not stale.
 
     Rejects empty input, malformed/truncated strings, and tampered signatures.
-    No expiry check in Phase 0 (documented in the module docstring). Timing-safe.
+    The signature is checked FIRST (timing-safe); only then is the embedded
+    issued-ts compared against ``settings.extension_token_ttl_days`` — so an
+    attacker learns nothing new from an expired-vs-forged distinction. A token
+    strictly older than the TTL is rejected (→ 401 re-pair). A TTL of 0 or less
+    disables the age check (signature-only), for tests and a "never expire" mode.
     """
     if not token or not isinstance(token, str):
         return False
@@ -197,4 +201,17 @@ def verify_extension_token(token: str | None) -> bool:
     except (ValueError, TypeError, binascii.Error):
         return False
     expected = hmac.new(get_extension_secret(), issued, hashlib.sha256).digest()
-    return hmac.compare_digest(signature, expected)
+    if not hmac.compare_digest(signature, expected):
+        return False
+
+    # Max-age check (G-1391). The signed payload IS the issued epoch, so a valid
+    # signature guarantees the timestamp is authentic (not attacker-chosen).
+    ttl_days = settings.extension_token_ttl_days
+    if ttl_days > 0:
+        try:
+            issued_ts = int(issued.decode("ascii"))
+        except (ValueError, UnicodeDecodeError):
+            return False
+        if time.time() - issued_ts > ttl_days * 86400:
+            return False
+    return True

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -381,6 +381,32 @@ class TestDiscoveryService:
         assert dj.application_id == apps[0].id
 
     @pytest.mark.asyncio
+    async def test_discovery_application_source_and_notes_unchanged(self, db_session):
+        """R2 regression guard: after the promote refactor, the discovery path must
+        still produce an Application with source='discovery' AND the auto-discovered
+        notes string (byte-identical to the pre-refactor inline creation).
+
+        Without this, a future change routing discovery through the shared promote
+        service with source='extension' or dropped notes would ship silently.
+        """
+        adapter = MockAdapter(
+            "arbeitnow",
+            [_make_job("arbeitnow", title="Data Eng", company="DataCo", location="Remote")],
+        )
+        with (
+            patch(
+                "career_os.services.discovery.get_available_adapters",
+                return_value=[adapter],
+            ),
+            _PREFILTER_OFF,
+        ):
+            await run_discovery(db_session, 1, keywords=["data"])
+
+        app = db_session.query(Application).filter(Application.profile_id == 1).one()
+        assert app.source == "discovery"
+        assert app.notes == "Auto-discovered from: arbeitnow"
+
+    @pytest.mark.asyncio
     async def test_scraper_failure_doesnt_block_others(self, db_session):
         """VAL-DISC-009: One source failing still returns results from others."""
         adapter_ok = MockAdapter(

--- a/tests/test_extension_api.py
+++ b/tests/test_extension_api.py
@@ -25,12 +25,25 @@ _EXTENSION_SRC = (
 
 
 @pytest.fixture(autouse=True)
-def _deterministic_secret(monkeypatch):
-    """Pin the extension secret so pairing codes/tokens are deterministic."""
+def _deterministic_secret(monkeypatch, tmp_path):
+    """Pin the extension secret + isolate per-test pairing/rate-limit state.
+
+    - Pins ``EXTENSION_TOKEN_SECRET`` so codes/tokens are deterministic.
+    - Points ``settings.data_dir`` at a tmp dir so the single-use pairing nonce
+      file (``.extension_pairing``) is isolated per test.
+    - Resets the shared slowapi limiter before and after each test so the 429
+      rate-limit test does not throttle unrelated tests (all requests share the
+      TestClient source IP).
+    """
+    from career_os.api.oauth import limiter as _oauth_limiter
+
     monkeypatch.setenv("EXTENSION_TOKEN_SECRET", "test-extension-secret-000")
+    monkeypatch.setattr(extension_pairing.settings, "data_dir", tmp_path)
     extension_pairing.reset_secret_cache()
+    _oauth_limiter.reset()
     yield
     extension_pairing.reset_secret_cache()
+    _oauth_limiter.reset()
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +110,45 @@ class TestExtensionPairing:
         assert extension_pairing.verify_extension_token("a.b.c") is False
         assert extension_pairing.verify_extension_token(".") is False
 
+    @staticmethod
+    def _token_issued_at(issued_ts: int) -> str:
+        """Forge a validly-signed token whose embedded issued-ts is `issued_ts`.
+
+        Uses the real secret + HMAC path (so the signature verifies) but lets the
+        test choose the age — no time monkeypatching needed.
+        """
+        import hashlib
+        import hmac
+
+        issued = str(int(issued_ts)).encode("ascii")
+        secret = extension_pairing.get_extension_secret()
+        signature = hmac.new(secret, issued, hashlib.sha256).digest()
+        return (
+            f"{extension_pairing._b64url_encode(issued)}."
+            f"{extension_pairing._b64url_encode(signature)}"
+        )
+
+    def test_fresh_token_verifies_within_ttl(self, monkeypatch):
+        monkeypatch.setattr(extension_pairing.settings, "extension_token_ttl_days", 30)
+        token = extension_pairing.mint_extension_token()
+        assert extension_pairing.verify_extension_token(token) is True
+
+    def test_token_older_than_ttl_is_rejected(self, monkeypatch):
+        """A token whose issued-ts is older than the TTL fails verification (→401)."""
+        import time
+
+        monkeypatch.setattr(extension_pairing.settings, "extension_token_ttl_days", 30)
+        stale = self._token_issued_at(int(time.time()) - 31 * 86400)
+        assert extension_pairing.verify_extension_token(stale) is False
+
+    def test_ttl_zero_disables_age_check(self, monkeypatch):
+        """TTL <= 0 = never-expire mode: even an ancient token still verifies."""
+        import time
+
+        monkeypatch.setattr(extension_pairing.settings, "extension_token_ttl_days", 0)
+        ancient = self._token_issued_at(int(time.time()) - 3650 * 86400)  # ~10 years
+        assert extension_pairing.verify_extension_token(ancient) is True
+
     def test_token_minted_under_different_secret_fails(self, monkeypatch):
         token = extension_pairing.mint_extension_token()
         # Rotate the secret — the old token must no longer verify.
@@ -159,6 +211,17 @@ class TestExtensionRoutes:
         resp = client.post("/api/extension/pair", json={"pairing_code": "999999"})
         assert resp.status_code == 401
         assert resp.json()["detail"] == "Invalid or expired pairing code"
+
+    def test_pair_rate_limited_returns_429(self, client: TestClient):
+        """The 6th /pair within a minute from the same IP is throttled (T-01A-01)."""
+        # Fire 6 requests; the limiter is 5/minute/IP. Use a wrong code so none
+        # succeed — the limiter counts attempts regardless of the outcome.
+        statuses = [
+            client.post("/api/extension/pair", json={"pairing_code": "999999"}).status_code
+            for _ in range(6)
+        ]
+        assert statuses[:5] == [401, 401, 401, 401, 401]
+        assert statuses[5] == 429
 
     def test_capture_without_token_returns_401(self, client: TestClient):
         resp = client.post(

--- a/tests/test_extension_api.py
+++ b/tests/test_extension_api.py
@@ -19,9 +19,9 @@ from career_os.services import extension_pairing
 # A concrete, valid 32-char (a–p) Chrome extension origin for CORS assertions.
 _CHROME_ORIGIN = "chrome-extension://" + "a" * 32
 
-_EXTENSION_SRC = (
-    Path(__file__).resolve().parent.parent / "src" / "career_os" / "api" / "extension.py"
-)
+_SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "career_os"
+_EXTENSION_SRC = _SRC_ROOT / "api" / "extension.py"
+_CAPTURE_SVC_SRC = _SRC_ROOT / "services" / "extension_capture.py"
 
 
 @pytest.fixture(autouse=True)
@@ -267,24 +267,10 @@ class TestExtensionRoutes:
         assert resp.status_code == 401
         assert resp.json()["detail"] == "Extension not paired"
 
-    def test_capture_with_token_returns_job_id_unscored(self, client: TestClient):
-        token = extension_pairing.mint_extension_token()
-        resp = client.post(
-            "/api/extension/capture",
-            json={
-                "url": "https://example.com/job",
-                "title": "Engineer",
-                "company": "Acme",
-                "description": "Build things",
-                "location": "Remote",
-            },
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["scored"] is False
-        assert body["status"] == "accepted"
-        assert isinstance(body["job_id"], str) and body["job_id"]
+    # NOTE: the Phase-0 "capture returns an UNSCORED id" test was removed here —
+    # capture now really dedupes + scores (Part B). Real capture behavior (scoring,
+    # dedupe, LLM fallback, size cap, promote) is covered in test_extension_capture.py
+    # where the DB/profile fixtures are available.
 
     def test_capture_with_bad_token_returns_401(self, client: TestClient):
         resp = client.post(
@@ -323,11 +309,12 @@ class TestExtensionRoutes:
         )
         assert resp_global.status_code == 401
 
-        # A valid EXTENSION token reaches the route → 200.
+        # A valid EXTENSION token gets PAST the global middleware to the per-route
+        # token check. We assert on /status (token-gated, no DB/scoring) so this
+        # test stays about the middleware bypass, not capture's scoring path.
         token = extension_pairing.mint_extension_token()
-        resp_ok = client.post(
-            "/api/extension/capture",
-            json=payload,
+        resp_ok = client.get(
+            "/api/extension/status",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp_ok.status_code == 200
@@ -344,9 +331,19 @@ class TestExtensionRoutes:
         assert resp.status_code == 200
         assert resp.headers.get("access-control-allow-origin") == _CHROME_ORIGIN
 
-    def test_capture_does_not_import_score_job(self):
-        """Structural guard: the capture module must not reference score_job."""
-        assert "score_job" not in _EXTENSION_SRC.read_text(encoding="utf-8")
+    def test_capture_scores_through_scoring_service(self):
+        """Re-scoped structural guard (was test_capture_does_not_import_score_job).
+
+        Capture now legitimately scores, but ONLY by going THROUGH
+        services.scoring — it must not reimplement the prompt. Assert:
+        - the extension_capture service references score_job (reuse, not reimpl),
+        - the route delegates to capture_and_score rather than calling score_job
+          or building a scoring prompt itself.
+        """
+        capture_src = _CAPTURE_SVC_SRC.read_text(encoding="utf-8")
+        route_src = _EXTENSION_SRC.read_text(encoding="utf-8")
+        assert "score_job" in capture_src
+        assert "capture_and_score" in route_src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extension_api.py
+++ b/tests/test_extension_api.py
@@ -54,36 +54,63 @@ def _deterministic_secret(monkeypatch, tmp_path):
 class TestExtensionPairing:
     """Unit tests for the pure pairing/token functions."""
 
-    def test_current_pairing_code_is_six_digits(self):
-        code = extension_pairing.current_pairing_code()
+    def test_mint_pairing_code_is_six_digits_and_persisted(self):
+        code = extension_pairing.mint_pairing_code()
         assert isinstance(code, str)
         assert len(code) == 6
         assert code.isdigit()
+        # Only the hash + expiry are stored (never the code itself), 0600.
+        path = extension_pairing._pairing_path()
+        assert path.is_file()
+        assert (path.stat().st_mode & 0o777) == 0o600
+        assert code not in path.read_text(encoding="utf-8")
 
-    def test_verify_accepts_current_code(self):
-        code = extension_pairing.current_pairing_code()
-        assert extension_pairing.verify_pairing_code(code) is True
+    def test_consume_accepts_minted_code_once(self):
+        code = extension_pairing.mint_pairing_code()
+        assert extension_pairing.consume_pairing_code(code) is True
 
-    def test_verify_accepts_previous_window_code(self, monkeypatch):
-        """A code from the previous window is still accepted across a boundary."""
-        window = extension_pairing._current_window()
-        prev_code = extension_pairing._code_for_window(window - 1)
-        assert extension_pairing.verify_pairing_code(prev_code) is True
+    def test_consume_is_single_use(self):
+        """The second consume of the same code fails (nonce deleted on success)."""
+        code = extension_pairing.mint_pairing_code()
+        assert extension_pairing.consume_pairing_code(code) is True
+        assert extension_pairing.consume_pairing_code(code) is False
+        assert extension_pairing._pairing_path().exists() is False
 
-    def test_verify_rejects_wrong_code(self):
-        code = extension_pairing.current_pairing_code()
+    def test_consume_rejects_expired_code(self):
+        """An expired nonce is rejected (and cleaned up); a wrong code stays valid."""
+        import json
+        import time
+
+        code = extension_pairing.mint_pairing_code()
+        # Rewrite the persisted nonce with an already-past expiry.
+        path = extension_pairing._pairing_path()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["expires"] = time.time() - 1
+        path.write_text(json.dumps(data), encoding="utf-8")
+        assert extension_pairing.consume_pairing_code(code) is False
+        assert path.exists() is False
+
+    def test_consume_rejects_wrong_code_but_keeps_file(self):
+        code = extension_pairing.mint_pairing_code()
         wrong = "000000" if code != "000000" else "111111"
-        assert extension_pairing.verify_pairing_code(wrong) is False
+        assert extension_pairing.consume_pairing_code(wrong) is False
+        # File left in place so the legitimate user can still retry until expiry.
+        assert extension_pairing._pairing_path().is_file()
+        assert extension_pairing.consume_pairing_code(code) is True
 
-    def test_verify_rejects_empty_and_none(self):
-        assert extension_pairing.verify_pairing_code("") is False
-        assert extension_pairing.verify_pairing_code(None) is False
+    def test_consume_rejects_empty_none_and_missing_file(self):
+        assert extension_pairing.consume_pairing_code("") is False
+        assert extension_pairing.consume_pairing_code(None) is False
+        # No file minted yet → reject.
+        extension_pairing.reset_pairing_state()
+        assert extension_pairing.consume_pairing_code("123456") is False
 
-    def test_code_changes_across_windows(self, monkeypatch):
-        window = extension_pairing._current_window()
-        assert extension_pairing._code_for_window(window) != extension_pairing._code_for_window(
-            window + 5
-        )
+    def test_mint_regenerates_and_invalidates_previous_code(self):
+        first = extension_pairing.mint_pairing_code()
+        second = extension_pairing.mint_pairing_code()
+        # A re-mint overwrites the nonce, so the first code no longer works.
+        assert extension_pairing.consume_pairing_code(first) is False
+        assert extension_pairing.consume_pairing_code(second) is True
 
     def test_mint_then_verify_token(self):
         token = extension_pairing.mint_extension_token()
@@ -200,12 +227,21 @@ class TestExtensionRoutes:
     """End-to-end route behavior against the wire contract."""
 
     def test_pair_with_valid_code_returns_token_and_instance(self, client: TestClient):
-        code = extension_pairing.current_pairing_code()
+        code = extension_pairing.mint_pairing_code()
         resp = client.post("/api/extension/pair", json={"pairing_code": code})
         assert resp.status_code == 200
         body = resp.json()
         assert extension_pairing.verify_extension_token(body["token"]) is True
         assert body["instance"] == {"name": "Kestrel", "version": __version__}
+
+    def test_pair_code_is_single_use_over_the_wire(self, client: TestClient):
+        """Re-POSTing a consumed code returns 401 (nonce already spent)."""
+        code = extension_pairing.mint_pairing_code()
+        first = client.post("/api/extension/pair", json={"pairing_code": code})
+        assert first.status_code == 200
+        second = client.post("/api/extension/pair", json={"pairing_code": code})
+        assert second.status_code == 401
+        assert second.json()["detail"] == "Invalid or expired pairing code"
 
     def test_pair_with_wrong_code_returns_401(self, client: TestClient):
         resp = client.post("/api/extension/pair", json={"pairing_code": "999999"})
@@ -319,9 +355,11 @@ class TestExtensionRoutes:
 
 
 class TestExtensionCli:
-    """The CLI surfaces a currently-valid pairing code."""
+    """The CLI mints a fresh single-use pairing code."""
 
-    def test_pair_command_prints_valid_code(self):
+    @staticmethod
+    def _run_pair() -> str:
+        """Invoke `kestrel extension pair` and return the printed 6-digit code."""
         import re
 
         from typer.testing import CliRunner
@@ -330,8 +368,20 @@ class TestExtensionCli:
 
         result = CliRunner().invoke(cli_app, ["extension", "pair"])
         assert result.exit_code == 0
-
         # Strip Rich box formatting/newlines to recover the 6-digit code.
         digits = re.findall(r"\b\d{6}\b", result.stdout.replace("\n", " "))
         assert digits, f"no 6-digit code in output: {result.stdout!r}"
-        assert extension_pairing.verify_pairing_code(digits[0]) is True
+        return digits[0]
+
+    def test_pair_command_prints_consumable_code(self):
+        code = self._run_pair()
+        # The CLI-minted code is accepted by consume_pairing_code exactly once.
+        assert extension_pairing.consume_pairing_code(code) is True
+        assert extension_pairing.consume_pairing_code(code) is False
+
+    def test_pair_command_regenerates_code_each_call(self):
+        first = self._run_pair()
+        second = self._run_pair()
+        # A second CLI call mints a fresh code and invalidates the first.
+        assert extension_pairing.consume_pairing_code(first) is False
+        assert extension_pairing.consume_pairing_code(second) is True

--- a/tests/test_extension_capture.py
+++ b/tests/test_extension_capture.py
@@ -1,0 +1,282 @@
+"""Tests for the real extension capture + promote surface (G-1391 / Part B).
+
+Covers the ``services.extension_capture`` orchestration and the wired
+``/api/extension/capture`` + ``/api/extension/promote`` routes: structured and
+raw-text (LLM-fallback) scoring, dedupe, the size cap (413), profile-incomplete
+(422), token gating (401), and idempotent promote. AI_PROVIDER=mock is enforced
+by conftest; the raw-text path patches the extraction provider only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from career_os.config import settings
+from career_os.models.discovery import DiscoveredJob
+from career_os.models.models import Application, Profile
+from career_os.models.scoring import ScoredJob
+from career_os.services import extension_pairing
+
+_MIGRATIONS_DIR = (
+    Path(__file__).resolve().parent.parent / "src" / "career_os" / "_alembic" / "versions"
+)
+
+
+@pytest.fixture(autouse=True)
+def _extension_env(monkeypatch, tmp_path):
+    """Pin the extension secret, isolate the pairing/rate-limit state per test.
+
+    Mirrors the autouse fixture in test_extension_api.py — the shared oauth
+    limiter must be reset around each test or unrelated /pair throttling leaks in.
+    """
+    from career_os.api.oauth import limiter as _oauth_limiter
+
+    monkeypatch.setenv("EXTENSION_TOKEN_SECRET", "test-extension-secret-000")
+    monkeypatch.setattr(extension_pairing.settings, "data_dir", tmp_path)
+    extension_pairing.reset_secret_cache()
+    _oauth_limiter.reset()
+    yield
+    extension_pairing.reset_secret_cache()
+    _oauth_limiter.reset()
+
+
+def _auth_headers() -> dict:
+    """A valid Bearer extension token header."""
+    return {"Authorization": f"Bearer {extension_pairing.mint_extension_token()}"}
+
+
+_STRUCTURED_PAYLOAD = {
+    "url": "https://example.com/job/1",
+    "title": "Senior Backend Engineer",
+    "company": "Acme Corp",
+    "description": "Build distributed systems in Python. Kubernetes, Go a plus.",
+    "location": "Remote",
+    "salary": "150-180k",
+}
+
+
+# ---------------------------------------------------------------------------
+# Structured capture → real score
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredCapture:
+    def test_structured_capture_scores_and_persists(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        resp = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["scored"] is True
+        assert body["status"] == "scored"
+        assert isinstance(body["fit_score"], int | float)
+        assert body["discovered_job_id"] is not None
+        assert isinstance(body["gap"], str) and body["gap"]
+        assert body["letter_grade"]
+
+        djs = db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 1).all()
+        assert len(djs) == 1
+        assert djs[0].id == body["discovered_job_id"]
+        scored = db_session.query(ScoredJob).filter(ScoredJob.discovered_job_id == djs[0].id).all()
+        assert len(scored) >= 1
+
+    def test_recapture_same_job_dedupes_to_one_discovered_job(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        first = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        second = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        assert first.status_code == 200 and second.status_code == 200
+        # Same DiscoveredJob reused (dedupe on normalized title/company/location).
+        assert first.json()["discovered_job_id"] == second.json()["discovered_job_id"]
+        djs = db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 1).all()
+        assert len(djs) == 1
+
+    def test_oversize_description_returns_413(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        payload = {
+            **_STRUCTURED_PAYLOAD,
+            "description": "x" * (settings.extension_max_jd_chars + 1),
+        }
+        resp = client.post("/api/extension/capture", json=payload, headers=_auth_headers())
+        assert resp.status_code == 413
+        # No DiscoveredJob/ScoredJob created — the cap trips before any DB write.
+        assert db_session.query(DiscoveredJob).count() == 0
+        assert db_session.query(ScoredJob).count() == 0
+
+    def test_profile_incomplete_returns_422(self, client: TestClient, db_session: Session):
+        # A profile that exists but lacks job_family/location → ProfileIncompleteError.
+        db_session.add(Profile(id=1, name="Incomplete", email="i@example.com"))
+        db_session.commit()
+        resp = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        assert resp.status_code == 422
+
+    def test_capture_without_token_returns_401(self, client: TestClient):
+        resp = client.post("/api/extension/capture", json=_STRUCTURED_PAYLOAD)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Raw-text capture → single LLM extraction, then score
+# ---------------------------------------------------------------------------
+
+
+class _StubExtractionProvider:
+    """A stub AI provider whose ``complete`` returns fixed JSON and counts calls."""
+
+    def __init__(self, content: str):
+        self._content = content
+        self.calls = 0
+
+    async def complete(self, prompt, *, feature=None, **kwargs):
+        self.calls += 1
+
+        class _Resp:
+            content = self._content
+
+        return _Resp()
+
+
+class TestRawTextCapture:
+    def test_raw_text_runs_one_extraction_then_scores(
+        self, client: TestClient, db_session: Session, profile: Profile, monkeypatch
+    ):
+        extracted = json.dumps(
+            {
+                "company": "Globex",
+                "title": "Platform Engineer",
+                "description": "Own the CI/CD platform. Terraform, Go.",
+                "location": "Berlin",
+                "salary": "",
+            }
+        )
+        stub = _StubExtractionProvider(extracted)
+        monkeypatch.setattr(
+            "career_os.services.extension_capture.get_ai_provider", lambda *a, **k: stub
+        )
+
+        resp = client.post(
+            "/api/extension/capture",
+            json={"url": "https://example.com/job/raw", "raw_text": "Globex is hiring..."},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["scored"] is True
+        # Exactly ONE extraction provider call (cost/DoS bound).
+        assert stub.calls == 1
+
+        dj = db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 1).one()
+        assert dj.company == "Globex"
+        assert dj.title == "Platform Engineer"
+
+
+# ---------------------------------------------------------------------------
+# Promote — add captured job to pipeline (idempotent)
+# ---------------------------------------------------------------------------
+
+
+class TestPromote:
+    def _capture(self, client: TestClient) -> int:
+        resp = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        assert resp.status_code == 200
+        return resp.json()["discovered_job_id"]
+
+    def test_promote_creates_linked_application(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        dj_id = self._capture(client)
+        resp = client.post(
+            "/api/extension/promote", json={"discovered_job_id": dj_id}, headers=_auth_headers()
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "discovered"
+        app = db_session.query(Application).filter(Application.id == body["application_id"]).one()
+        assert app.source == "extension"
+        # The DiscoveredJob↔Application link is DiscoveredJob.application_id.
+        dj = db_session.query(DiscoveredJob).filter(DiscoveredJob.id == dj_id).one()
+        assert dj.application_id == app.id
+
+    def test_promote_is_idempotent(self, client: TestClient, db_session: Session, profile: Profile):
+        dj_id = self._capture(client)
+        first = client.post(
+            "/api/extension/promote", json={"discovered_job_id": dj_id}, headers=_auth_headers()
+        )
+        second = client.post(
+            "/api/extension/promote", json={"discovered_job_id": dj_id}, headers=_auth_headers()
+        )
+        assert first.status_code == 200 and second.status_code == 200
+        assert first.json()["application_id"] == second.json()["application_id"]
+        assert db_session.query(Application).count() == 1
+
+    def test_promote_without_token_returns_401(self, client: TestClient):
+        resp = client.post("/api/extension/promote", json={"discovered_job_id": 1})
+        assert resp.status_code == 401
+
+    def test_promote_missing_job_returns_404(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        resp = client.post(
+            "/api/extension/promote", json={"discovered_job_id": 9999}, headers=_auth_headers()
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# No schema drift: this plan adds ZERO Alembic migrations
+# ---------------------------------------------------------------------------
+
+
+def test_no_new_alembic_migration_added():
+    """Part B reuses existing tables only — this branch may add no migration file.
+
+    The link column ``DiscoveredJob.application_id`` already exists; capture and
+    promote write only to existing tables. Compare the versions/ dir against the
+    branch merge-base with main so this stays correct even as unrelated migrations
+    land on main. Skips cleanly if git isn't available (e.g. an sdist test run).
+    """
+    import subprocess
+
+    assert _MIGRATIONS_DIR.is_dir()
+    repo_root = _MIGRATIONS_DIR.parents[3]
+    try:
+        base = subprocess.run(
+            ["git", "merge-base", "HEAD", "main"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        changed = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                f"{base}..HEAD",
+                "--",
+                "src/career_os/_alembic/versions/",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pytest.skip("git unavailable — migration-leak guard runs in CI")
+    assert not changed, f"Part B must add no migration; changed: {changed}"

--- a/tests/test_extension_capture.py
+++ b/tests/test_extension_capture.py
@@ -128,6 +128,26 @@ class TestStructuredCapture:
         resp = client.post("/api/extension/capture", json=_STRUCTURED_PAYLOAD)
         assert resp.status_code == 401
 
+    def test_capture_ignores_client_profile_id(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        """A client-supplied profile_id must be ignored — capture always uses 1.
+
+        MED-01 / SECURITY F-2: /capture previously did ``payload.profile_id or 1``,
+        letting a paired token write/score into an arbitrary profile. The field is
+        removed from CaptureRequest and the route hardcodes profile 1 (matching
+        /promote); an attacker-named profile_id is silently dropped by Pydantic.
+        """
+        resp = client.post(
+            "/api/extension/capture",
+            json={**_STRUCTURED_PAYLOAD, "profile_id": 999},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200, resp.text
+        # DiscoveredJob landed under profile 1, never the client-named 999.
+        assert db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 1).count() == 1
+        assert db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 999).count() == 0
+
 
 # ---------------------------------------------------------------------------
 # Raw-text capture → single LLM extraction, then score

--- a/tests/test_extension_capture.py
+++ b/tests/test_extension_capture.py
@@ -152,6 +152,21 @@ class TestStructuredCapture:
         assert db_session.query(DiscoveredJob).count() == 0
         assert db_session.query(ScoredJob).count() == 0
 
+    def test_oversize_title_returns_413(
+        self, client: TestClient, db_session: Session, profile: Profile
+    ):
+        """A multi-megabyte title is rejected before any LLM/DB write (F-1).
+
+        The big-text cap only bounds description/raw_text, but title+company flow
+        into the scoring prompt, so an unbounded title bypassed the cost/DoS
+        bound. Short fields now have their own per-field cap.
+        """
+        payload = {**_STRUCTURED_PAYLOAD, "title": "x" * 5000}
+        resp = client.post("/api/extension/capture", json=payload, headers=_auth_headers())
+        assert resp.status_code == 413
+        assert db_session.query(DiscoveredJob).count() == 0
+        assert db_session.query(ScoredJob).count() == 0
+
     def test_profile_incomplete_returns_422(self, client: TestClient, db_session: Session):
         # A profile that exists but lacks job_family/location → ProfileIncompleteError.
         db_session.add(Profile(id=1, name="Incomplete", email="i@example.com"))

--- a/tests/test_extension_capture.py
+++ b/tests/test_extension_capture.py
@@ -102,6 +102,43 @@ class TestStructuredCapture:
         djs = db_session.query(DiscoveredJob).filter(DiscoveredJob.profile_id == 1).all()
         assert len(djs) == 1
 
+    def test_recapture_reuses_score_no_second_scoring_call(
+        self, client: TestClient, db_session: Session, profile: Profile, monkeypatch
+    ):
+        """Capturing the same job twice scores ONCE and never duplicates the score.
+
+        MED-03: dedupe only deduped the DiscoveredJob; score_job unconditionally
+        inserted a new ScoredJob on every call, so a second Capture click silently
+        re-charged a paid LLM call and left two ScoredJob rows. On a dedupe hit
+        with a fresh existing score we now return it without re-scoring.
+        """
+        import career_os.services.extension_capture as ec
+
+        calls = {"n": 0}
+        real_score_job = ec.score_job
+
+        async def _counting_score_job(*args, **kwargs):
+            calls["n"] += 1
+            return await real_score_job(*args, **kwargs)
+
+        monkeypatch.setattr(ec, "score_job", _counting_score_job)
+
+        first = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        second = client.post(
+            "/api/extension/capture", json=_STRUCTURED_PAYLOAD, headers=_auth_headers()
+        )
+        assert first.status_code == 200 and second.status_code == 200
+        # Second capture reused the first score: exactly ONE scoring call...
+        assert calls["n"] == 1
+        # ...and exactly ONE ScoredJob row for the single deduped DiscoveredJob.
+        dj_id = first.json()["discovered_job_id"]
+        assert second.json()["discovered_job_id"] == dj_id
+        assert db_session.query(ScoredJob).filter(ScoredJob.discovered_job_id == dj_id).count() == 1
+        # The reused score is still returned to the caller.
+        assert second.json()["fit_score"] == first.json()["fit_score"]
+
     def test_oversize_description_returns_413(
         self, client: TestClient, db_session: Session, profile: Profile
     ):


### PR DESCRIPTION
## Browser Extension — Phase 1: THE EYE

The v1 payoff of the Kestrel browser extension (epic G-1389). One button on any job posting scrapes it, scores it against your profile inline, shows a plain-language fit gap, adds it to your pipeline, and auto-logs the application when you submit — **companion, review-first, never blind auto-apply**. Builds on Phase 0 (#470).

### What's here

**Part A — pairing hardening** (closes the security gaps deferred from Phase 0)
- `POST /api/extension/pair` rate-limited (5/min/IP, shared slowapi limiter).
- Single-use, user-initiated pairing code (`kestrel extension pair` mints it; only `sha256(code)`+expiry stored at `data/.extension_pairing`, consumed on first use).
- Extension token now expires (`extension_token_ttl_days`, default 30). **No Alembic migration.**

**Part B — real capture → scoring**
- `/api/extension/capture` now creates/dedupes a job and scores it **through `services.scoring.score_job`** (no reimplementation), returning the fit score + breakdown + a plain-language gap. Raw-text pages get one LLM extraction call; structured pages (JSON-LD) cost none. Re-capturing a job reuses the existing score (no repeat LLM cost).
- New token-gated `POST /api/extension/promote` (add-to-pipeline), refactored from discovery's inline logic — discovery's own Applications stay byte-identical (`source="discovery"`, verified by a new regression test).

**Part C/D — the extension (WXT + React 19, MV3)**
- One-button capture (popup + floating in-page button) with tiered extraction: JSON-LD `JobPosting` → OpenGraph → raw-text + LLM fallback.
- **sidePanel** score/gap panel (surface-agnostic `ScorePanel`, in-page overlay documented as fallback) + one-click add-to-pipeline.
- Auto-log-on-submit for Greenhouse/Lever/Ashby: a **visible, dismissible** "Log this application?" banner that names the job — never silent, and it only *logs* (no autofill, no auto-submit).
- Manifest stays least-privilege: `activeTab` + `storage` + `sidePanel` + explicit ATS content-script matches. **No `<all_urls>`, no telemetry.**

### Verification
- Backend: `pytest tests/test_extension_api.py tests/test_extension_capture.py tests/test_discovery.py` → **97 passed** (+ 700 in the broad regression sweep, 0 regressions).
- Extension: `npm run build` ✔, `npm run compile` (tsc strict) ✔, `npm run test` → **58 passed**.
- No `<all_urls>`; no new migration; scoring goes through `score_job` (guard-tested).

### Reviewed
Code review (0 critical) + security audit (17/17 threat mitigations verified, **the G-1390 pairing risk is now closed**, go-for-merge). All findings fixed before this PR:
- **HIGH:** auto-log TDZ crash on the confirmation-page path — fixed + regression test.
- **Medium:** `/capture` no longer trusts a client `profile_id`; auto-log banner names the job; re-capture reuses the existing score (cost); per-field size caps.
- **Low:** 500 handlers no longer echo internal exception text.
- **Deferred (tracked, G-1432):** per-token capture rate-limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
