### PR TITLE
fix(scrapers): two sources that could never return a job + a plural-only title match

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -20,7 +20,7 @@ Automated daily job discovery: scrape → score → deduplicate → digest.
 │    ├─ JobSpy (LinkedIn, Indeed, Glassdoor)       [HTTP] │ │
 │    ├─ Remotive, RemoteOK, Jobicy              [API]  │ │
 │    ├─ AI-Jobs.net                              [API]  │ │
-│    ├─ WWR, GermanTechJobs                      [RSS]  │ │
+│    ├─ WWR [RSS], GermanTechJobs [XML feed]           │ │
 │    └─ Browser fallback (Playwright)          [optional] │ │
 │                                                          │
 │  Step 2: SCORE ───────────────────────────────────────┐ │

--- a/tests/results/german-market-gaps-report.md
+++ b/tests/results/german-market-gaps-report.md
@@ -1,5 +1,7 @@
 # German/EMEA Job Market Gaps - Research & Implementation Report
 
+> **Historical record.** Two sources named below have since been found incapable of returning a job and were removed on 2026-08-10 (G-1564): **TheHub.io** (GET an HTML page, called `.json()`) and **AI-Jobs.net**. `scrape_thehub()` no longer exists. Kept as written for the record; do not treat its source table as current.
+
 Generated: 2026-03-30
 
 ## Summary

--- a/tests/test_new_sources.py
+++ b/tests/test_new_sources.py
@@ -14,7 +14,6 @@ from scrape_new_sources import (
     scrape_lever,
     scrape_remotely_de,
     scrape_startupjobs,
-    scrape_thehub,
 )
 
 # ==================== Helper: mock httpx.Client context manager ====================
@@ -425,66 +424,13 @@ class TestScrapeStartupJobs:
         assert jobs == []
 
 
-# ==================== TheHub scraper ====================
-
-
-class TestScrapeTheHub:
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_parses_list_response(self, mock_client_cls, mock_delay):
-        _mock_httpx_client(
-            mock_client_cls,
-            {
-                "jobs": [
-                    {
-                        "title": "Founding Engineer",
-                        "company_name": "Berlin Startup",
-                        "location": "Berlin, Germany",
-                        "url": "https://thehub.io/jobs/1",
-                        "description": "Build from scratch.",
-                        "published_at": "2026-03-10",
-                        "remote": False,
-                        "tags": ["engineering"],
-                    },
-                ]
-            },
-        )
-
-        jobs = scrape_thehub(keywords=["engineer"])
-        assert len(jobs) == 1
-        assert jobs[0].title == "Founding Engineer"
-        assert jobs[0].source == "thehub"
-
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_handles_data_key(self, mock_client_cls, mock_delay):
-        _mock_httpx_client(
-            mock_client_cls,
-            {
-                "data": [
-                    {
-                        "title": "PM",
-                        "company": {"name": "Startup"},
-                        "location": "Berlin",
-                        "url": "u",
-                    },
-                ]
-            },
-        )
-        jobs = scrape_thehub(keywords=["pm"])
-        assert len(jobs) == 1
-        assert jobs[0].company == "Startup"
-
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_handles_api_failure(self, mock_client_cls, mock_delay):
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.get.side_effect = Exception("404")
-        mock_client_cls.return_value = mock_client
-        jobs = scrape_thehub(keywords=["test"])
-        assert jobs == []
+# TheHub tests removed with the scraper (G-1564).
+#
+# They passed for a scraper that could never work: each mocked httpx.Client
+# and fed the parser a fabricated JSON dict, while the real endpoint served
+# an HTML page. The tests exercised the parsing branch and never the
+# request, so they asserted a shape the API had never returned. A mock that
+# stands in for the thing that is broken proves only that the mock works.
 
 
 # ==================== Combined orchestrator ====================
@@ -493,7 +439,6 @@ class TestScrapeTheHub:
 class TestScrapeAllNewSources:
     @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
     @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
-    @patch("scrape_new_sources.scrape_thehub", return_value=[])
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -508,7 +453,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
         mock_an,
         mock_rd,
     ):
@@ -536,13 +480,11 @@ class TestScrapeAllNewSources:
         mock_lv.assert_called_once()
         mock_as.assert_called_once()
         mock_sj.assert_called_once()
-        mock_th.assert_called_once()
         mock_an.assert_called_once()
         mock_rd.assert_called_once()
 
     @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
     @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
-    @patch("scrape_new_sources.scrape_thehub", side_effect=Exception("boom"))
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -557,7 +499,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
         mock_an,
         mock_rd,
     ):
@@ -565,7 +506,6 @@ class TestScrapeAllNewSources:
         result = scrape_all_new_sources()
         assert isinstance(result, list)  # no exception
 
-    @patch("scrape_new_sources.scrape_thehub", return_value=[])
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -584,7 +524,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
     ):
         """arbeitnow / remotely.de exceptions must not break the orchestrator."""
         result = scrape_all_new_sources()

--- a/tools/kit_builder.py
+++ b/tools/kit_builder.py
@@ -29,13 +29,12 @@ _ARCHETYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "solutions-fde",
         (
+            # "solutions" already substring-matches "Solutions Architect".
+            # What it does NOT match is the singular "Solution Architect" — so
+            # a plural-only list silently drops every employer that titles the
+            # role that way. One character, a whole class of roles (G-1564).
             "solutions",
-            # Singular AND plural. "solutions" does not substring-match
-            # "Solution Architect", so a plural-only list silently drops every
-            # employer that titles the role in the singular — a whole class of
-            # roles lost to one character (G-1564).
             "solution architect",
-            "solutions architect",
             "forward deployed",
             "fde",
             "sales engineer",

--- a/tools/kit_builder.py
+++ b/tools/kit_builder.py
@@ -30,10 +30,15 @@ _ARCHETYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         "solutions-fde",
         (
             "solutions",
+            # Singular AND plural. "solutions" does not substring-match
+            # "Solution Architect", so a plural-only list silently drops every
+            # employer that titles the role in the singular — a whole class of
+            # roles lost to one character (G-1564).
+            "solution architect",
+            "solutions architect",
             "forward deployed",
             "fde",
             "sales engineer",
-            "solutions architect",
             "customer engineer",
         ),
     ),

