### PR TITLE
chore(deps): nanoid 3.3.16 -> 3.3.18 to clear GHSA-2v37-7h3g-55p8 (unblocks all PRs)

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -5001,9 +5001,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.24.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.24.0",
+      "version": "0.26.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -3830,9 +3830,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
The frontend **Security audit** step fails on every open PR:

```
Non-ignored moderate+ advisories: {
  'GHSA-2v37-7h3g-55p8': 'high nanoid: custom generators can loop indefinitely when size is zero'
}
```

nanoid is transitive — `vite 8.1.3 -> postcss 8.5.23 -> nanoid`. Fixed range is `>= 3.3.17`; `npm update nanoid` resolves to **3.3.18** with no change to any direct dependency, so no `overrides` entry is needed.

### Supply-chain checks before accepting the bump

Per the never-blindly-update rule:

- **3.3.17 and 3.3.18 both exist on the registry** (published 2026-08-03 / 2026-08-07)
- **upstream tag `refs/tags/3.3.17` exists** at `ai/nanoid` — a real release, not a registry-only artifact
- **`npm audit signatures` passes:** 115 packages have verified attestations

### Verified against CI'''s own filter

Ran the exact `audit-filter.js` from `.github/workflows/ci.yml` against the updated lockfile:

```
WOULD PASS. ignored: GHSA-qwww-vcr4-c8h2
```

The two remaining react-router advisories are the documented, already-ignored `GHSA-qwww-vcr4-c8h2` (RSC-mode CSRF; this frontend is a non-RSC BrowserRouter SPA — G-1412).

Lands alone, separate from any feature work, because it blocks every open PR.