### PR TITLE
G-1469: clear undici + brace-expansion advisories in all 3 npm trees

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -2400,9 +2400,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4615,9 +4615,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1468,9 +1468,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -11,6 +11,7 @@
     "wrangler": "^4.0.0"
   },
   "overrides": {
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "undici": "^7.29.0"
   }
 }


### PR DESCRIPTION
## What

Two npm advisory sets published 2026-08-04 turned both audit gates (the frontend workflow check and `tests/test_dep_security.py`) red on every PR:

- **undici** GHSA-4cwx-7wf7-3272 (high) + 4 moderate, fixed in 7.29.0
- **brace-expansion** GHSA-rgw5-rvv9-x895 (high DoS), fixed in 1.1.18 / 5.0.9

Dependabot #493 only bumped `frontend`'s undici, so its own CI still failed on `worker` undici and brace-expansion in `frontend`/`extension`. This PR clears all three trees:

| Tree | Change | How |
|---|---|---|
| frontend | undici 7.28.0 → 7.29.0, brace-expansion 5.0.8 → 5.0.9 | `npm update` (in-range) |
| worker | undici 7.28.0 → 7.29.0 | `"undici": "^7.29.0"` override (miniflare pins exact; dev-only tree, patch bump) |
| extension | brace-expansion 1.1.16 → 1.1.18 | `npm update` (in-range) |

## Verification

- GitHub tags confirmed for undici v7.29.0, brace-expansion v1.1.18 / v5.0.9 (supply-chain check)
- `npm audit signatures`: clean in all three trees (315 verified signatures + 115 attestations in frontend)
- `tests/test_dep_security.py`: 4 passed locally
- frontend `npm test`: 376/376 passed
- `npm audit --audit-level=high`: worker 0 vulns; frontend/extension remainder (react-router, postcss) is pre-allowlisted, unchanged by this PR

Supersedes #493 (will close it once this merges). Unblocks #494. Tracked in Linear G-1469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtvvsTYvyomdjU7mcQLMPX