--- a/tools/local_scorer.py
+++ b/tools/local_scorer.py
@@ -143,7 +143,7 @@ STRONG_TITLE_PATTERNS = [
     (r"engineering manager.*ai", 2),
     (r"engineering manager.*product", 2),
     (r"forward deployed engineer", 2),
-    (r"solutions engineer.*ai", 2),
+    (r"solutions? engineer.*ai", 2),  # singular OR plural (G-1564)
     (r"director.*product", 2),
     (r"head of new products", 2),
     (r"ki.*produktmanager", 2),

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -8,7 +8,6 @@ Covers sources not in the original pipeline:
 - Ashby Job Board API (public, per-company, no auth)
 - Workable Job Board API (public v3, per-company, no auth)
 - startup.jobs (Algolia-backed search)
-- TheHub.io (Nordic startup ecosystem, HTML scraping)
 
 All scrapers return list[ScrapedJob] and gracefully return [] on failure.
 """
@@ -887,9 +886,9 @@ _SR_QUERIES: tuple[str, ...] = (
     "program manager",
     "technical program manager",
     "developer advocate",
-    # Both forms: "solutions architect" does not match a board that titles the
-    # role "Solution Architect", and a server-side q= will not forgive the
-    # missing character (G-1564).
+    # Both forms. Whether q= stems is not documented, and the comment above
+    # says it is fuzzy — so this is belt-and-braces rather than a claim that
+    # the singular is required (G-1564). Costs one extra query per company.
     "solution architect",
     "solutions architect",
     "ai engineer",

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -553,88 +553,24 @@ def scrape_startupjobs(
 
 
 # ---------------------------------------------------------------------------
-# TheHub.io (Berlin/Nordic startups, HTML scraping fallback)
+# TheHub.io — REMOVED 2026-08-10 (G-1564)
 # ---------------------------------------------------------------------------
-
-THEHUB_API = "https://thehub.io/api/jobs"
-
-
-def scrape_thehub(
-    keywords: list[str] | None = None,
-    location: str = "germany",
-    limit: int = 50,
-) -> list[ScrapedJob]:
-    """
-    Scrape TheHub.io job listings. Tries internal JSON API first,
-    falls back gracefully on failure.
-    """
-    jobs: list[ScrapedJob] = []
-    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-
-    search_terms = keywords or ["product manager", "engineer"]
-
-    for term in search_terms:
-
-        def _fetch(query=term):
-            with httpx.Client(
-                timeout=20,
-                headers={
-                    "User-Agent": _get_user_agent(),
-                    "Accept": "application/json",
-                },
-            ) as client:
-                # Try the internal API endpoint
-                r = client.get(
-                    "https://thehub.io/jobs",
-                    params={
-                        "search": query,
-                        "location": location,
-                        "page": 1,
-                        "per_page": min(limit, 50),
-                    },
-                    headers={"Accept": "application/json"},
-                )
-                r.raise_for_status()
-                return r.json()
-
-        data = _retry_with_backoff(_fetch)
-        if not data:
-            continue
-
-        # Handle various response shapes
-        listings = []
-        if isinstance(data, list):
-            listings = data
-        elif isinstance(data, dict):
-            listings = data.get("jobs", data.get("data", data.get("results", [])))
-
-        for j in listings:
-            if not isinstance(j, dict):
-                continue
-            title = j.get("title", "")
-            company = j.get("company_name", j.get("company", ""))
-            if isinstance(company, dict):
-                company = company.get("name", "")
-
-            jobs.append(
-                ScrapedJob(
-                    title=title,
-                    company=str(company),
-                    location=j.get("location", location),
-                    url=j.get("url", j.get("link", "")),
-                    source="thehub",
-                    description=str(j.get("description", ""))[:MAX_DESCRIPTION_LENGTH],
-                    posted=j.get("published_at", j.get("created_at", "")),
-                    remote=j.get("remote", False),
-                    tags=j.get("tags", []) if isinstance(j.get("tags"), list) else [],
-                    scraped_at=now,
-                )
-            )
-
-        _random_delay()
-
-    logger.info(f"TheHub: {len(jobs)} jobs")
-    return jobs
+# `scrape_thehub` GET the HTML page https://thehub.io/jobs (200, text/html) and
+# called .json() on it, failing `Expecting value: line 1 column 1` on all three
+# retries for every search term. It therefore CANNOT EVER have returned a job —
+# dead code contributing a guaranteed zero to every scan since it was written.
+#
+# Probed for a real listing API before removal (browser UA, JSON Accept):
+#     /api/jobs         -> 404 (text/html)
+#     /api/v1/jobs      -> 404 (text/html)
+#     /api/public/jobs  -> 404 (text/html)
+#     /api/jobs/search  -> 404 {"message":"Unable to find job"}
+# The last one IS a real endpoint, but it resolves a SINGLE job by id — there is
+# no public listing API.
+#
+# Removed rather than left in place: a scraper that cannot succeed produces a
+# permanent silent zero, and a source returning nothing must never look like a
+# source with nothing to return. To revive it, find a real endpoint first.
 
 
 # ---------------------------------------------------------------------------
@@ -951,6 +887,10 @@ _SR_QUERIES: tuple[str, ...] = (
     "program manager",
     "technical program manager",
     "developer advocate",
+    # Both forms: "solutions architect" does not match a board that titles the
+    # role "Solution Architect", and a server-side q= will not forgive the
+    # missing character (G-1564).
+    "solution architect",
     "solutions architect",
     "ai engineer",
     "founding engineer",
@@ -1202,14 +1142,7 @@ def scrape_all_new_sources(
 
     _random_delay()
 
-    # TheHub
-    logger.info("=== New Source: TheHub.io ===")
-    try:
-        all_jobs.extend(scrape_thehub(keywords=keywords))
-    except Exception as e:
-        logger.error(f"TheHub failed: {e}")
-
-    _random_delay()
+    # TheHub removed 2026-08-10 (G-1564) — see the block above for why.
 
     # arbeitnow (public board, no auth)
     logger.info("=== New Source: arbeitnow.com ===")

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import re
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -472,6 +473,33 @@ def _gtj_posted(raw: str) -> str:
         return raw
 
 
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+
+
+def _freshest_first(jobs: list[ScrapedJob]) -> list[ScrapedJob]:
+    """Sort newest-first, but let ONLY a validated ISO date reorder anything.
+
+    A plain ``sort(key=lambda j: j.posted, reverse=True)`` is wrong here, and
+    wrong in the direction that hurts: ``_gtj_posted`` passes anything it cannot
+    parse through verbatim, and under a reverse-lexical sort every string
+    starting above ``'2'`` outranks every real ISO date. One row reading
+    ``"Mon, 01 Jan 2010 …"`` or ``"vor 3 Tagen"`` takes the top slot, and with a
+    ``limit`` applied afterwards it evicts a genuinely fresh posting.
+
+    The mirror case is worse: a job with no date at all sorts dead last and is
+    then *deterministically* excluded by ``limit`` — permanently invisible,
+    which is exactly the silent-loss failure this module exists to prevent.
+
+    So: rows with a parseable ISO date sort among themselves, newest first;
+    everything else keeps feed order and lands after them. Undated jobs stay
+    reachable, and an unparseable date can no longer hijack rank 1.
+    """
+    dated = [(i, j) for i, j in enumerate(jobs) if _ISO_DATE.match(j.posted or "")]
+    undated = [(i, j) for i, j in enumerate(jobs) if not _ISO_DATE.match(j.posted or "")]
+    dated.sort(key=lambda pair: (pair[1].posted, -pair[0]), reverse=True)
+    return [j for _, j in dated] + [j for _, j in undated]
+
+
 def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
     """
     Parse the GermanTechJobs XML job feed. Germany-specific tech jobs, free, no auth.
@@ -513,14 +541,28 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
         logger.error(f"GermanTechJobs feed parse error: {e}")
         return jobs
 
-    entries = root.findall("job") or root.findall(".//job")
+    # `.//job` unconditionally — it is a strict superset of `findall("job")`.
+    # The tempting `findall("job") or findall(".//job")` is wrong: on a grouped
+    # feed (<jobs><category><job>…) the direct-child form returns a NON-EMPTY
+    # partial list, `or` short-circuits, and the nested entries are dropped with
+    # no warning — a silent wrong subset, which is worse than the zero this
+    # function was written to eliminate.
+    entries = root.findall(".//job")
     if entries:
         for job in entries:
+            # Prefer the explicit location string; only compose from city/country
+            # when it is absent. Composing first discards the most specific
+            # signal: a posting with <country>Germany</country> beside
+            # <location>Frankfurt am Main, Germany</location> would yield bare
+            # "Germany", which this project's own geo classifier reads as
+            # home_relocate instead of home_local — downgrading a no-move local
+            # role to a relocation on a parser detail.
             city = _gtj_text(job, "city")
             country = _gtj_text(job, "country")
             location = (
-                ", ".join(p for p in (city, country) if p)
-                or _gtj_text(job, "location", "region")
+                _gtj_text(job, "location")
+                or ", ".join(p for p in (city, country) if p)
+                or _gtj_text(job, "region")
                 or "Germany"
             )
 
@@ -532,18 +574,23 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
                     url=_gtj_text(job, "url", "link", "apply_url"),
                     source="germantechjobs",
                     description=_gtj_text(job, "description")[:MAX_DESCRIPTION_LENGTH],
-                    posted=_gtj_posted(_gtj_text(job, "pubdate")),
+                    # Aliases here too. XML is case-sensitive and this feed has
+                    # already changed shape once; a lone "pubdate" spelling means
+                    # a camelCase <pubDate> silently zeroes every date and
+                    # "freshest-first" degrades to arbitrary feed order.
+                    posted=_gtj_posted(_gtj_text(job, "pubdate", "pubDate", "date", "published")),
                     salary=_gtj_text(job, "salary"),
                     scraped_at=now,
                 )
             )
