### PR TITLE
fix(G-1427): Web Storage shim covers Node 26's undefined localStorage global

### DIFF
--- a/frontend/src/__tests__/test-setup.test.ts
+++ b/frontend/src/__tests__/test-setup.test.ts
@@ -1,0 +1,29 @@
+/** Regression tests for the test-environment Web Storage shim (G-1427).
+ *
+ * Node 25+ ships an experimental webstorage global that shadows jsdom's
+ * localStorage/sessionStorage; without the shim in test-setup.ts, every
+ * component touching Web Storage fails on newer local Node versions while
+ * CI (Node 22) stays green. These assertions pin that the environment
+ * always provides a WORKING Storage, whatever Node exposes natively.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("vitest environment Web Storage (G-1427)", () => {
+  it("localStorage supports the full round-trip", () => {
+    localStorage.setItem("g1427-key", "value");
+    expect(localStorage.getItem("g1427-key")).toBe("value");
+    localStorage.removeItem("g1427-key");
+    expect(localStorage.getItem("g1427-key")).toBeNull();
+    localStorage.setItem("g1427-a", "1");
+    localStorage.clear();
+    expect(localStorage.getItem("g1427-a")).toBeNull();
+  });
+
+  it("sessionStorage supports the full round-trip", () => {
+    sessionStorage.setItem("g1427-key", "value");
+    expect(sessionStorage.getItem("g1427-key")).toBe("value");
+    sessionStorage.clear();
+    expect(sessionStorage.getItem("g1427-key")).toBeNull();
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,11 +1,15 @@
 import "@testing-library/jest-dom/vitest";
 
-// Node.js 25+ provides a built-in localStorage global where methods
-// (clear, setItem, getItem, removeItem) are undefined. This conflicts
-// with jsdom's proper Web Storage implementation. Polyfill the missing
-// methods to ensure tests can use localStorage/sessionStorage normally.
+// Node.js 25+ ships an experimental webstorage global that shadows jsdom's
+// proper Web Storage implementation. Its shape varies by Node version:
+// Node 25 exposes a localStorage object whose methods (clear, setItem,
+// getItem, removeItem) are undefined; Node 26 exposes a getter that
+// evaluates to `undefined` entirely (unless --localstorage-file is set),
+// while still occupying the global so jsdom's version never installs
+// (G-1427). Polyfill whenever a WORKING Storage is absent, covering both
+// shapes.
 if (
-  typeof localStorage !== "undefined" &&
+  typeof localStorage === "undefined" ||
   typeof localStorage.clear !== "function"
 ) {
   const store = new Map<string, string>();
@@ -26,7 +30,7 @@ if (
 }
 
 if (
-  typeof sessionStorage !== "undefined" &&
+  typeof sessionStorage === "undefined" ||
   typeof sessionStorage.clear !== "function"
 ) {
   const store = new Map<string, string>();


### PR DESCRIPTION
## Summary
Fixes the 57 local-only frontend test failures on Node 26 (G-1427). The existing test-setup shim only handled Node 25's webstorage shape (object present, methods undefined); Node 26 exposes `localStorage` as an undefined-valued getter, so the guard skipped the polyfill while the native global still shadowed jsdom's Storage. The guard now installs the Map-backed polyfill whenever a working Storage is absent — both Node shapes plus plain jsdom are covered.

Adds regression tests pinning full `localStorage`/`sessionStorage` round-trips in the vitest environment.

## Validation
- Node 26 local: **376/376 pass** (previously 317 pass / 57 fail in Discovery + KanbanBoard).
- Node 22 (CI): unaffected — jsdom's Storage passes the guard and is used as before.
- eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uk9RJQnzuckwxXrJPakoes