### PR TITLE
G-1449: fix no-op PII CI gate + Kestrel credibility cleanup

### DIFF
--- a/.github/pii-patterns.txt
+++ b/.github/pii-patterns.txt
@@ -1,9 +1,23 @@
-# PII patterns for CI leak detection
-# These patterns catch personal identifiers that should not appear in source code.
-# Add project-specific patterns below (one per line, blank lines and # comments are ignored).
+# PII patterns for the CI leak check (see the "PII leak check" step in ci.yml).
 #
-# For forks: replace these with your own patterns or delete lines you don't need.
-# Add your own PII patterns here (one per line).
-# Example:
+# One extended-regex pattern per line. Blank lines and # comments are ignored.
+# The gate scans EVERY tracked file (code, markdown, docs, profile/) via
+# `git grep`, so a pattern here catches identifiers wherever they land — not
+# just in code directories.
+#
+# Two ways to supply patterns:
+#   1. This file — committed and PUBLIC. Only put patterns here that are safe to
+#      publish (generic shapes, a fork's own project name). NEVER put a real
+#      person's name, email, phone, or address here: committing the pattern
+#      leaks the very thing it guards.
+#   2. The PII_PATTERNS repo secret (Settings -> Secrets -> Actions) — PRIVATE,
+#      newline-delimited. Put real identifiers here so they never enter source
+#      history. The gate merges both sources. Fork PRs don't receive the secret,
+#      so they fall back to this file alone.
+#
+# With zero active patterns from both sources the gate is INACTIVE and emits a
+# CI warning (it will not silently report "clean").
+#
+# Example (safe generic shapes only):
 # your\.email
 # yourname

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,21 +127,54 @@ jobs:
           pip-audit "${ignore_args[@]}"
 
       - name: PII leak check
+        # Scans every TRACKED file with `git grep` — this deliberately covers
+        # markdown, docs, and profile/ (not just code dirs). A prior version
+        # scanned only src/ tests/ frontend/src/ tools/ with 5 code extensions,
+        # so a markdown dossier committed elsewhere sailed through unseen.
+        #
+        # Patterns come from two sources, so the public repo never has to carry
+        # real identifiers:
+        #   1. .github/pii-patterns.txt  — committed, public; forks edit this.
+        #   2. PII_PATTERNS repo secret  — private, newline-delimited; the owner's
+        #      real identifiers live here, never in source. Empty on fork PRs
+        #      (secrets aren't shared with forks) — that path just no-ops loudly.
+        env:
+          PII_PATTERNS_SECRET: ${{ secrets.PII_PATTERNS }}
         run: |