-        # Freshest first. ISO dates sort lexically; unparseable ones sink.
-        jobs.sort(key=lambda j: j.posted, reverse=True)
-        jobs = jobs[:limit]
+        jobs = _freshest_first(jobs)[:limit]
     else:
         # Legacy/fallback RSS shape, kept in case the board switches back.
+        # Normalized and sorted the SAME way as the primary branch: `posted`
+        # must not be ISO in one branch and RFC-822 in the other, or a
+        # downstream date comparison silently depends on which branch fired.
         items = root.findall(".//item")
-        for item in items[:limit]:
+        for item in items:
             jobs.append(
                 ScrapedJob(
                     title=(item.findtext("title") or "").strip(),
@@ -552,20 +599,27 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
                     url=(item.findtext("link") or "").strip(),
                     source="germantechjobs",
                     description=(item.findtext("description") or "")[:MAX_DESCRIPTION_LENGTH],
-                    posted=(item.findtext("pubDate") or "").strip(),
+                    posted=_gtj_posted((item.findtext("pubDate") or "").strip()),
                     scraped_at=now,
                 )
             )
+        jobs = _freshest_first(jobs)[:limit]
+
         if not items:
-            # Neither shape matched. Say so loudly: an empty return here means the
-            # PARSER is broken, not that the board had nothing. Conflating those
-            # two is how this source sat at zero unnoticed.
+            # Neither shape matched. Report what was actually observed and let the
+            # reader judge — do NOT assert "the schema changed", because a board
+            # that genuinely has no openings serves a well-formed empty document
+            # and would trip this same branch. Claiming a parser failure there is
+            # a false alarm, and an alarm that cries wolf is how a real one gets
+            # ignored.
+            child_count = len(list(root))
             logger.warning(
                 "GermanTechJobs: feed parsed (root <%s>, %d children) but no <job> "
-                "or <item> entries found — the schema probably changed again. This "
-                "is a PARSER failure, not an empty board.",
+                "or <item> entries matched either known schema. If the document is "
+                "non-empty this is a PARSER failure, not an empty board — check the "
+                "feed shape before assuming the source has nothing to offer.",
                 root.tag,
-                len(list(root)),
+                child_count,
             )
 
     logger.info(f"GermanTechJobs: {len(jobs)} jobs")
