### PR TITLE
fix(G-1391): resolve CodeQL js/double-escaping in extension stripHtml

### DIFF
--- a/extension/__tests__/extraction.test.ts
+++ b/extension/__tests__/extraction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { extractJob, isJobPage } from "@/lib/extraction";
+import { stripHtml } from "@/lib/extraction/dom";
 
 // ---------------------------------------------------------------------------
 // Extraction is a pure function over a `Document`, so every case builds a
@@ -203,5 +204,24 @@ describe("isJobPage", () => {
   it("is false on a page with no JobPosting signal", () => {
     const d = doc(`<html><body>just a blog</body></html>`);
     expect(isJobPage(d)).toBe(false);
+  });
+});
+
+describe("stripHtml entity decoding (js/double-escaping guard)", () => {
+  it("decodes each entity exactly once — no double-unescape of &amp;lt;", () => {
+    // The encoded literal text "&lt;" is written as "&amp;lt;"; it must decode
+    // to the literal "&lt;", NOT to "<" (which a chained decode would produce).
+    expect(stripHtml("a &amp;lt; b")).toBe("a &lt; b");
+    expect(stripHtml("x &amp;gt; y")).toBe("x &gt; y");
+  });
+
+  it("still decodes plain entities and strips tags", () => {
+    expect(stripHtml("<b>A&nbsp;&amp;&nbsp;B</b>")).toBe("A & B");
+    expect(stripHtml("<p>1 &lt; 2</p>")).toBe("1 < 2");
+  });
+
+  it("returns empty string for non-string input", () => {
+    expect(stripHtml(null)).toBe("");
+    expect(stripHtml(undefined)).toBe("");
   });
 });

--- a/extension/lib/extraction/dom.ts
+++ b/extension/lib/extraction/dom.ts
@@ -4,19 +4,29 @@
  * page-provided strings are turned into plain text, never re-injected as HTML.
  */
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+};
+
 /** Strip HTML tags and collapse whitespace to plain text (no innerHTML sink). */
 export function stripHtml(value: unknown): string {
   if (typeof value !== "string") {
     return "";
   }
-  return value
-    .replace(/<[^>]*>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    value
+      .replace(/<[^>]*>/g, " ")
+      // Single-pass entity decode: each entity is decoded exactly once, left to
+      // right, so an encoded literal like "&amp;lt;" yields "&lt;" (not "<").
+      // A chained .replace() (with &amp; first) would double-unescape it — the
+      // js/double-escaping class CodeQL flags.
+      .replace(/&(nbsp|amp|lt|gt);/gi, (m) => HTML_ENTITIES[m.toLowerCase()] ?? m)
+      .replace(/\s+/g, " ")
+      .trim()
+  );
 }
 
 /** Read a `<meta property=... | name=...>` content attribute, or "". */


### PR DESCRIPTION
Resolves CodeQL alert #177 (js/double-escaping, HIGH) introduced in Phase 1 (#478).

`extension/lib/extraction/dom.ts::stripHtml` chained `.replace()` calls decoding `&amp;` **before** `&lt;`/`&gt;`, so an encoded literal like `&amp;lt;` double-unescaped to `<` instead of the literal `&lt;`. Replaced the chain with a single-pass entity decode (one regex + lookup map) so each entity is decoded exactly once.

Impact is text-only (extraction output is sent to the backend as JD text, never re-injected as HTML), but it is incorrect and left a HIGH code-scanning alert on main.

Adds 3 direct `stripHtml` tests (incl. the `&amp;lt;` double-escape case). Extension: 61 tests pass, tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)