-          # Check for personal data patterns defined in .github/pii-patterns.txt
-          # For forks: update that file with your own patterns
-          FAIL=0
-          if [ -f .github/pii-patterns.txt ]; then
-            while IFS= read -r pattern; do
-              [[ "$pattern" =~ ^#.*$ || -z "$pattern" ]] && continue
-              if grep -rn "$pattern" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.yaml" --include="*.yml" \
-                src/ tests/ frontend/src/ tools/ 2>/dev/null; then
-                echo "PII pattern found: $pattern"
-                FAIL=1
-              fi
-            done < .github/pii-patterns.txt
+          patterns=()
+          add_patterns() {  # read one-per-line, skip blanks and # comments
+            while IFS= read -r line; do
+              [[ "$line" =~ ^[[:space:]]*# || -z "${line// }" ]] && continue
+              patterns+=("$line")
+            done
+          }
+          [ -f .github/pii-patterns.txt ] && add_patterns < .github/pii-patterns.txt
+          [ -n "${PII_PATTERNS_SECRET:-}" ] && add_patterns <<< "$PII_PATTERNS_SECRET"
+
+          echo "PII gate: ${#patterns[@]} active pattern(s) loaded."
+          if [ "${#patterns[@]}" -eq 0 ]; then
+            # Fail-open ONLY here, and loudly: an empty gate is legitimate for a
+            # fresh fork, but must never masquerade as a passing PII check.
+            echo "::warning::PII gate is INACTIVE (0 patterns). Add patterns to .github/pii-patterns.txt or the PII_PATTERNS secret to enable it."
+            exit 0
           fi
-          [ "$FAIL" -eq 0 ] && echo "No PII found - clean." || exit 1
+
+          FAIL=0
+          for pattern in "${patterns[@]}"; do
+            # -l: list matching files only. Never print the matched line — that
+            # content is not a masked secret and would leak the very PII we guard.
+            files=$(git grep -lE -- "$pattern") && status=0 || status=$?
+            if [ "$status" -eq 0 ]; then
+              echo "::error::PII pattern matched in tracked files (pattern withheld from log):"
+              echo "$files"
+              FAIL=1
+            elif [ "$status" -ge 2 ]; then
+              # Fail-closed: a scan that errored is NOT a clean scan.
+              echo "::error::git grep errored (exit $status) while scanning — treating as failure."
+              exit 1
+            fi
+          done
+          [ "$FAIL" -eq 0 ] && echo "No PII found — clean." || exit 1
 
   actionlint:
     name: actionlint
@@ -240,28 +273,58 @@ jobs:
       - name: Verify npm package signatures
         run: npm audit signatures
 
+  extension:
+    name: Extension (WXT)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: extension
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install dependencies
+        # postinstall runs `wxt prepare`, which generates the .wxt/ type
+        # shims that the tsc compile step below depends on.
+        run: npm ci --legacy-peer-deps
+
+      - name: Type check
+        run: npm run compile
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Verify npm package signatures
+        run: npm audit signatures
+
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
     if: always()
-    needs: [backend, frontend, actionlint]
+    needs: [backend, frontend, extension, actionlint]
     steps:
       - name: Check required jobs
         env:
           BACKEND_RESULT: ${{ needs.backend.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
+          EXTENSION_RESULT: ${{ needs.extension.result }}
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
         run: |
-          # All three jobs are hard gates. Backend was advisory while the
+          # All four jobs are hard gates. Backend was advisory while the
           # golden-set failures were being resolved; those are fixed (main
           # has been fully green since 2026-06) and CI Complete is now a
           # required status check gating Dependabot automerge (G-1277) —
-          # a soft backend gate would let a broken pip bump auto-merge.
+          # a soft gate would let a broken bump auto-merge.
           failed=0
-          for job in backend frontend actionlint; do
+          for job in backend frontend extension actionlint; do
             case "$job" in
               backend) result="$BACKEND_RESULT" ;;
               frontend) result="$FRONTEND_RESULT" ;;
+              extension) result="$EXTENSION_RESULT" ;;
               actionlint) result="$ACTIONLINT_RESULT" ;;
             esac
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then

--- a/docs/roadmap/browser-extension.md
+++ b/docs/roadmap/browser-extension.md
@@ -10,7 +10,7 @@ Add any job from any website to your scoring queue with one click.
 
 Kestrel's built-in discovery engine scans major job boards automatically, but it cannot reach every posting. Some jobs appear on company career pages, niche boards, or platforms the scrapers do not cover. The browser extension fills that gap. When you find a job posting anywhere on the web, you click a button and it goes straight into your Kestrel pipeline for scoring.
 
-The extension will be available for Chrome and Firefox. It reads the page you are on, extracts the relevant job details (title, company, description, location), and sends them to your local Kestrel instance. You keep browsing. Behind the scenes, the job enters your scoring queue and gets evaluated like any other discovered position.
+The extension targets Chrome and Firefox (Manifest V3, built with WXT + React 19). It reads the page you are on, extracts the relevant job details (title, company, description, location), and sends them to your local Kestrel instance. You keep browsing. Behind the scenes, the job enters your scoring queue and gets evaluated like any other discovered position.
 
 ## Design Considerations
 
@@ -20,9 +20,11 @@ The extension communicates with a Kestrel instance running on your machine. This
 
 ## Current Status
 
-*Status: Planned -- not yet started*
+*Status: Built and tested in-repo (`extension/`) -- not yet published to the Chrome Web Store / Firefox Add-ons.*
 
-No implementation exists. The extension depends on a stable API surface from the backend, which is available today.
+The extension is implemented with WXT + React 19 on Manifest V3. Shipped entrypoints: a background service worker, page content scripts, an auto-log content script, a popup, a side panel, and an options page. Authentication is handled by a pairing flow (`PairingForm`) that exchanges a locally generated token with your Kestrel instance, and a `HealthBadge` surfaces backend connectivity. A `ScorePanel` shows the fit/desire score inline. The suite runs under Vitest (`extension/__tests__/`: extraction, autolog, background, options, score panel).
+
+What remains before a public release: store submission (Chrome Web Store + Firefox Add-ons review), and the offline queue-and-sync behavior for when Kestrel is not running.
 
 ## Related Milestones
 
@@ -33,13 +35,16 @@ No implementation exists. The extension depends on a stable API surface from the
 
 *For Contributors*
 
-## Open Questions
+Resolved during implementation:
 
-- How should the extension detect job posting content on pages with no standard markup? Heuristic-based extraction versus site-specific parsers is a core design choice
-- What authentication mechanism should the extension use to connect to the local Kestrel backend? A shared secret generated during setup, or something more formal?
-- Should the extension support a "quick preview" of the score before adding to the pipeline, or just a one-click save?
-- How should offline queuing work when Kestrel is not running? Local storage with automatic sync on reconnect?
-- Chrome Web Store and Firefox Add-ons have different review processes and content policies. What submission requirements need to be met?
+- **Authentication** -- a locally generated token exchanged during setup (`PairingForm`), as anticipated. Backend connectivity is surfaced by `HealthBadge`.
+- **Quick preview** -- the extension shows the fit/desire score inline (`ScorePanel`), not just a one-click save.
+
+Still open:
+
+- How should the extension detect job posting content on pages with no standard markup? Heuristic-based extraction versus site-specific parsers remains a live trade-off as coverage grows
+- How should offline queuing work when Kestrel is not running? Local storage with automatic sync on reconnect (not yet built)
+- Chrome Web Store and Firefox Add-ons have different review processes and content policies. What submission requirements need to be met before publishing?
 - Should the extension support multiple Kestrel instances (e.g., work laptop and personal desktop)?
 
 ## Research Needed
@@ -50,9 +55,7 @@ No dedicated extension research exists yet. Research areas include: Manifest V3 
 
 ## BMAD Integration
 
-**PRD Status:** Not started
-
-A PRD would define the supported site list and content extraction rules, the extension-to-backend communication protocol, Chrome Web Store and Firefox Add-ons submission requirements, and the offline job queuing strategy.
+**PRD Status:** Superseded by implementation for the core flow (extraction, pairing, scoring). A focused PRD would still help for the remaining pre-release scope: the supported-site list and extraction rules as coverage expands, store submission requirements, and the offline job-queuing strategy.
 
 To start a PRD: `/bmad-create-prd` in Claude Code.
 See the [planning hierarchy](inventory.md#how-planning-works) for how PRDs connect to implementation.

--- a/frontend/src/__tests__/Layout.test.tsx
+++ b/frontend/src/__tests__/Layout.test.tsx
@@ -23,9 +23,9 @@ function renderWithRouter(initialEntries: string[] = ["/"]) {
 }
 
 describe("Layout", () => {
-  it("renders the Career OS branding", () => {
+  it("renders the Kestrel branding", () => {
     renderWithRouter();
-    expect(screen.getByText("Career OS")).toBeInTheDocument();
+    expect(screen.getByText("Kestrel")).toBeInTheDocument();
   });
 
   it("renders Pipeline navigation link", () => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,18 @@
 import { Link, useLocation, Outlet } from "react-router-dom";
 import { cn } from "@/lib/utils";
-import { Kanban, BarChart3, Bell, Settings, Sparkles, BookOpen, Compass, Mic, Activity, Users, HelpCircle } from "lucide-react";
+import {
+  Kanban,
+  BarChart3,
+  Bell,
+  Settings,
+  Sparkles,
+  BookOpen,
+  Compass,
+  Mic,
+  Activity,
+  Users,
+  HelpCircle,
+} from "lucide-react";
 import { FeedbackButton } from "@/components/FeedbackButton";
 import { TourProvider } from "@/components/TourProvider";
 
@@ -27,7 +39,7 @@ export function Layout() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="text-xl font-bold text-gray-900">Career OS</span>
+              <span className="text-xl font-bold text-gray-900">Kestrel</span>
             </div>
             <div className="flex items-center gap-1">
               {navItems.map((item) => {
@@ -45,7 +57,7 @@ export function Layout() {
                       "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                       isActive
                         ? "bg-gray-100 text-gray-900"
-                        : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                        : "text-gray-600 hover:bg-gray-50 hover:text-gray-900",
                     )}
                   >
                     <Icon className="h-4 w-4" />

--- a/homebrew/kestrel.rb
+++ b/homebrew/kestrel.rb
@@ -29,6 +29,6 @@ class Kestrel < Formula
   end
 
   test do
-    assert_match "Career OS", shell_output("#{bin}/kestrel --help")
+    assert_match "Kestrel", shell_output("#{bin}/kestrel --help")
   end
 end


### PR DESCRIPTION
## Why

The PII leak check in CI was a **double no-op** and structurally could not have caught the kind of file that recently leaked into history (a markdown dossier). This PR makes the gate real, plus a batch of public-facing credibility fixes.

## PII gate (the important part)

Two structural bugs:
1. `pii-patterns.txt` had **zero active patterns** (all `#` comments) → loop body never ran → always "clean."
2. Even fully populated, the scan only covered `src/ tests/ frontend/src/ tools/` with 5 code extensions — **it never scanned markdown/docs**, exactly where personal data lands.

Rework:
- **Wide by construction:** scan every *tracked* file via `git grep` (covers `.md`, `docs/`, `profile/`; excludes `node_modules` for free). No path allowlist to forget.
- **Public-repo-safe patterns:** merge the committed `pii-patterns.txt` (forks edit) with a `PII_PATTERNS` **repo secret** so real identifiers never enter source. Fork PRs (no secret) fall back to the committed file.
- **Fail-closed:** a `git grep` error (exit ≥2, e.g. malformed regex) fails the build instead of reading as clean. Zero patterns → loud `::warning::` INACTIVE notice, never a silent pass.
- **No PII in logs:** matches list files only (`-l`), never the matched line.

Verified locally, 4 cases: `0 patterns → warn+pass`, `planted match in README.md → fail` (proves markdown is scanned), `no match → clean`, `malformed regex → fail-closed`.

> ⚠️ The gate stays INACTIVE (warns, doesn't fail) until the `PII_PATTERNS` secret is set in repo settings — a manual owner step.

## Credibility cleanup
- Frontend header **"Career OS" → "Kestrel"** (`Layout.tsx` + its test).
- `homebrew/kestrel.rb` asserted `"Career OS"` in `kestrel --help`, but the CLI says "Kestrel" — **the formula test would have failed.** Fixed.
- `docs/roadmap/browser-extension.md` said *"Planned — not yet started / No implementation exists"*, but `extension/` is a full **WXT + React 19 MV3** project with **61 passing tests**. Rewrote Current Status, resolved now-answered open questions (token pairing, inline score preview), corrected future-tense claims.
- Added an **Extension (WXT) CI job** (`npm ci → tsc --noEmit → vitest`) wired into the `ci-complete` required-jobs gate. Verified locally: compile clean, 61/61 pass.

## Deferred (flagged, not in this PR)
Gitignoring `.planning`/`_bmad`. Kestrel commits its `.planning/` tree **deliberately** as a GSD showcase (only generated subdirs are ignored). A sweeping ignore/`rm --cached` is a ~200-file diff and a separate decision.

## Test
Backend/frontend/extension jobs all run in CI. Locally: PII gate 4/4 cases, frontend Layout 6/6, extension compile clean + 61/61 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)