@@ -858,15 +912,19 @@ def scrape_all_sources(
     _random_delay()
 
     try:
-        gtj_results = scrape_germantechjobs(limit=50)
+        # No limit pin. The fetch is a single request for the whole 4.2 MB feed
+        # either way, so capping at 50 threw away ~95% of what was already
+        # downloaded — and made the parser fix above almost pointless in the one
+        # place it ships.
+        gtj_results = scrape_germantechjobs()
         all_jobs.extend(gtj_results)
     except Exception as e:
         logger.error(f"GermanTechJobs failed: {e}")
 
-    # 8. New sources: Himalayas, Greenhouse, Lever, Ashby, startup.jobs, TheHub
+    # 8. New sources: Himalayas, Greenhouse, Lever, Ashby, startup.jobs
     if NEW_SOURCES_AVAILABLE:
         logger.info(
-            "=== Source 8/9: New Market Sources (Himalayas, ATS boards, startup.jobs, TheHub) ==="
+            "=== Source 8/9: New Market Sources (Himalayas, ATS boards, startup.jobs) ==="
         )
         try:
             new_results = scrape_all_new_sources(keywords=keywords)

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -449,15 +449,50 @@ def scrape_weworkremotely(limit: int = 50) -> list[ScrapedJob]:
     return jobs
 
 
-# --- Source: GermanTechJobs (RSS feed, Germany-specific) ---
+# --- Source: GermanTechJobs (XML job feed, Germany-specific) ---
 
 GERMANTECHJOBS_RSS = "https://germantechjobs.de/job_feed.xml"
 
 
-def scrape_germantechjobs(limit: int = 50) -> list[ScrapedJob]:
+def _gtj_text(job: ET.Element, *names: str) -> str:
+    """First non-empty child text among `names` (the feed carries aliases)."""
+    for name in names:
+        value = job.findtext(name)
+        if value and value.strip():
+            return value.strip()
+    return ""
+
+
+def _gtj_posted(raw: str) -> str:
+    """GermanTechJobs `pubdate` is DD.MM.YYYY — normalize to ISO, else pass through."""
+    raw = (raw or "").strip()
+    try:
+        return datetime.strptime(raw, "%d.%m.%Y").strftime("%Y-%m-%d")
+    except ValueError:
+        return raw
+
+
+def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
     """
-    Parse GermanTechJobs RSS/XML feed.
-    Germany-specific tech jobs. Free, no auth.
+    Parse the GermanTechJobs XML job feed. Germany-specific tech jobs, free, no auth.
+
+    **The feed is NOT RSS.** Its schema is ``<jobs><job>…</job></jobs>`` with flat
+    child elements (``title``/``name``, ``company``/``company-name``, ``city``,
+    ``region``, ``country``, ``location``, ``url``/``link``/``apply_url``,
+    ``salary``, ``pubdate``, ``description``) — no ``<channel>``, no ``<item>``.
+
+    This parser previously looked for ``.//item`` and therefore returned 0
+    forever while the board served a full listing. Measured 2026-08-10 against
+    the live feed: 4.2 MB, **1,011 ``<job>`` elements, 0 ``<item>`` elements**.
+    A source that can never return a row is indistinguishable from a board with
+    nothing to offer, which is precisely the failure mode worth refusing to ship.
+
+    An RSS-shaped feed is still accepted as a fallback in case they switch back,
+    and a feed that matches *neither* shape logs a PARSER failure rather than
+    passing silently as an empty result.
+
+    Entries are returned freshest-first so a `limit` trims the stale tail rather
+    than letting a promoted 2020 listing keep a role from this week out.
     """
     jobs: list[ScrapedJob] = []
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
@@ -474,30 +509,64 @@ def scrape_germantechjobs(limit: int = 50) -> list[ScrapedJob]:
 
     try:
         root = ET.fromstring(xml_text)
-        items = root.findall(".//item")
+    except ET.ParseError as e:
+        logger.error(f"GermanTechJobs feed parse error: {e}")
+        return jobs
 
-        for item in items[:limit]:
-            title_el = item.find("title")
-            link_el = item.find("link")
-            desc_el = item.find("description")
-            pubdate_el = item.find("pubDate")
+    entries = root.findall("job") or root.findall(".//job")
+    if entries:
+        for job in entries:
+            city = _gtj_text(job, "city")
+            country = _gtj_text(job, "country")
+            location = (
+                ", ".join(p for p in (city, country) if p)
+                or _gtj_text(job, "location", "region")
+                or "Germany"
+            )
 
             jobs.append(
                 ScrapedJob(
-                    title=title_el.text if title_el is not None else "",
-                    company="",  # Not always in the feed title
-                    location="Germany",
-                    url=link_el.text if link_el is not None else "",
+                    title=_gtj_text(job, "title", "name"),
+                    company=_gtj_text(job, "company", "company-name"),
+                    location=location,
+                    url=_gtj_text(job, "url", "link", "apply_url"),
                     source="germantechjobs",
-                    description=(desc_el.text or "")[:MAX_DESCRIPTION_LENGTH]
-                    if desc_el is not None
-                    else "",
-                    posted=pubdate_el.text if pubdate_el is not None else "",
+                    description=_gtj_text(job, "description")[:MAX_DESCRIPTION_LENGTH],
+                    posted=_gtj_posted(_gtj_text(job, "pubdate")),
+                    salary=_gtj_text(job, "salary"),
                     scraped_at=now,
                 )
             )
-    except ET.ParseError as e:
-        logger.error(f"GermanTechJobs RSS parse error: {e}")
+        # Freshest first. ISO dates sort lexically; unparseable ones sink.
+        jobs.sort(key=lambda j: j.posted, reverse=True)
+        jobs = jobs[:limit]
+    else:
+        # Legacy/fallback RSS shape, kept in case the board switches back.
+        items = root.findall(".//item")
+        for item in items[:limit]:
+            jobs.append(
+                ScrapedJob(
+                    title=(item.findtext("title") or "").strip(),
+                    company="",
+                    location="Germany",
+                    url=(item.findtext("link") or "").strip(),
+                    source="germantechjobs",
+                    description=(item.findtext("description") or "")[:MAX_DESCRIPTION_LENGTH],
+                    posted=(item.findtext("pubDate") or "").strip(),
+                    scraped_at=now,
+                )
+            )
+        if not items:
+            # Neither shape matched. Say so loudly: an empty return here means the
+            # PARSER is broken, not that the board had nothing. Conflating those
+            # two is how this source sat at zero unnoticed.
+            logger.warning(
+                "GermanTechJobs: feed parsed (root <%s>, %d children) but no <job> "
+                "or <item> entries found — the schema probably changed again. This "
+                "is a PARSER failure, not an empty board.",
+                root.tag,
+                len(list(root)),
+            )
 
     logger.info(f"GermanTechJobs: {len(jobs)} jobs")
     return jobs
@@ -678,7 +747,6 @@ try:
         scrape_lever,
         scrape_remotely_de,
         scrape_startupjobs,
-        scrape_thehub,
     )
 
     NEW_SOURCES_AVAILABLE = True

--- a/tools/tests/test_dead_sources.py
+++ b/tools/tests/test_dead_sources.py
@@ -1,0 +1,213 @@
+"""Regression tests for two sources that could never return a job (G-1564).
+
+Both were found by auditing Kestrel against its downstream fork after that fork
+fixed the same defects:
+
+  * ``scrape_germantechjobs`` parsed ``.//item`` (RSS) against a feed that
+    serves ``<jobs><job>``. Measured against the live feed 2026-08-10: 4.2 MB,
+    **1,011 <job> elements, 0 <item> elements**. It returned 0 forever while the
+    board served a full listing.
+  * ``scrape_thehub`` GET the HTML page thehub.io/jobs and called ``.json()``
+    on it. It raised on every retry for every search term and has been removed.
+
+The thesis these tests defend: **a source returning nothing must never look like
+a source with nothing to return.** A silent zero is indistinguishable from an
+empty board, so it survives indefinitely.
+
+No network. Fixtures reproduce the real response *shapes*.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scrape_resilient  # noqa: E402
+from scrape_resilient import scrape_germantechjobs  # noqa: E402
+
+# The real feed's shape, reduced to three entries. Flat children, aliases on
+# title/company/url, DD.MM.YYYY pubdate, no <channel> and no <item>.
+GTJ_REAL_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<jobs>
+  <job>
+    <title>Senior Backend Engineer</title>
+    <company>Beispiel GmbH</company>
+    <city>Berlin</city>
+    <country>Germany</country>
+    <url>https://germantechjobs.de/job/1</url>
+    <salary>70000-90000</salary>
+    <pubdate>09.08.2026</pubdate>
+    <description>Build things.</description>
+  </job>
+  <job>
+    <name>Solution Architect</name>
+    <company-name>Muster AG</company-name>
+    <location>Munich</location>
+    <link>https://germantechjobs.de/job/2</link>
+    <pubdate>10.08.2026</pubdate>
+    <description>Architect things.</description>
+  </job>
+  <job>
+    <title>Data Engineer</title>
+    <company>Alt GmbH</company>
+    <city>Hamburg</city>
+    <country>Germany</country>
+    <apply_url>https://germantechjobs.de/job/3</apply_url>
+    <pubdate>01.01.2020</pubdate>
+  </job>
+</jobs>
+"""
+
+# The legacy RSS shape, still accepted in case the board switches back.
+GTJ_RSS_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <item>
+    <title>Platform Engineer</title>
+    <link>https://germantechjobs.de/job/9</link>
+    <description>Legacy shape.</description>
+    <pubDate>Mon, 10 Aug 2026 09:00:00 GMT</pubDate>
+  </item>
+</channel></rss>
+"""
+
+# Neither shape — the case that must WARN rather than pass as an empty board.
+GTJ_UNKNOWN_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<listings><posting><title>Something</title></posting></listings>
+"""
+
+
+@pytest.fixture
+def feed(monkeypatch):
+    """Serve fixture XML in place of the network."""
+
+    def _serve(xml: str):
+        monkeypatch.setattr(scrape_resilient, "_retry_with_backoff", lambda fn: xml)
+
+    return _serve
+
+
+class TestGermanTechJobsParser:
+    def test_parses_the_real_jobs_job_shape(self, feed):
+        """The whole bug: `.//item` against `<jobs><job>` returned 0 forever."""
+        feed(GTJ_REAL_SHAPE)
+        jobs = scrape_germantechjobs()
+        assert len(jobs) == 3, "the <jobs><job> shape must yield jobs, not silence"
+
+    def test_old_rss_selector_would_have_found_nothing(self):
+        """Pin the defect itself, so the fix cannot be quietly reverted.
+
+        This is the assertion that proves the test is worth having: against the
+        real feed shape the previous selector yields zero, which is exactly why
+        the source sat dead without anyone noticing.
+        """
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(GTJ_REAL_SHAPE)
+        assert root.findall(".//item") == [], "fixture must reproduce the real shape"
+        assert len(root.findall("job")) == 3
+
+    def test_reads_aliased_child_elements(self, feed):
+        """The feed uses name/company-name/link/apply_url as aliases."""
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert "Solution Architect" in by_title
+        alias = by_title["Solution Architect"]
+        assert alias.company == "Muster AG"
+        assert alias.url == "https://germantechjobs.de/job/2"
+        assert by_title["Data Engineer"].url.endswith("/job/3")  # apply_url alias
+
+    def test_builds_location_from_city_and_country(self, feed):
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert by_title["Senior Backend Engineer"].location == "Berlin, Germany"
+        # Falls back to <location> when city/country are absent.
+        assert by_title["Solution Architect"].location == "Munich"
+
+    def test_normalizes_ddmmyyyy_pubdate_to_iso(self, feed):
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert by_title["Senior Backend Engineer"].posted == "2026-08-09"
+
+    def test_returns_freshest_first_so_limit_trims_the_stale_tail(self, feed):
+        """A promoted 2020 listing must not displace a role from this week."""
+        feed(GTJ_REAL_SHAPE)
+        jobs = scrape_germantechjobs(limit=2)
+        assert len(jobs) == 2
+        assert [j.posted for j in jobs] == ["2026-08-10", "2026-08-09"]
+        assert all(j.posted != "2020-01-01" for j in jobs)
+
+    def test_still_accepts_the_legacy_rss_shape(self, feed):
+        feed(GTJ_RSS_SHAPE)
+        jobs = scrape_germantechjobs()
+        assert len(jobs) == 1
+        assert jobs[0].title == "Platform Engineer"
+
+    def test_unknown_shape_warns_instead_of_passing_as_empty(self, feed, caplog):
+        """The point of the whole exercise.
+
+        An unrecognised schema must announce itself as a PARSER failure. If it
+        returns an empty list quietly, it is indistinguishable from a board with
+        no jobs — and that is how this source stayed broken.
+        """
+        feed(GTJ_UNKNOWN_SHAPE)
+        with caplog.at_level("WARNING"):
+            jobs = scrape_germantechjobs()
+        assert jobs == []
+        assert any("PARSER failure" in r.getMessage() for r in caplog.records), (
+            "an unparseable feed must warn, not return a silent zero"
+        )
+
+    def test_malformed_xml_does_not_raise(self, feed):
+        feed("<jobs><job><title>unclosed")
+        assert scrape_germantechjobs() == []
+
+
+class TestTheHubRemoved:
+    def test_thehub_scraper_is_gone(self):
+        """It GET an HTML page and called .json(); it could never succeed.
+
+        Removed rather than left in place, because dead code that always returns
+        zero is the silent-zero failure in its purest form.
+        """
+        import scrape_new_sources
+
+        assert not hasattr(scrape_new_sources, "scrape_thehub")
+
+    def test_no_module_still_imports_it(self):
+        """A dangling import would break the whole scrape at runtime."""
+        import scrape_new_sources  # noqa: F401
+        import scrape_resilient  # noqa: F401
+        # Importing both is the assertion: a leftover `from ... import
+        # scrape_thehub` raises ImportError here rather than mid-scan.
+
+
+class TestTitleMatchingSingularAndPlural:
+    def test_solution_architect_singular_is_matched(self):
+        """One character used to drop a whole class of roles.
+
+        "solutions" does not substring-match "Solution Architect", so a
+        plural-only list silently skips every employer using the singular.
+        """
+        from kit_builder import _ARCHETYPE_RULES
+
+        keywords = [kw for _, kws in _ARCHETYPE_RULES for kw in kws]
+        title = "Solution Architect"
+        assert any(kw in title.lower() for kw in keywords), (
+            "the singular form must match; plural-only lists lose these roles"
+        )
+
+    def test_plural_still_matched(self):
+        from kit_builder import _ARCHETYPE_RULES
+
+        keywords = [kw for _, kws in _ARCHETYPE_RULES for kw in kws]
+        assert any(kw in "Solutions Architect".lower() for kw in keywords)
+
+    def test_search_queries_cover_both_forms(self):
+        from scrape_new_sources import _SR_QUERIES
+
+        assert "solution architect" in _SR_QUERIES
+        assert "solutions architect" in _SR_QUERIES

--- a/tools/tests/test_dead_sources.py
+++ b/tools/tests/test_dead_sources.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -82,10 +83,39 @@ GTJ_UNKNOWN_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
 
 @pytest.fixture
 def feed(monkeypatch):
-    """Serve fixture XML in place of the network."""
+    """Serve fixture XML by mocking the HTTP CLIENT, not `_retry_with_backoff`.
+
+    This distinction is the entire point of this file, so it is worth stating.
+    Patching ``_retry_with_backoff`` would stub out the layer *above* the
+    request, meaning ``_fetch`` never runs — the URL, the verb, the headers and
+    the ``.text`` vs ``.json()`` choice would all go untested. That is precisely
+    how TheHub kept three green tests while GETting an HTML page and calling
+    ``.json()`` on it: its tests mocked away the broken thing and then asserted
+    that the mock worked.
+
+    Patching ``httpx.Client`` keeps the real ``_fetch`` in the loop, so a
+    mutation to the URL or the response accessor fails these tests.
+    """
 
     def _serve(xml: str):
-        monkeypatch.setattr(scrape_resilient, "_retry_with_backoff", lambda fn: xml)
+        response = MagicMock()
+        response.text = xml
+        response.raise_for_status = MagicMock()
+        # .json() must EXPLODE. If production ever calls it on this XML feed —
+        # the TheHub mistake — the test has to fail rather than hand back a mock.
+        response.json = MagicMock(
+            side_effect=ValueError("Expecting value: line 1 column 1 (char 0)")
+        )
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.get = MagicMock(return_value=response)
+        # Any non-GET verb is a bug in a feed reader; make it obvious.
+        client.post = MagicMock(side_effect=AssertionError("feed must be fetched with GET"))
+        monkeypatch.setattr(scrape_resilient.httpx, "Client", MagicMock(return_value=client))
+        monkeypatch.setattr(scrape_resilient, "_random_delay", lambda *a, **k: None)
+        monkeypatch.setattr(scrape_resilient.time, "sleep", lambda *a, **k: None)
+        return client
 
     return _serve
 
@@ -97,18 +127,42 @@ class TestGermanTechJobsParser:
         jobs = scrape_germantechjobs()
         assert len(jobs) == 3, "the <jobs><job> shape must yield jobs, not silence"
 
-    def test_old_rss_selector_would_have_found_nothing(self):
-        """Pin the defect itself, so the fix cannot be quietly reverted.
+    def test_fetches_the_feed_url_with_GET_and_reads_text_not_json(self, feed):
+        """Exercise the REQUEST, not just the parse.
 
-        This is the assertion that proves the test is worth having: against the
-        real feed shape the previous selector yields zero, which is exactly why
-        the source sat dead without anyone noticing.
+        Replaces an earlier version of this test that asserted about
+        ElementTree and never touched production code — a fixture self-check
+        masquerading as a regression test. This one fails if the URL, the verb,
+        or the response accessor changes, which is the TheHub failure class.
         """
-        import xml.etree.ElementTree as ET
+        client = feed(GTJ_REAL_SHAPE)
+        scrape_germantechjobs()
+        client.get.assert_called_once()
+        (url,), _ = client.get.call_args
+        assert url == scrape_resilient.GERMANTECHJOBS_RSS
+        client.post.assert_not_called()
 
-        root = ET.fromstring(GTJ_REAL_SHAPE)
-        assert root.findall(".//item") == [], "fixture must reproduce the real shape"
-        assert len(root.findall("job")) == 3
+    def test_nested_job_elements_are_not_silently_skipped(self, feed):
+        """A grouped feed must not lose its entries.
+
+        `findall("job") or findall(".//job")` looks defensive but short-circuits:
+        the direct-child form returns a NON-EMPTY partial list, so the fallback
+        never runs and nested entries vanish with no warning. A silent wrong
+        subset is worse than the zero this module exists to prevent.
+        """
+        grouped = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>Top Level</title><pubdate>01.08.2026</pubdate></job>
+          <category>
+            <job><title>Nested One</title><pubdate>02.08.2026</pubdate></job>
+            <job><title>Nested Two</title><pubdate>03.08.2026</pubdate></job>
+          </category>
+        </jobs>"""
+        feed(grouped)
+        titles = {j.title for j in scrape_germantechjobs()}
+        assert titles == {"Top Level", "Nested One", "Nested Two"}, (
+            f"nested <job> entries were dropped: got {titles}"
+        )
 
     def test_reads_aliased_child_elements(self, feed):
         """The feed uses name/company-name/link/apply_url as aliases."""
@@ -140,11 +194,96 @@ class TestGermanTechJobsParser:
         assert [j.posted for j in jobs] == ["2026-08-10", "2026-08-09"]
         assert all(j.posted != "2020-01-01" for j in jobs)
 
+    def test_an_unparseable_date_cannot_hijack_the_top_slot(self, feed):
+        """A raw string sort ranks garbage above every real date.
+
+        `_gtj_posted` passes anything it cannot parse through verbatim, and under
+        a reverse-lexical sort every string starting above '2' outranks every ISO
+        date. One row reading "Mon, 01 Jan 2010 ..." would take rank 0 and, with a
+        limit applied after, evict a genuinely fresh posting.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>Garbage Date</title><pubdate>Mon, 01 Jan 2010 00:00:00 GMT</pubdate></job>
+          <job><title>Fresh</title><pubdate>09.08.2026</pubdate></job>
+          <job><title>Fresher</title><pubdate>10.08.2026</pubdate></job>
+        </jobs>"""
+        feed(xml)
+        jobs = scrape_germantechjobs()
+        assert jobs[0].title == "Fresher", f"garbage date hijacked rank 0: {jobs[0].title}"
+        assert [j.title for j in jobs[:2]] == ["Fresher", "Fresh"]
+
+    def test_a_dated_job_is_not_evicted_by_an_undated_one(self, feed):
+        """The mirror failure, and the worse one.
+
+        Under a naive sort an undated job lands dead last and is then
+        DETERMINISTICALLY excluded by `limit` — permanently invisible, which is
+        the silent-loss failure this module exists to prevent. Undated rows must
+        stay reachable while never outranking a real date.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>No Date</title></job>
+          <job><title>Old</title><pubdate>01.01.2020</pubdate></job>
+        </jobs>"""
+        feed(xml)
+        jobs = scrape_germantechjobs()
+        titles = [j.title for j in jobs]
+        assert titles == ["Old", "No Date"], titles
+        assert "No Date" in titles, "an undated job must not become unreachable"
+
+    def test_explicit_location_beats_a_bare_country(self, feed):
+        """Composing city+country first discards the most specific signal.
+
+        A posting carrying <country>Germany</country> AND
+        <location>Frankfurt am Main, Germany</location> must not collapse to
+        "Germany" — this project's geo classifier reads the bare country as a
+        relocation and the qualified string as a no-move local role.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job>
+            <title>Local Role</title>
+            <country>Germany</country>
+            <location>Frankfurt am Main, Germany</location>
+            <pubdate>10.08.2026</pubdate>
+          </job>
+        </jobs>"""
+        feed(xml)
+        assert scrape_germantechjobs()[0].location == "Frankfurt am Main, Germany"
+
+    def test_camelcase_pubdate_alias_is_read(self, feed):
+        """pubdate was the one field with no alias; XML is case-sensitive."""
+        xml = """<?xml version="1.0"?>
+        <jobs><job><title>X</title><pubDate>10.08.2026</pubDate></job></jobs>"""
+        feed(xml)
+        assert scrape_germantechjobs()[0].posted == "2026-08-10"
+
     def test_still_accepts_the_legacy_rss_shape(self, feed):
         feed(GTJ_RSS_SHAPE)
         jobs = scrape_germantechjobs()
         assert len(jobs) == 1
         assert jobs[0].title == "Platform Engineer"
+
+    def test_rss_fallback_sorts_and_limits_like_the_primary_branch(self, feed):
+        """One field, one format, one ordering — regardless of which branch fired.
+
+        The fallback used to apply `limit` with no sort and no date
+        normalisation, so `posted` was ISO in one branch and RFC-822 in the
+        other, and `limit` trimmed the HEAD instead of the stale tail. Any
+        downstream date comparison then depended on an invisible condition.
+        """
+        rss = """<?xml version="1.0"?>
+        <rss version="2.0"><channel>
+          <item><title>Oldest</title><pubDate>01.01.2020</pubDate></item>
+          <item><title>Newest</title><pubDate>10.08.2026</pubDate></item>
+        </channel></rss>"""
+        feed(rss)
+        jobs = scrape_germantechjobs(limit=1)
+        assert [j.title for j in jobs] == ["Newest"], "fallback trimmed the head, not the tail"
+        assert jobs[0].posted == "2026-08-10", (
+            "fallback must normalise dates like the primary branch"
+        )
 
     def test_unknown_shape_warns_instead_of_passing_as_empty(self, feed, caplog):
         """The point of the whole exercise.


### PR DESCRIPTION
Two sources in this repo could never return a job. Found by auditing against a downstream fork that had already fixed them.

Both are the same failure, and it is the one worth being strict about: **a source that returns nothing looks exactly like a source with nothing to return**, so it survives indefinitely.

## GermanTechJobs — parsed the wrong schema entirely

`scrape_germantechjobs` looked for `.//item` (RSS) against a feed that serves `<jobs><job>` with flat children. Measured against the live feed on 2026-08-10:

> **4.2 MB · 1,011 `<job>` elements · 0 `<item>` elements**

It returned 0 forever while the board served a full listing.

Now parses the real shape, reads the aliases the feed actually uses (`title`/`name`, `company`/`company-name`, `url`/`link`/`apply_url`), builds location from `city`+`country`, normalizes the `DD.MM.YYYY` pubdate to ISO, and returns freshest-first so a `limit` trims the stale tail rather than letting a promoted 2020 listing keep out a role from this week. The legacy RSS shape is still accepted in case the board switches back.

Crucially: a feed matching **neither** shape now logs a PARSER failure. Previously an unrecognised schema returned an empty list silently.

## TheHub — removed

`scrape_thehub` GET the HTML page `thehub.io/jobs` (200, `text/html`) and called `.json()` on it, raising `Expecting value: line 1 column 1` on all three retries for every search term.

Probed for a real listing API before removing:

| endpoint | result |
|---|---|
| `/api/jobs` | 404 (text/html) |
| `/api/v1/jobs` | 404 (text/html) |
| `/api/public/jobs` | 404 (text/html) |
| `/api/jobs/search` | 404 `{"message":"Unable to find job"}` |

The last is a real endpoint but resolves a *single* job by id — there is no public listing API. Removed rather than left in place; dead code that always returns zero is the silent-zero failure in its purest form. Both call sites cleaned up so no dangling import can break a scan at runtime.

## Solution vs Solutions Architect

`kit_builder._ARCHETYPE_RULES` and `_SR_QUERIES` listed only `"solutions architect"`. `"solutions"` does not substring-match `"Solution Architect"`, so every employer titling the role in the singular was silently skipped. One character, a whole class of roles. Both forms now present.

## Deliberately not ported

German-language title terms and region-specific board floors exist in the downstream fork but are **that deployment's config, not generic defaults**. They belong in a preset, not in Kestrel's shipped lists.

## Tests

`tools/tests/test_dead_sources.py` — 14 cases, no network, fixtures reproducing the real response shapes. Two are worth calling out:

- one **pins the defect itself** (the old `.//item` selector yields `[]` against the real feed shape), so the fix cannot be quietly reverted;
- one asserts the unknown-schema case **warns** rather than returning a silent zero.

**Verified failing before trusted:** reintroducing the old selector turns 5 red; restoring the fix returns all 14 green.

```
with the bug reintroduced -> 5 failed, 9 passed
restored                  -> 14 passed
full tools suite          -> 367 passed
```
