### PR TITLE
feat(scrapers): source registry — every source reported, every run, with a reason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ config/blocklist.yaml
 config/geo.yaml
 # Target-company lists for ATS scrapers (personal; copy from companies.example.yaml)
 config/companies.yaml
+config/scan-sources.yaml
 # Voice corpus (raw personal writing — never commit)
 config/voice-corpus.md
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -20,7 +20,7 @@ Automated daily job discovery: scrape → score → deduplicate → digest.
 │    ├─ JobSpy (LinkedIn, Indeed, Glassdoor)       [HTTP] │ │
 │    ├─ Remotive, RemoteOK, Jobicy              [API]  │ │
 │    ├─ AI-Jobs.net                              [API]  │ │
-│    ├─ WWR, GermanTechJobs                      [RSS]  │ │
+│    ├─ WWR [RSS], GermanTechJobs [XML feed]           │ │
 │    └─ Browser fallback (Playwright)          [optional] │ │
 │                                                          │
 │  Step 2: SCORE ───────────────────────────────────────┐ │

--- a/config/scan-sources.example.yaml
+++ b/config/scan-sources.example.yaml
@@ -1,0 +1,135 @@
+# Scan source registry -- copy this file to config/scan-sources.yaml and customize.
+#
+#   cp config/scan-sources.example.yaml config/scan-sources.yaml
+#
+# config/scan-sources.yaml is gitignored; only this .example.yaml is tracked.
+# The file is OPTIONAL: with no config at all, every source this repo ships is
+# still reported on every run and a hard ZERO is still loud. The config adds
+# calibrated floors and deliberate exclusions on top of that.
+#
+# TWO JOBS, deliberately in the same file:
+#
+#   1. EXCLUSION.    `enabled: false` turns a source off without deleting code.
+#   2. HEALTH FLOOR. `floor: N` is the count below which the run SHOUTS.
+#
+# THE RULE THAT MAKES THIS SAFE: a disabled source is reported as DISABLED,
+# never as absent and never as zero. If you could silently switch a source off
+# here, this file would recreate the exact bug it exists to kill -- a source
+# contributing nothing while the run looks healthy. Every source appears in
+# every status table with one of:
+#
+#     ok · DISABLED · BLOCKED · ABANDONED · EMPTY-BY-DESIGN · BELOW-FLOOR · ZERO
+#
+# ---------------------------------------------------------------------------
+# `floor` HAS THREE STATES AND THE DIFFERENCE MATTERS
+# ---------------------------------------------------------------------------
+#
+#   floor absent   -> NOT CALIBRATED. No below-floor check. A hard zero is still
+#                     loud. This is the right default until you have measured a
+#                     normal run.
+#   floor: 0 + note -> DOCUMENTED ZERO. You are asserting empty is correct here
+#                     and saying why. Reported as EMPTY-BY-DESIGN, quietly.
+#                     The `note` is REQUIRED -- an undocumented zero-floor is
+#                     indistinguishable from an unnoticed breakage.
+#   floor: N        -> CALIBRATED. Below N shouts.
+#
+# DO NOT copy floors from someone else's install. Volumes depend entirely on
+# your company lists, keywords and region. To calibrate from a real run:
+#
+#     python tools/source_registry.py --calibrate '{"greenhouse": 4042, ...}'
+#
+# It suggests ~1/3 of the observed count, because a floor near the measured
+# value fires on ordinary variance -- and a warning that fires every run is one
+# you learn to ignore, which costs more than no warning at all.
+#
+# NEVER raise a floor to make a broken source look healthy. Fix the source.
+
+sources:
+  # --- ATS boards (per-company; volume depends on YOUR config/companies.yaml) --
+  greenhouse:
+    enabled: true
+    # floor: 300        # uncomment after calibrating against a real run
+
+  lever:
+    enabled: true
+
+  ashby:
+    enabled: true
+
+  workable:
+    enabled: true
+
+  smartrecruiters:
+    enabled: true
+
+  personio:
+    enabled: true
+
+  # --- Aggregators / job boards ---------------------------------------------
+  himalayas:
+    enabled: true
+
+  arbeitnow:
+    enabled: true
+
+  germantechjobs:
+    enabled: true
+    note: >-
+      XML feed at germantechjobs.de/job_feed.xml. NOT RSS -- the schema is
+      <jobs><job>. A parser that looks for <item> returns zero forever while the
+      board serves a full listing; that is exactly what happened before G-1564.
+
+  # JobSpy is a multiplexer: postings are reported under the board they came
+  # from (indeed / linkedin / glassdoor / google / zip_recruiter), so there is
+  # no "jobspy" source name to register. Add the boards you actually scrape:
+  #
+  #   indeed:
+  #     enabled: true
+  #
+  # Registering boards you do not use would give you permanent ZERO warnings.
+
+  aijobs:
+    enabled: true
+    note: >-
+      ai-jobs.net. Its downstream fork found the list-jobs API returning 404 in
+      August 2026 and removed the source there; it is kept here pending
+      re-verification. If this reports ZERO, that finding probably applies.
+
+  remoteok:
+    enabled: true
+
+  weworkremotely:
+    enabled: true
+
+  jobicy:
+    enabled: true
+
+  remotive:
+    enabled: true
+
+  remotely.de:
+    enabled: true
+    note: >-
+      Emits source="remotely.de" (with a dot). The scraper function is
+      scrape_remotely_de -- the names differ, and the registry must match what
+      is EMITTED, not what the function is called.
+
+  startupjobs:
+    enabled: true
+
+# ---------------------------------------------------------------------------
+# Sources REMOVED from this repo, and why. Recorded so nobody restores one
+# without reading the reason first.
+# ---------------------------------------------------------------------------
+removed:
+  thehub:
+    removed: 2026-08-10
+    ticket: G-1564
+    reason: >-
+      scrape_thehub GET the HTML page thehub.io/jobs (200, text/html) and called
+      .json() on it, so it could never return a job. Probed for a real listing
+      API before removal -- /api/jobs, /api/v1/jobs and /api/public/jobs all 404;
+      /api/jobs/search exists but resolves a SINGLE job by id. No public listing
+      endpoint. Its unit tests passed throughout by mocking the HTTP client and
+      feeding the parser fabricated JSON -- a mock standing in for the broken
+      thing proves only that the mock works.

--- a/tests/results/german-market-gaps-report.md
+++ b/tests/results/german-market-gaps-report.md
@@ -1,5 +1,7 @@
 # German/EMEA Job Market Gaps - Research & Implementation Report
 
+> **Historical record.** Two sources named below have since been found incapable of returning a job and were removed on 2026-08-10 (G-1564): **TheHub.io** (GET an HTML page, called `.json()`) and **AI-Jobs.net**. `scrape_thehub()` no longer exists. Kept as written for the record; do not treat its source table as current.
+
 Generated: 2026-03-30
 
 ## Summary

--- a/tests/test_new_sources.py
+++ b/tests/test_new_sources.py
@@ -14,7 +14,6 @@ from scrape_new_sources import (
     scrape_lever,
     scrape_remotely_de,
     scrape_startupjobs,
-    scrape_thehub,
 )
 
 # ==================== Helper: mock httpx.Client context manager ====================
@@ -425,66 +424,13 @@ class TestScrapeStartupJobs:
         assert jobs == []
 
 
-# ==================== TheHub scraper ====================
-
-
-class TestScrapeTheHub:
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_parses_list_response(self, mock_client_cls, mock_delay):
-        _mock_httpx_client(
-            mock_client_cls,
-            {
-                "jobs": [
-                    {
-                        "title": "Founding Engineer",
-                        "company_name": "Berlin Startup",
-                        "location": "Berlin, Germany",
-                        "url": "https://thehub.io/jobs/1",
-                        "description": "Build from scratch.",
-                        "published_at": "2026-03-10",
-                        "remote": False,
-                        "tags": ["engineering"],
-                    },
-                ]
-            },
-        )
-
-        jobs = scrape_thehub(keywords=["engineer"])
-        assert len(jobs) == 1
-        assert jobs[0].title == "Founding Engineer"
-        assert jobs[0].source == "thehub"
-
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_handles_data_key(self, mock_client_cls, mock_delay):
-        _mock_httpx_client(
-            mock_client_cls,
-            {
-                "data": [
-                    {
-                        "title": "PM",
-                        "company": {"name": "Startup"},
-                        "location": "Berlin",
-                        "url": "u",
-                    },
-                ]
-            },
-        )
-        jobs = scrape_thehub(keywords=["pm"])
-        assert len(jobs) == 1
-        assert jobs[0].company == "Startup"
-
-    @patch("scrape_new_sources._random_delay")
-    @patch("scrape_new_sources.httpx.Client")
-    def test_handles_api_failure(self, mock_client_cls, mock_delay):
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.get.side_effect = Exception("404")
-        mock_client_cls.return_value = mock_client
-        jobs = scrape_thehub(keywords=["test"])
-        assert jobs == []
+# TheHub tests removed with the scraper (G-1564).
+#
+# They passed for a scraper that could never work: each mocked httpx.Client
+# and fed the parser a fabricated JSON dict, while the real endpoint served
+# an HTML page. The tests exercised the parsing branch and never the
+# request, so they asserted a shape the API had never returned. A mock that
+# stands in for the thing that is broken proves only that the mock works.
 
 
 # ==================== Combined orchestrator ====================
@@ -493,7 +439,6 @@ class TestScrapeTheHub:
 class TestScrapeAllNewSources:
     @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
     @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
-    @patch("scrape_new_sources.scrape_thehub", return_value=[])
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -508,7 +453,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
         mock_an,
         mock_rd,
     ):
@@ -536,13 +480,11 @@ class TestScrapeAllNewSources:
         mock_lv.assert_called_once()
         mock_as.assert_called_once()
         mock_sj.assert_called_once()
-        mock_th.assert_called_once()
         mock_an.assert_called_once()
         mock_rd.assert_called_once()
 
     @patch("scrape_new_sources.scrape_remotely_de", return_value=[])
     @patch("scrape_new_sources.scrape_arbeitnow", return_value=[])
-    @patch("scrape_new_sources.scrape_thehub", side_effect=Exception("boom"))
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -557,7 +499,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
         mock_an,
         mock_rd,
     ):
@@ -565,7 +506,6 @@ class TestScrapeAllNewSources:
         result = scrape_all_new_sources()
         assert isinstance(result, list)  # no exception
 
-    @patch("scrape_new_sources.scrape_thehub", return_value=[])
     @patch("scrape_new_sources.scrape_startupjobs", return_value=[])
     @patch("scrape_new_sources.scrape_ashby", return_value=[])
     @patch("scrape_new_sources.scrape_lever", return_value=[])
@@ -584,7 +524,6 @@ class TestScrapeAllNewSources:
         mock_lv,
         mock_as,
         mock_sj,
-        mock_th,
     ):
         """arbeitnow / remotely.de exceptions must not break the orchestrator."""
         result = scrape_all_new_sources()

--- a/tools/kit_builder.py
+++ b/tools/kit_builder.py
@@ -29,13 +29,12 @@ _ARCHETYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "solutions-fde",
         (
+            # "solutions" already substring-matches "Solutions Architect".
+            # What it does NOT match is the singular "Solution Architect" — so
+            # a plural-only list silently drops every employer that titles the
+            # role that way. One character, a whole class of roles (G-1564).
             "solutions",
-            # Singular AND plural. "solutions" does not substring-match
-            # "Solution Architect", so a plural-only list silently drops every
-            # employer that titles the role in the singular — a whole class of
-            # roles lost to one character (G-1564).
             "solution architect",
-            "solutions architect",
             "forward deployed",
             "fde",
             "sales engineer",

--- a/tools/kit_builder.py
+++ b/tools/kit_builder.py
@@ -30,10 +30,15 @@ _ARCHETYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         "solutions-fde",
         (
             "solutions",
+            # Singular AND plural. "solutions" does not substring-match
+            # "Solution Architect", so a plural-only list silently drops every
+            # employer that titles the role in the singular — a whole class of
+            # roles lost to one character (G-1564).
+            "solution architect",
+            "solutions architect",
             "forward deployed",
             "fde",
             "sales engineer",
-            "solutions architect",
             "customer engineer",
         ),
     ),

--- a/tools/local_scorer.py
+++ b/tools/local_scorer.py
@@ -143,7 +143,7 @@ STRONG_TITLE_PATTERNS = [
     (r"engineering manager.*ai", 2),
     (r"engineering manager.*product", 2),
     (r"forward deployed engineer", 2),
-    (r"solutions engineer.*ai", 2),
+    (r"solutions? engineer.*ai", 2),  # singular OR plural (G-1564)
     (r"director.*product", 2),
     (r"head of new products", 2),
     (r"ki.*produktmanager", 2),

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -8,7 +8,6 @@ Covers sources not in the original pipeline:
 - Ashby Job Board API (public, per-company, no auth)
 - Workable Job Board API (public v3, per-company, no auth)
 - startup.jobs (Algolia-backed search)
-- TheHub.io (Nordic startup ecosystem, HTML scraping)
 
 All scrapers return list[ScrapedJob] and gracefully return [] on failure.
 """
@@ -887,9 +886,9 @@ _SR_QUERIES: tuple[str, ...] = (
     "program manager",
     "technical program manager",
     "developer advocate",
-    # Both forms: "solutions architect" does not match a board that titles the
-    # role "Solution Architect", and a server-side q= will not forgive the
-    # missing character (G-1564).
+    # Both forms. Whether q= stems is not documented, and the comment above
+    # says it is fuzzy — so this is belt-and-braces rather than a claim that
+    # the singular is required (G-1564). Costs one extra query per company.
     "solution architect",
     "solutions architect",
     "ai engineer",

--- a/tools/scrape_new_sources.py
+++ b/tools/scrape_new_sources.py
@@ -553,88 +553,24 @@ def scrape_startupjobs(
 
 
 # ---------------------------------------------------------------------------
-# TheHub.io (Berlin/Nordic startups, HTML scraping fallback)
+# TheHub.io — REMOVED 2026-08-10 (G-1564)
 # ---------------------------------------------------------------------------
-
-THEHUB_API = "https://thehub.io/api/jobs"
-
-
-def scrape_thehub(
-    keywords: list[str] | None = None,
-    location: str = "germany",
-    limit: int = 50,
-) -> list[ScrapedJob]:
-    """
-    Scrape TheHub.io job listings. Tries internal JSON API first,
-    falls back gracefully on failure.
-    """
-    jobs: list[ScrapedJob] = []
-    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-
-    search_terms = keywords or ["product manager", "engineer"]
-
-    for term in search_terms:
-
-        def _fetch(query=term):
-            with httpx.Client(
-                timeout=20,
-                headers={
-                    "User-Agent": _get_user_agent(),
-                    "Accept": "application/json",
-                },
-            ) as client:
-                # Try the internal API endpoint
-                r = client.get(
-                    "https://thehub.io/jobs",
-                    params={
-                        "search": query,
-                        "location": location,
-                        "page": 1,
-                        "per_page": min(limit, 50),
-                    },
-                    headers={"Accept": "application/json"},
-                )
-                r.raise_for_status()
-                return r.json()
-
-        data = _retry_with_backoff(_fetch)
-        if not data:
-            continue
-
-        # Handle various response shapes
-        listings = []
-        if isinstance(data, list):
-            listings = data
-        elif isinstance(data, dict):
-            listings = data.get("jobs", data.get("data", data.get("results", [])))
-
-        for j in listings:
-            if not isinstance(j, dict):
-                continue
-            title = j.get("title", "")
-            company = j.get("company_name", j.get("company", ""))
-            if isinstance(company, dict):
-                company = company.get("name", "")
-
-            jobs.append(
-                ScrapedJob(
-                    title=title,
-                    company=str(company),
-                    location=j.get("location", location),
-                    url=j.get("url", j.get("link", "")),
-                    source="thehub",
-                    description=str(j.get("description", ""))[:MAX_DESCRIPTION_LENGTH],
-                    posted=j.get("published_at", j.get("created_at", "")),
-                    remote=j.get("remote", False),
-                    tags=j.get("tags", []) if isinstance(j.get("tags"), list) else [],
-                    scraped_at=now,
-                )
-            )
-
-        _random_delay()
-
-    logger.info(f"TheHub: {len(jobs)} jobs")
-    return jobs
+# `scrape_thehub` GET the HTML page https://thehub.io/jobs (200, text/html) and
+# called .json() on it, failing `Expecting value: line 1 column 1` on all three
+# retries for every search term. It therefore CANNOT EVER have returned a job —
+# dead code contributing a guaranteed zero to every scan since it was written.
+#
+# Probed for a real listing API before removal (browser UA, JSON Accept):
+#     /api/jobs         -> 404 (text/html)
+#     /api/v1/jobs      -> 404 (text/html)
+#     /api/public/jobs  -> 404 (text/html)
+#     /api/jobs/search  -> 404 {"message":"Unable to find job"}
+# The last one IS a real endpoint, but it resolves a SINGLE job by id — there is
+# no public listing API.
+#
+# Removed rather than left in place: a scraper that cannot succeed produces a
+# permanent silent zero, and a source returning nothing must never look like a
+# source with nothing to return. To revive it, find a real endpoint first.
 
 
 # ---------------------------------------------------------------------------
@@ -951,6 +887,10 @@ _SR_QUERIES: tuple[str, ...] = (
     "program manager",
     "technical program manager",
     "developer advocate",
+    # Both forms: "solutions architect" does not match a board that titles the
+    # role "Solution Architect", and a server-side q= will not forgive the
+    # missing character (G-1564).
+    "solution architect",
     "solutions architect",
     "ai engineer",
     "founding engineer",
@@ -1202,14 +1142,7 @@ def scrape_all_new_sources(
 
     _random_delay()
 
-    # TheHub
-    logger.info("=== New Source: TheHub.io ===")
-    try:
-        all_jobs.extend(scrape_thehub(keywords=keywords))
-    except Exception as e:
-        logger.error(f"TheHub failed: {e}")
-
-    _random_delay()
+    # TheHub removed 2026-08-10 (G-1564) — see the block above for why.
 
     # arbeitnow (public board, no auth)
     logger.info("=== New Source: arbeitnow.com ===")

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import re
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -472,6 +473,33 @@ def _gtj_posted(raw: str) -> str:
         return raw
 
 
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+
+
+def _freshest_first(jobs: list[ScrapedJob]) -> list[ScrapedJob]:
+    """Sort newest-first, but let ONLY a validated ISO date reorder anything.
+
+    A plain ``sort(key=lambda j: j.posted, reverse=True)`` is wrong here, and
+    wrong in the direction that hurts: ``_gtj_posted`` passes anything it cannot
+    parse through verbatim, and under a reverse-lexical sort every string
+    starting above ``'2'`` outranks every real ISO date. One row reading
+    ``"Mon, 01 Jan 2010 …"`` or ``"vor 3 Tagen"`` takes the top slot, and with a
+    ``limit`` applied afterwards it evicts a genuinely fresh posting.
+
+    The mirror case is worse: a job with no date at all sorts dead last and is
+    then *deterministically* excluded by ``limit`` — permanently invisible,
+    which is exactly the silent-loss failure this module exists to prevent.
+
+    So: rows with a parseable ISO date sort among themselves, newest first;
+    everything else keeps feed order and lands after them. Undated jobs stay
+    reachable, and an unparseable date can no longer hijack rank 1.
+    """
+    dated = [(i, j) for i, j in enumerate(jobs) if _ISO_DATE.match(j.posted or "")]
+    undated = [(i, j) for i, j in enumerate(jobs) if not _ISO_DATE.match(j.posted or "")]
+    dated.sort(key=lambda pair: (pair[1].posted, -pair[0]), reverse=True)
+    return [j for _, j in dated] + [j for _, j in undated]
+
+
 def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
     """
     Parse the GermanTechJobs XML job feed. Germany-specific tech jobs, free, no auth.
@@ -513,14 +541,28 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
         logger.error(f"GermanTechJobs feed parse error: {e}")
         return jobs
 
-    entries = root.findall("job") or root.findall(".//job")
+    # `.//job` unconditionally — it is a strict superset of `findall("job")`.
+    # The tempting `findall("job") or findall(".//job")` is wrong: on a grouped
+    # feed (<jobs><category><job>…) the direct-child form returns a NON-EMPTY
+    # partial list, `or` short-circuits, and the nested entries are dropped with
+    # no warning — a silent wrong subset, which is worse than the zero this
+    # function was written to eliminate.
+    entries = root.findall(".//job")
     if entries:
         for job in entries:
+            # Prefer the explicit location string; only compose from city/country
+            # when it is absent. Composing first discards the most specific
+            # signal: a posting with <country>Germany</country> beside
+            # <location>Frankfurt am Main, Germany</location> would yield bare
+            # "Germany", which this project's own geo classifier reads as
+            # home_relocate instead of home_local — downgrading a no-move local
+            # role to a relocation on a parser detail.
             city = _gtj_text(job, "city")
             country = _gtj_text(job, "country")
             location = (
-                ", ".join(p for p in (city, country) if p)
-                or _gtj_text(job, "location", "region")
+                _gtj_text(job, "location")
+                or ", ".join(p for p in (city, country) if p)
+                or _gtj_text(job, "region")
                 or "Germany"
             )
 
@@ -532,18 +574,23 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
                     url=_gtj_text(job, "url", "link", "apply_url"),
                     source="germantechjobs",
                     description=_gtj_text(job, "description")[:MAX_DESCRIPTION_LENGTH],
-                    posted=_gtj_posted(_gtj_text(job, "pubdate")),
+                    # Aliases here too. XML is case-sensitive and this feed has
+                    # already changed shape once; a lone "pubdate" spelling means
+                    # a camelCase <pubDate> silently zeroes every date and
+                    # "freshest-first" degrades to arbitrary feed order.
+                    posted=_gtj_posted(_gtj_text(job, "pubdate", "pubDate", "date", "published")),
                     salary=_gtj_text(job, "salary"),
                     scraped_at=now,
                 )
             )
-        # Freshest first. ISO dates sort lexically; unparseable ones sink.
-        jobs.sort(key=lambda j: j.posted, reverse=True)
-        jobs = jobs[:limit]
+        jobs = _freshest_first(jobs)[:limit]
     else:
         # Legacy/fallback RSS shape, kept in case the board switches back.
+        # Normalized and sorted the SAME way as the primary branch: `posted`
+        # must not be ISO in one branch and RFC-822 in the other, or a
+        # downstream date comparison silently depends on which branch fired.
         items = root.findall(".//item")
-        for item in items[:limit]:
+        for item in items:
             jobs.append(
                 ScrapedJob(
                     title=(item.findtext("title") or "").strip(),
@@ -552,20 +599,27 @@ def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
                     url=(item.findtext("link") or "").strip(),
                     source="germantechjobs",
                     description=(item.findtext("description") or "")[:MAX_DESCRIPTION_LENGTH],
-                    posted=(item.findtext("pubDate") or "").strip(),
+                    posted=_gtj_posted((item.findtext("pubDate") or "").strip()),
                     scraped_at=now,
                 )
             )
+        jobs = _freshest_first(jobs)[:limit]
+
         if not items:
-            # Neither shape matched. Say so loudly: an empty return here means the
-            # PARSER is broken, not that the board had nothing. Conflating those
-            # two is how this source sat at zero unnoticed.
+            # Neither shape matched. Report what was actually observed and let the
+            # reader judge — do NOT assert "the schema changed", because a board
+            # that genuinely has no openings serves a well-formed empty document
+            # and would trip this same branch. Claiming a parser failure there is
+            # a false alarm, and an alarm that cries wolf is how a real one gets
+            # ignored.
+            child_count = len(list(root))
             logger.warning(
                 "GermanTechJobs: feed parsed (root <%s>, %d children) but no <job> "
-                "or <item> entries found — the schema probably changed again. This "
-                "is a PARSER failure, not an empty board.",
+                "or <item> entries matched either known schema. If the document is "
+                "non-empty this is a PARSER failure, not an empty board — check the "
+                "feed shape before assuming the source has nothing to offer.",
                 root.tag,
-                len(list(root)),
+                child_count,
             )
 
     logger.info(f"GermanTechJobs: {len(jobs)} jobs")
@@ -858,15 +912,19 @@ def scrape_all_sources(
     _random_delay()
 
     try:
-        gtj_results = scrape_germantechjobs(limit=50)
+        # No limit pin. The fetch is a single request for the whole 4.2 MB feed
+        # either way, so capping at 50 threw away ~95% of what was already
+        # downloaded — and made the parser fix above almost pointless in the one
+        # place it ships.
+        gtj_results = scrape_germantechjobs()
         all_jobs.extend(gtj_results)
     except Exception as e:
         logger.error(f"GermanTechJobs failed: {e}")
 
-    # 8. New sources: Himalayas, Greenhouse, Lever, Ashby, startup.jobs, TheHub
+    # 8. New sources: Himalayas, Greenhouse, Lever, Ashby, startup.jobs
     if NEW_SOURCES_AVAILABLE:
         logger.info(
-            "=== Source 8/9: New Market Sources (Himalayas, ATS boards, startup.jobs, TheHub) ==="
+            "=== Source 8/9: New Market Sources (Himalayas, ATS boards, startup.jobs) ==="
         )
         try:
             new_results = scrape_all_new_sources(keywords=keywords)

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -23,6 +23,7 @@ import random
 import re
 import sys
 import time
+from collections import Counter
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -34,6 +35,7 @@ import xml.etree.ElementTree as ET
 
 import germany_jobs
 import httpx
+import source_registry
 
 logger = logging.getLogger("scrape_resilient")
 
@@ -956,11 +958,38 @@ def scrape_all_sources(
                     )
                 )
 
+    # Per-source health BEFORE dedup — dedup removes cross-posted duplicates and
+    # would understate a source's real contribution, making a healthy board look
+    # like it is fading.
+    report_source_health(all_jobs)
+
     # Deduplicate
     all_jobs = deduplicate(all_jobs)
     logger.info(f"Total after all sources: {len(all_jobs)} jobs")
 
     return all_jobs
+
+
+def report_source_health(jobs: list[ScrapedJob]) -> list[str]:
+    """Log the per-source status table and every non-ok warning.
+
+    Counts come from what actually landed in ``ScrapedJob.source`` rather than
+    from counters threaded through each call site — so a source cannot report a
+    number it did not produce, and a source that returned nothing simply does not
+    appear, which ``source_registry.check`` already treats as ZERO.
+
+    This is the whole point of the registry: without it a broken scraper
+    contributes zero forever while the run looks healthy, which is exactly how
+    two sources in this repo stayed dead for months.
+
+    Returns the warning list (also logged) so callers and tests can assert on it.
+    """
+    counts = Counter(j.source for j in jobs)
+    logger.info("Per-source health:\n%s", source_registry.status_table(counts))
+    warnings = source_registry.check(counts)
+    for line in warnings:
+        logger.warning("SOURCE HEALTH — %s", line)
+    return warnings
 
 
 def save_results(jobs: list[ScrapedJob], output_dir: Path) -> Path:

--- a/tools/scrape_resilient.py
+++ b/tools/scrape_resilient.py
@@ -449,15 +449,50 @@ def scrape_weworkremotely(limit: int = 50) -> list[ScrapedJob]:
     return jobs
 
 
-# --- Source: GermanTechJobs (RSS feed, Germany-specific) ---
+# --- Source: GermanTechJobs (XML job feed, Germany-specific) ---
 
 GERMANTECHJOBS_RSS = "https://germantechjobs.de/job_feed.xml"
 
 
-def scrape_germantechjobs(limit: int = 50) -> list[ScrapedJob]:
+def _gtj_text(job: ET.Element, *names: str) -> str:
+    """First non-empty child text among `names` (the feed carries aliases)."""
+    for name in names:
+        value = job.findtext(name)
+        if value and value.strip():
+            return value.strip()
+    return ""
+
+
+def _gtj_posted(raw: str) -> str:
+    """GermanTechJobs `pubdate` is DD.MM.YYYY — normalize to ISO, else pass through."""
+    raw = (raw or "").strip()
+    try:
+        return datetime.strptime(raw, "%d.%m.%Y").strftime("%Y-%m-%d")
+    except ValueError:
+        return raw
+
+
+def scrape_germantechjobs(limit: int = 1500) -> list[ScrapedJob]:
     """
-    Parse GermanTechJobs RSS/XML feed.
-    Germany-specific tech jobs. Free, no auth.
+    Parse the GermanTechJobs XML job feed. Germany-specific tech jobs, free, no auth.
+
+    **The feed is NOT RSS.** Its schema is ``<jobs><job>…</job></jobs>`` with flat
+    child elements (``title``/``name``, ``company``/``company-name``, ``city``,
+    ``region``, ``country``, ``location``, ``url``/``link``/``apply_url``,
+    ``salary``, ``pubdate``, ``description``) — no ``<channel>``, no ``<item>``.
+
+    This parser previously looked for ``.//item`` and therefore returned 0
+    forever while the board served a full listing. Measured 2026-08-10 against
+    the live feed: 4.2 MB, **1,011 ``<job>`` elements, 0 ``<item>`` elements**.
+    A source that can never return a row is indistinguishable from a board with
+    nothing to offer, which is precisely the failure mode worth refusing to ship.
+
+    An RSS-shaped feed is still accepted as a fallback in case they switch back,
+    and a feed that matches *neither* shape logs a PARSER failure rather than
+    passing silently as an empty result.
+
+    Entries are returned freshest-first so a `limit` trims the stale tail rather
+    than letting a promoted 2020 listing keep a role from this week out.
     """
     jobs: list[ScrapedJob] = []
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
@@ -474,30 +509,64 @@ def scrape_germantechjobs(limit: int = 50) -> list[ScrapedJob]:
 
     try:
         root = ET.fromstring(xml_text)
-        items = root.findall(".//item")
+    except ET.ParseError as e:
+        logger.error(f"GermanTechJobs feed parse error: {e}")
+        return jobs
 
-        for item in items[:limit]:
-            title_el = item.find("title")
-            link_el = item.find("link")
-            desc_el = item.find("description")
-            pubdate_el = item.find("pubDate")
+    entries = root.findall("job") or root.findall(".//job")
+    if entries:
+        for job in entries:
+            city = _gtj_text(job, "city")
+            country = _gtj_text(job, "country")
+            location = (
+                ", ".join(p for p in (city, country) if p)
+                or _gtj_text(job, "location", "region")
+                or "Germany"
+            )
 
             jobs.append(
                 ScrapedJob(
-                    title=title_el.text if title_el is not None else "",
-                    company="",  # Not always in the feed title
-                    location="Germany",
-                    url=link_el.text if link_el is not None else "",
+                    title=_gtj_text(job, "title", "name"),
+                    company=_gtj_text(job, "company", "company-name"),
+                    location=location,
+                    url=_gtj_text(job, "url", "link", "apply_url"),
                     source="germantechjobs",
-                    description=(desc_el.text or "")[:MAX_DESCRIPTION_LENGTH]
-                    if desc_el is not None
-                    else "",
-                    posted=pubdate_el.text if pubdate_el is not None else "",
+                    description=_gtj_text(job, "description")[:MAX_DESCRIPTION_LENGTH],
+                    posted=_gtj_posted(_gtj_text(job, "pubdate")),
+                    salary=_gtj_text(job, "salary"),
                     scraped_at=now,
                 )
             )
-    except ET.ParseError as e:
-        logger.error(f"GermanTechJobs RSS parse error: {e}")
+        # Freshest first. ISO dates sort lexically; unparseable ones sink.
+        jobs.sort(key=lambda j: j.posted, reverse=True)
+        jobs = jobs[:limit]
+    else:
+        # Legacy/fallback RSS shape, kept in case the board switches back.
+        items = root.findall(".//item")
+        for item in items[:limit]:
+            jobs.append(
+                ScrapedJob(
+                    title=(item.findtext("title") or "").strip(),
+                    company="",
+                    location="Germany",
+                    url=(item.findtext("link") or "").strip(),
+                    source="germantechjobs",
+                    description=(item.findtext("description") or "")[:MAX_DESCRIPTION_LENGTH],
+                    posted=(item.findtext("pubDate") or "").strip(),
+                    scraped_at=now,
+                )
+            )
+        if not items:
+            # Neither shape matched. Say so loudly: an empty return here means the
+            # PARSER is broken, not that the board had nothing. Conflating those
+            # two is how this source sat at zero unnoticed.
+            logger.warning(
+                "GermanTechJobs: feed parsed (root <%s>, %d children) but no <job> "
+                "or <item> entries found — the schema probably changed again. This "
+                "is a PARSER failure, not an empty board.",
+                root.tag,
+                len(list(root)),
+            )
 
     logger.info(f"GermanTechJobs: {len(jobs)} jobs")
     return jobs
@@ -678,7 +747,6 @@ try:
         scrape_lever,
         scrape_remotely_de,
         scrape_startupjobs,
-        scrape_thehub,
     )
 
     NEW_SOURCES_AVAILABLE = True

--- a/tools/source_registry.py
+++ b/tools/source_registry.py
@@ -1,0 +1,346 @@
+"""Scan-source registry: every source reported, every run, with a reason.
+
+WHY THIS EXISTS
+---------------
+A source that returns nothing must never look like a source with nothing to
+return. Those two states are indistinguishable in a bare job count, so a broken
+scraper contributes zero indefinitely while the run looks healthy.
+
+This is not hypothetical. Two sources in this repo were found in August 2026 to
+have *never* been capable of returning a job:
+
+* ``scrape_thehub`` GET an HTML page and called ``.json()`` on it;
+* ``scrape_germantechjobs`` parsed ``.//item`` against a feed serving
+  ``<jobs><job>`` — the board was serving over a thousand postings the whole
+  time.
+
+Neither was caught by a test, a log line, or a metric. Both were found by hand,
+months later. This module is the machinery that would have caught them on the
+first run.
+
+WHAT IT ADDS
+------------
+1. an **expected floor** — the count below which a run shouts;
+2. an explicit **enabled** flag, so a source can be switched off deliberately
+   rather than commented out or quietly left broken.
+
+THE RULE THAT MAKES EXCLUSION SAFE
+----------------------------------
+A disabled source is reported as ``DISABLED`` — never as absent, never as zero.
+If a source could be silently switched off in config, this file would recreate
+the exact bug it was written to kill. **Every registered source appears in every
+status table**, with one of:
+
+    ok · DISABLED · BLOCKED · ABANDONED · EMPTY-BY-DESIGN · BELOW-FLOOR · ZERO
+
+CALIBRATION, AND WHY ``floor`` IS OPTIONAL
+------------------------------------------
+Floors are deployment-specific: a board that yields 4,000 postings for one
+search yields 12 for another, and a floor copied from someone else's install
+fires constantly. A warning that fires every run trains the reader to ignore it,
+which is worse than no warning at all.
+
+So ``floor`` has three distinct states, and the difference matters:
+
+* **absent / null — not calibrated.** No BELOW-FLOOR check. A hard ZERO is still
+  loud, so the protection that matters most is on from the first run without any
+  configuration at all.
+* **``floor: 0`` + a ``note``** — a *documented* zero. You are asserting that
+  empty is correct here and saying why. Reported as EMPTY-BY-DESIGN, quietly.
+* **``floor: N``** — calibrated. Below N shouts.
+
+Run ``python tools/source_registry.py --calibrate <counts.json>`` to turn an
+observed run into suggested floors.
+
+Source of truth is ``config/scan-sources.yaml`` (gitignored; copy
+``config/scan-sources.example.yaml``). As with ``tools/blocklist.py``, an
+embedded fallback means an unreadable YAML can never silently empty the
+registry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger("source_registry")
+
+_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "scan-sources.yaml"
+
+# Embedded fallback: the source NAMES this repo ships scrapers for. Deliberately
+# names only — no counts. Counts are deployment-specific (see CALIBRATION above),
+# so shipping someone else's numbers as defaults would guarantee false alarms.
+#
+# This doubles as the non-shrink guard: tests assert every name here stays
+# registered, so a source cannot be dropped from the registry without a decision.
+# These are the values scrapers actually put in ``ScrapedJob.source`` — verified
+# against the emitting code, not guessed from function names. That distinction
+# matters: registering a name nothing emits creates a permanent ZERO warning,
+# and an alarm that always fires is one the reader learns to skip. Two traps
+# found while building this:
+#
+#   * ``scrape_remotely_de`` emits "remotely.de" (a dot), not "remotely_de";
+#   * ``scrape_jobspy`` emits ``row["site"]`` — the UNDERLYING board — so a
+#     "jobspy" entry would never match. Its boards are listed individually.
+FLOOR_SOURCES: tuple[str, ...] = (
+    "aijobs",
+    "arbeitnow",
+    "ashby",
+    "germantechjobs",
+    "greenhouse",
+    "himalayas",
+    "jobicy",
+    "lever",
+    "personio",
+    "remoteok",
+    "remotely.de",
+    "remotive",
+    "smartrecruiters",
+    "startupjobs",
+    "weworkremotely",
+    "workable",
+)
+
+# JobSpy is a multiplexer: it reports each posting under the board it came from
+# (``row["site"]``), so it has no single source name. Which boards run is a
+# caller argument, so these are registered only when configured — otherwise a
+# user who scrapes Indeed alone would get four permanent ZEROs for boards they
+# never asked for.
+JOBSPY_BOARDS: tuple[str, ...] = ("indeed", "linkedin", "glassdoor", "google", "zip_recruiter")
+
+# Status vocabulary.
+OK = "ok"
+DISABLED = "DISABLED"
+BLOCKED = "BLOCKED"
+BELOW_FLOOR = "BELOW-FLOOR"
+ZERO = "ZERO"
+# The source blew its wall-clock budget and the run walked away from it. It gets
+# its own label for the same reason BLOCKED does: an abandoned source reported as
+# a plain ZERO looks like a source that had nothing to give. Ranked ahead of every
+# count-based label — a partial count from an abandoned source is still abandoned,
+# and BELOW-FLOOR would send the reader hunting a scraper bug that is not there.
+ABANDONED = "ABANDONED"
+# A documented zero: floor 0 WITH a recorded reason. Distinct from ZERO, which
+# means "nothing came back and nobody knows why" — the state this module exists
+# to make impossible to overlook.
+EMPTY_BY_DESIGN = "EMPTY-BY-DESIGN"
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    enabled: bool = True
+    # None means "not calibrated" — no BELOW-FLOOR check. NOT the same as 0.
+    floor: int | None = None
+    expect_blocked: bool = False
+    note: str = ""
+
+
+def _load() -> dict[str, SourceSpec]:
+    """Load the registry, falling back to the embedded names on any problem."""
+    fallback = {n: SourceSpec(name=n) for n in FLOOR_SOURCES}
+    try:
+        raw = yaml.safe_load(_CONFIG_PATH.read_text(encoding="utf-8")) or {}
+        entries = raw.get("sources") or {}
+        if not entries:
+            raise ValueError("no `sources:` block")
+        specs: dict[str, SourceSpec] = {}
+        for name, cfg in entries.items():
+            cfg = cfg or {}
+            floor = cfg.get("floor", None)
+            specs[name] = SourceSpec(
+                name=name,
+                enabled=bool(cfg.get("enabled", True)),
+                floor=None if floor is None else int(floor),
+                expect_blocked=bool(cfg.get("expect_blocked", False)),
+                note=str(cfg.get("note", "") or "").strip(),
+            )
+        # A config that drops a shipped source must not remove it from reporting;
+        # otherwise "not in the table" becomes a silent way to disable a source.
+        for name, spec in fallback.items():
+            specs.setdefault(name, spec)
+        return specs
+    except FileNotFoundError:
+        # No config is the normal case for a fresh install — stay silent. The
+        # embedded names still give full reporting with ZERO detection on.
+        return fallback
+    except Exception as exc:  # unreadable / malformed
+        logger.warning(
+            "config/scan-sources.yaml unusable (%s) — falling back to the embedded "
+            "source list. The registry must never silently empty.",
+            exc,
+        )
+        return fallback
+
+
+SOURCES: dict[str, SourceSpec] = _load()
+
+
+def is_enabled(name: str) -> bool:
+    """Unknown sources default to ENABLED.
+
+    Deliberate: a source missing from the registry must still run and still be
+    reported. Defaulting to disabled would let a typo silently delete a source —
+    the precise failure this module exists to prevent.
+    """
+    spec = SOURCES.get(name)
+    return True if spec is None else spec.enabled
+
+
+def floor(name: str) -> int | None:
+    spec = SOURCES.get(name)
+    return None if spec is None else spec.floor
+
+
+def classify(name: str, count: int | None, status: str | None = None) -> str:
+    """Return the status label for one source's result.
+
+    ``count`` of None means the source did not run at all.
+    ``status`` is the source's own report, e.g. "blocked" or "abandoned".
+    """
+    spec = SOURCES.get(name)
+    if spec is not None and not spec.enabled:
+        return DISABLED
+    normalized = (status or "").lower()
+    if normalized == "blocked":
+        return BLOCKED
+    if normalized == "abandoned":
+        return ABANDONED
+    if count is None:
+        return ZERO
+    if count > 0:
+        f = floor(name)
+        # Uncalibrated (None) means any positive count is acceptable — we have no
+        # basis to call it low, and inventing one would cry wolf.
+        return OK if f is None or count >= f else BELOW_FLOOR
+    # count == 0. floor 0 is a CLAIM that zero is correct here; it must be
+    # justified in writing or it is indistinguishable from an unnoticed breakage.
+    if spec is not None and spec.floor == 0 and spec.note:
+        return EMPTY_BY_DESIGN
+    return ZERO
+
+
+def check(
+    counts: dict[str, int],
+    statuses: dict[str, str] | None = None,
+) -> list[str]:
+    """Return human-readable WARNING lines for everything that is not ``ok``.
+
+    Every registered source is considered, including ones absent from ``counts``
+    — a source that did not report at all is the loudest failure of the lot, and
+    the one most likely to be overlooked.
+    """
+    statuses = statuses or {}
+    warnings: list[str] = []
+    for name, spec in SOURCES.items():
+        label = classify(name, counts.get(name), statuses.get(name))
+        if label in (OK, EMPTY_BY_DESIGN):
+            continue
+        if label == DISABLED:
+            warnings.append(
+                f"{name}: DISABLED in config/scan-sources.yaml — "
+                f"{spec.note or 'no reason recorded'}"
+            )
+        elif label == BLOCKED:
+            detail = statuses.get(f"{name}_detail") or spec.note
+            # An expected block is still reported. It stops being news when it is
+            # FIXED, not when it becomes familiar.
+            warnings.append(f"{name}: BLOCKED — {detail or 'host refused the request'}")
+        elif label == ABANDONED:
+            detail = statuses.get(f"{name}_detail") or "no budget recorded"
+            warnings.append(
+                f"{name}: ABANDONED — exceeded its wall-clock budget ({detail}) and the "
+                f"run continued without it. Anything it returned is missing from this "
+                f"scan; this is not an empty source."
+            )
+        elif label == BELOW_FLOOR:
+            warnings.append(
+                f"{name}: BELOW FLOOR — {counts.get(name)} jobs, expected >= {spec.floor}"
+            )
+        else:  # ZERO
+            warnings.append(
+                f"{name}: ZERO jobs and no explanation — a blocked source and an empty "
+                f"source must never look the same. Investigate before trusting this run."
+            )
+    return warnings
+
+
+def status_table(
+    counts: dict[str, int],
+    statuses: dict[str, str] | None = None,
+) -> str:
+    """Every registered source, one line each. Used by the run summary."""
+    statuses = statuses or {}
+    rows = ["source                 jobs   state", "-" * 62]
+    for name in sorted(SOURCES):
+        c = counts.get(name)
+        rows.append(
+            f"{name:<20}{('-' if c is None else c):>7}   "
+            f"{classify(name, c, statuses.get(name))}"
+        )
+    return "\n".join(rows)
+
+
+def registered() -> set[str]:
+    return set(SOURCES)
+
+
+def suggest_floors(counts: dict[str, int], fraction: float = 0.33) -> dict[str, int]:
+    """Turn an observed run into conservative floor suggestions.
+
+    Floors sit well below the observed count on purpose. A floor at or near the
+    measured value fires on ordinary day-to-day variance, and a warning that
+    fires every run is one the reader learns to skip — which costs more than
+    having no warning at all.
+
+    A source observed at zero gets no suggestion: we cannot tell from one run
+    whether that is correct, and guessing would either paper over a break or
+    invent a false alarm.
+    """
+    out: dict[str, int] = {}
+    for name, count in sorted(counts.items()):
+        if count > 0:
+            out[name] = max(1, int(count * fraction))
+    return out
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--calibrate",
+        metavar="COUNTS_JSON",
+        help='JSON file or literal mapping source -> count, e.g. \'{"greenhouse": 4042}\'',
+    )
+    parser.add_argument(
+        "--fraction",
+        type=float,
+        default=0.33,
+        help="floor as a fraction of the observed count (default: 0.33)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.calibrate:
+        print(status_table({}))
+        return 0
+
+    path = Path(args.calibrate)
+    raw = path.read_text(encoding="utf-8") if path.exists() else args.calibrate
+    counts = json.loads(raw)
+    print("# Suggested floors — paste into config/scan-sources.yaml")
+    print("# Sources observed at 0 are omitted deliberately: one run cannot tell")
+    print("# a correct zero from a broken one. Investigate, then set floor: 0")
+    print("# WITH a note if the zero is real.")
+    print("sources:")
+    for name, f in suggest_floors(counts, args.fraction).items():
+        print(f"  {name}:\n    enabled: true\n    floor: {f}    # observed {counts[name]}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_main())

--- a/tools/tests/test_dead_sources.py
+++ b/tools/tests/test_dead_sources.py
@@ -1,0 +1,213 @@
+"""Regression tests for two sources that could never return a job (G-1564).
+
+Both were found by auditing Kestrel against its downstream fork after that fork
+fixed the same defects:
+
+  * ``scrape_germantechjobs`` parsed ``.//item`` (RSS) against a feed that
+    serves ``<jobs><job>``. Measured against the live feed 2026-08-10: 4.2 MB,
+    **1,011 <job> elements, 0 <item> elements**. It returned 0 forever while the
+    board served a full listing.
+  * ``scrape_thehub`` GET the HTML page thehub.io/jobs and called ``.json()``
+    on it. It raised on every retry for every search term and has been removed.
+
+The thesis these tests defend: **a source returning nothing must never look like
+a source with nothing to return.** A silent zero is indistinguishable from an
+empty board, so it survives indefinitely.
+
+No network. Fixtures reproduce the real response *shapes*.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scrape_resilient  # noqa: E402
+from scrape_resilient import scrape_germantechjobs  # noqa: E402
+
+# The real feed's shape, reduced to three entries. Flat children, aliases on
+# title/company/url, DD.MM.YYYY pubdate, no <channel> and no <item>.
+GTJ_REAL_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<jobs>
+  <job>
+    <title>Senior Backend Engineer</title>
+    <company>Beispiel GmbH</company>
+    <city>Berlin</city>
+    <country>Germany</country>
+    <url>https://germantechjobs.de/job/1</url>
+    <salary>70000-90000</salary>
+    <pubdate>09.08.2026</pubdate>
+    <description>Build things.</description>
+  </job>
+  <job>
+    <name>Solution Architect</name>
+    <company-name>Muster AG</company-name>
+    <location>Munich</location>
+    <link>https://germantechjobs.de/job/2</link>
+    <pubdate>10.08.2026</pubdate>
+    <description>Architect things.</description>
+  </job>
+  <job>
+    <title>Data Engineer</title>
+    <company>Alt GmbH</company>
+    <city>Hamburg</city>
+    <country>Germany</country>
+    <apply_url>https://germantechjobs.de/job/3</apply_url>
+    <pubdate>01.01.2020</pubdate>
+  </job>
+</jobs>
+"""
+
+# The legacy RSS shape, still accepted in case the board switches back.
+GTJ_RSS_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <item>
+    <title>Platform Engineer</title>
+    <link>https://germantechjobs.de/job/9</link>
+    <description>Legacy shape.</description>
+    <pubDate>Mon, 10 Aug 2026 09:00:00 GMT</pubDate>
+  </item>
+</channel></rss>
+"""
+
+# Neither shape — the case that must WARN rather than pass as an empty board.
+GTJ_UNKNOWN_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
+<listings><posting><title>Something</title></posting></listings>
+"""
+
+
+@pytest.fixture
+def feed(monkeypatch):
+    """Serve fixture XML in place of the network."""
+
+    def _serve(xml: str):
+        monkeypatch.setattr(scrape_resilient, "_retry_with_backoff", lambda fn: xml)
+
+    return _serve
+
+
+class TestGermanTechJobsParser:
+    def test_parses_the_real_jobs_job_shape(self, feed):
+        """The whole bug: `.//item` against `<jobs><job>` returned 0 forever."""
+        feed(GTJ_REAL_SHAPE)
+        jobs = scrape_germantechjobs()
+        assert len(jobs) == 3, "the <jobs><job> shape must yield jobs, not silence"
+
+    def test_old_rss_selector_would_have_found_nothing(self):
+        """Pin the defect itself, so the fix cannot be quietly reverted.
+
+        This is the assertion that proves the test is worth having: against the
+        real feed shape the previous selector yields zero, which is exactly why
+        the source sat dead without anyone noticing.
+        """
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(GTJ_REAL_SHAPE)
+        assert root.findall(".//item") == [], "fixture must reproduce the real shape"
+        assert len(root.findall("job")) == 3
+
+    def test_reads_aliased_child_elements(self, feed):
+        """The feed uses name/company-name/link/apply_url as aliases."""
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert "Solution Architect" in by_title
+        alias = by_title["Solution Architect"]
+        assert alias.company == "Muster AG"
+        assert alias.url == "https://germantechjobs.de/job/2"
+        assert by_title["Data Engineer"].url.endswith("/job/3")  # apply_url alias
+
+    def test_builds_location_from_city_and_country(self, feed):
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert by_title["Senior Backend Engineer"].location == "Berlin, Germany"
+        # Falls back to <location> when city/country are absent.
+        assert by_title["Solution Architect"].location == "Munich"
+
+    def test_normalizes_ddmmyyyy_pubdate_to_iso(self, feed):
+        feed(GTJ_REAL_SHAPE)
+        by_title = {j.title: j for j in scrape_germantechjobs()}
+        assert by_title["Senior Backend Engineer"].posted == "2026-08-09"
+
+    def test_returns_freshest_first_so_limit_trims_the_stale_tail(self, feed):
+        """A promoted 2020 listing must not displace a role from this week."""
+        feed(GTJ_REAL_SHAPE)
+        jobs = scrape_germantechjobs(limit=2)
+        assert len(jobs) == 2
+        assert [j.posted for j in jobs] == ["2026-08-10", "2026-08-09"]
+        assert all(j.posted != "2020-01-01" for j in jobs)
+
+    def test_still_accepts_the_legacy_rss_shape(self, feed):
+        feed(GTJ_RSS_SHAPE)
+        jobs = scrape_germantechjobs()
+        assert len(jobs) == 1
+        assert jobs[0].title == "Platform Engineer"
+
+    def test_unknown_shape_warns_instead_of_passing_as_empty(self, feed, caplog):
+        """The point of the whole exercise.
+
+        An unrecognised schema must announce itself as a PARSER failure. If it
+        returns an empty list quietly, it is indistinguishable from a board with
+        no jobs — and that is how this source stayed broken.
+        """
+        feed(GTJ_UNKNOWN_SHAPE)
+        with caplog.at_level("WARNING"):
+            jobs = scrape_germantechjobs()
+        assert jobs == []
+        assert any("PARSER failure" in r.getMessage() for r in caplog.records), (
+            "an unparseable feed must warn, not return a silent zero"
+        )
+
+    def test_malformed_xml_does_not_raise(self, feed):
+        feed("<jobs><job><title>unclosed")
+        assert scrape_germantechjobs() == []
+
+
+class TestTheHubRemoved:
+    def test_thehub_scraper_is_gone(self):
+        """It GET an HTML page and called .json(); it could never succeed.
+
+        Removed rather than left in place, because dead code that always returns
+        zero is the silent-zero failure in its purest form.
+        """
+        import scrape_new_sources
+
+        assert not hasattr(scrape_new_sources, "scrape_thehub")
+
+    def test_no_module_still_imports_it(self):
+        """A dangling import would break the whole scrape at runtime."""
+        import scrape_new_sources  # noqa: F401
+        import scrape_resilient  # noqa: F401
+        # Importing both is the assertion: a leftover `from ... import
+        # scrape_thehub` raises ImportError here rather than mid-scan.
+
+
+class TestTitleMatchingSingularAndPlural:
+    def test_solution_architect_singular_is_matched(self):
+        """One character used to drop a whole class of roles.
+
+        "solutions" does not substring-match "Solution Architect", so a
+        plural-only list silently skips every employer using the singular.
+        """
+        from kit_builder import _ARCHETYPE_RULES
+
+        keywords = [kw for _, kws in _ARCHETYPE_RULES for kw in kws]
+        title = "Solution Architect"
+        assert any(kw in title.lower() for kw in keywords), (
+            "the singular form must match; plural-only lists lose these roles"
+        )
+
+    def test_plural_still_matched(self):
+        from kit_builder import _ARCHETYPE_RULES
+
+        keywords = [kw for _, kws in _ARCHETYPE_RULES for kw in kws]
+        assert any(kw in "Solutions Architect".lower() for kw in keywords)
+
+    def test_search_queries_cover_both_forms(self):
+        from scrape_new_sources import _SR_QUERIES
+
+        assert "solution architect" in _SR_QUERIES
+        assert "solutions architect" in _SR_QUERIES

--- a/tools/tests/test_dead_sources.py
+++ b/tools/tests/test_dead_sources.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -82,10 +83,39 @@ GTJ_UNKNOWN_SHAPE = """<?xml version="1.0" encoding="UTF-8"?>
 
 @pytest.fixture
 def feed(monkeypatch):
-    """Serve fixture XML in place of the network."""
+    """Serve fixture XML by mocking the HTTP CLIENT, not `_retry_with_backoff`.
+
+    This distinction is the entire point of this file, so it is worth stating.
+    Patching ``_retry_with_backoff`` would stub out the layer *above* the
+    request, meaning ``_fetch`` never runs — the URL, the verb, the headers and
+    the ``.text`` vs ``.json()`` choice would all go untested. That is precisely
+    how TheHub kept three green tests while GETting an HTML page and calling
+    ``.json()`` on it: its tests mocked away the broken thing and then asserted
+    that the mock worked.
+
+    Patching ``httpx.Client`` keeps the real ``_fetch`` in the loop, so a
+    mutation to the URL or the response accessor fails these tests.
+    """
 
     def _serve(xml: str):
-        monkeypatch.setattr(scrape_resilient, "_retry_with_backoff", lambda fn: xml)
+        response = MagicMock()
+        response.text = xml
+        response.raise_for_status = MagicMock()
+        # .json() must EXPLODE. If production ever calls it on this XML feed —
+        # the TheHub mistake — the test has to fail rather than hand back a mock.
+        response.json = MagicMock(
+            side_effect=ValueError("Expecting value: line 1 column 1 (char 0)")
+        )
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.get = MagicMock(return_value=response)
+        # Any non-GET verb is a bug in a feed reader; make it obvious.
+        client.post = MagicMock(side_effect=AssertionError("feed must be fetched with GET"))
+        monkeypatch.setattr(scrape_resilient.httpx, "Client", MagicMock(return_value=client))
+        monkeypatch.setattr(scrape_resilient, "_random_delay", lambda *a, **k: None)
+        monkeypatch.setattr(scrape_resilient.time, "sleep", lambda *a, **k: None)
+        return client
 
     return _serve
 
@@ -97,18 +127,42 @@ class TestGermanTechJobsParser:
         jobs = scrape_germantechjobs()
         assert len(jobs) == 3, "the <jobs><job> shape must yield jobs, not silence"
 
-    def test_old_rss_selector_would_have_found_nothing(self):
-        """Pin the defect itself, so the fix cannot be quietly reverted.
+    def test_fetches_the_feed_url_with_GET_and_reads_text_not_json(self, feed):
+        """Exercise the REQUEST, not just the parse.
 
-        This is the assertion that proves the test is worth having: against the
-        real feed shape the previous selector yields zero, which is exactly why
-        the source sat dead without anyone noticing.
+        Replaces an earlier version of this test that asserted about
+        ElementTree and never touched production code — a fixture self-check
+        masquerading as a regression test. This one fails if the URL, the verb,
+        or the response accessor changes, which is the TheHub failure class.
         """
-        import xml.etree.ElementTree as ET
+        client = feed(GTJ_REAL_SHAPE)
+        scrape_germantechjobs()
+        client.get.assert_called_once()
+        (url,), _ = client.get.call_args
+        assert url == scrape_resilient.GERMANTECHJOBS_RSS
+        client.post.assert_not_called()
 
-        root = ET.fromstring(GTJ_REAL_SHAPE)
-        assert root.findall(".//item") == [], "fixture must reproduce the real shape"
-        assert len(root.findall("job")) == 3
+    def test_nested_job_elements_are_not_silently_skipped(self, feed):
+        """A grouped feed must not lose its entries.
+
+        `findall("job") or findall(".//job")` looks defensive but short-circuits:
+        the direct-child form returns a NON-EMPTY partial list, so the fallback
+        never runs and nested entries vanish with no warning. A silent wrong
+        subset is worse than the zero this module exists to prevent.
+        """
+        grouped = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>Top Level</title><pubdate>01.08.2026</pubdate></job>
+          <category>
+            <job><title>Nested One</title><pubdate>02.08.2026</pubdate></job>
+            <job><title>Nested Two</title><pubdate>03.08.2026</pubdate></job>
+          </category>
+        </jobs>"""
+        feed(grouped)
+        titles = {j.title for j in scrape_germantechjobs()}
+        assert titles == {"Top Level", "Nested One", "Nested Two"}, (
+            f"nested <job> entries were dropped: got {titles}"
+        )
 
     def test_reads_aliased_child_elements(self, feed):
         """The feed uses name/company-name/link/apply_url as aliases."""
@@ -140,11 +194,96 @@ class TestGermanTechJobsParser:
         assert [j.posted for j in jobs] == ["2026-08-10", "2026-08-09"]
         assert all(j.posted != "2020-01-01" for j in jobs)
 
+    def test_an_unparseable_date_cannot_hijack_the_top_slot(self, feed):
+        """A raw string sort ranks garbage above every real date.
+
+        `_gtj_posted` passes anything it cannot parse through verbatim, and under
+        a reverse-lexical sort every string starting above '2' outranks every ISO
+        date. One row reading "Mon, 01 Jan 2010 ..." would take rank 0 and, with a
+        limit applied after, evict a genuinely fresh posting.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>Garbage Date</title><pubdate>Mon, 01 Jan 2010 00:00:00 GMT</pubdate></job>
+          <job><title>Fresh</title><pubdate>09.08.2026</pubdate></job>
+          <job><title>Fresher</title><pubdate>10.08.2026</pubdate></job>
+        </jobs>"""
+        feed(xml)
+        jobs = scrape_germantechjobs()
+        assert jobs[0].title == "Fresher", f"garbage date hijacked rank 0: {jobs[0].title}"
+        assert [j.title for j in jobs[:2]] == ["Fresher", "Fresh"]
+
+    def test_a_dated_job_is_not_evicted_by_an_undated_one(self, feed):
+        """The mirror failure, and the worse one.
+
+        Under a naive sort an undated job lands dead last and is then
+        DETERMINISTICALLY excluded by `limit` — permanently invisible, which is
+        the silent-loss failure this module exists to prevent. Undated rows must
+        stay reachable while never outranking a real date.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job><title>No Date</title></job>
+          <job><title>Old</title><pubdate>01.01.2020</pubdate></job>
+        </jobs>"""
+        feed(xml)
+        jobs = scrape_germantechjobs()
+        titles = [j.title for j in jobs]
+        assert titles == ["Old", "No Date"], titles
+        assert "No Date" in titles, "an undated job must not become unreachable"
+
+    def test_explicit_location_beats_a_bare_country(self, feed):
+        """Composing city+country first discards the most specific signal.
+
+        A posting carrying <country>Germany</country> AND
+        <location>Frankfurt am Main, Germany</location> must not collapse to
+        "Germany" — this project's geo classifier reads the bare country as a
+        relocation and the qualified string as a no-move local role.
+        """
+        xml = """<?xml version="1.0"?>
+        <jobs>
+          <job>
+            <title>Local Role</title>
+            <country>Germany</country>
+            <location>Frankfurt am Main, Germany</location>
+            <pubdate>10.08.2026</pubdate>
+          </job>
+        </jobs>"""
+        feed(xml)
+        assert scrape_germantechjobs()[0].location == "Frankfurt am Main, Germany"
+
+    def test_camelcase_pubdate_alias_is_read(self, feed):
+        """pubdate was the one field with no alias; XML is case-sensitive."""
+        xml = """<?xml version="1.0"?>
+        <jobs><job><title>X</title><pubDate>10.08.2026</pubDate></job></jobs>"""
+        feed(xml)
+        assert scrape_germantechjobs()[0].posted == "2026-08-10"
+
     def test_still_accepts_the_legacy_rss_shape(self, feed):
         feed(GTJ_RSS_SHAPE)
         jobs = scrape_germantechjobs()
         assert len(jobs) == 1
         assert jobs[0].title == "Platform Engineer"
+
+    def test_rss_fallback_sorts_and_limits_like_the_primary_branch(self, feed):
+        """One field, one format, one ordering — regardless of which branch fired.
+
+        The fallback used to apply `limit` with no sort and no date
+        normalisation, so `posted` was ISO in one branch and RFC-822 in the
+        other, and `limit` trimmed the HEAD instead of the stale tail. Any
+        downstream date comparison then depended on an invisible condition.
+        """
+        rss = """<?xml version="1.0"?>
+        <rss version="2.0"><channel>
+          <item><title>Oldest</title><pubDate>01.01.2020</pubDate></item>
+          <item><title>Newest</title><pubDate>10.08.2026</pubDate></item>
+        </channel></rss>"""
+        feed(rss)
+        jobs = scrape_germantechjobs(limit=1)
+        assert [j.title for j in jobs] == ["Newest"], "fallback trimmed the head, not the tail"
+        assert jobs[0].posted == "2026-08-10", (
+            "fallback must normalise dates like the primary branch"
+        )
 
     def test_unknown_shape_warns_instead_of_passing_as_empty(self, feed, caplog):
         """The point of the whole exercise.

--- a/tools/tests/test_source_registry.py
+++ b/tools/tests/test_source_registry.py
@@ -1,0 +1,357 @@
+"""The source registry must make a silent zero impossible (G-1564).
+
+Thesis: *a source returning nothing must never look like a source with nothing
+to return.* Two sources in this repo were found in August 2026 to have never
+been capable of returning a job — ``scrape_thehub`` (GET an HTML page, called
+``.json()``) and ``scrape_germantechjobs`` (parsed ``.//item`` against a
+``<jobs><job>`` feed, while the board served over a thousand postings). Neither
+was caught by a test, a log line or a metric.
+
+These tests pin the machinery that would have caught both on the first run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import source_registry as sr  # noqa: E402
+
+EXAMPLE_CONFIG = Path(__file__).resolve().parents[2] / "config" / "scan-sources.example.yaml"
+
+
+# --------------------------------------------------------------------------
+# The registry cannot silently shrink (same discipline as tools/blocklist.py)
+# --------------------------------------------------------------------------
+
+
+def test_every_shipped_source_is_registered():
+    """The embedded name list is the contract; config may extend, never shrink."""
+    missing = set(sr.FLOOR_SOURCES) - sr.registered()
+    assert not missing, f"registry lost sources: {sorted(missing)}"
+
+
+def test_a_config_that_omits_a_source_does_not_unregister_it():
+    """Otherwise "leave it out of the config" becomes a silent way to disable.
+
+    That is the same hole as commenting the scraper out, which is what this
+    module exists to replace.
+    """
+    assert set(sr.FLOOR_SOURCES) <= sr.registered()
+
+
+def test_registry_survives_a_missing_config(monkeypatch, tmp_path):
+    """No config is the normal case for a fresh install; reporting still works."""
+    monkeypatch.setattr(sr, "_CONFIG_PATH", tmp_path / "nope.yaml")
+    assert set(sr._load()) == set(sr.FLOOR_SOURCES)
+
+
+def test_registry_survives_a_malformed_config(monkeypatch, tmp_path, caplog):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("sources:\n")  # present but empty
+    monkeypatch.setattr(sr, "_CONFIG_PATH", bad)
+    with caplog.at_level("WARNING"):
+        specs = sr._load()
+    assert set(specs) == set(sr.FLOOR_SOURCES)
+    assert any("never silently empty" in r.getMessage() for r in caplog.records)
+
+
+def test_unreadable_config_warns_but_a_missing_one_does_not(monkeypatch, tmp_path, caplog):
+    """A missing config is normal; a broken one is not. Only the latter warns."""
+    monkeypatch.setattr(sr, "_CONFIG_PATH", tmp_path / "absent.yaml")
+    with caplog.at_level("WARNING"):
+        sr._load()
+    assert not caplog.records, "a fresh install must not be nagged"
+
+
+# --------------------------------------------------------------------------
+# Classification — the states a source can be in
+# --------------------------------------------------------------------------
+
+
+def _spec(monkeypatch, name, **kw):
+    monkeypatch.setitem(sr.SOURCES, name, sr.SourceSpec(name=name, **kw))
+
+
+def test_healthy_source_is_ok(monkeypatch):
+    _spec(monkeypatch, "greenhouse", floor=1200)
+    assert sr.classify("greenhouse", 4042) == sr.OK
+
+
+def test_regression_below_floor_is_caught(monkeypatch):
+    """The GermanTechJobs shape: a live board reduced to a trickle."""
+    _spec(monkeypatch, "germantechjobs", floor=300)
+    assert sr.classify("germantechjobs", 4) == sr.BELOW_FLOOR
+
+
+def test_uncalibrated_source_never_reports_below_floor(monkeypatch):
+    """An uncalibrated floor must not invent an alarm.
+
+    Volumes are deployment-specific. Guessing a floor produces a warning that
+    fires every run, and a warning that always fires is one the reader learns to
+    skip — which costs more than having none.
+    """
+    _spec(monkeypatch, "jobicy", floor=None)
+    assert sr.classify("jobicy", 1) == sr.OK
+    assert sr.classify("jobicy", 99999) == sr.OK
+
+
+def test_uncalibrated_source_still_catches_a_hard_zero(monkeypatch):
+    """The protection that matters most works with no configuration at all."""
+    _spec(monkeypatch, "jobicy", floor=None)
+    assert sr.classify("jobicy", 0) == sr.ZERO
+
+
+def test_blocked_beats_count(monkeypatch):
+    """A blocked source is BLOCKED even though its count is a normal-looking 0."""
+    _spec(monkeypatch, "startupjobs", floor=None, expect_blocked=True)
+    assert sr.classify("startupjobs", 0, status="blocked") == sr.BLOCKED
+
+
+def test_abandoned_beats_a_partial_count(monkeypatch):
+    """A partial count from an abandoned source is still an abandoned source.
+
+    Labelling it BELOW-FLOOR would send the reader hunting a scraper bug that
+    is not there.
+    """
+    _spec(monkeypatch, "greenhouse", floor=1200)
+    assert sr.classify("greenhouse", 300, status="abandoned") == sr.ABANDONED
+
+
+def test_documented_zero_is_not_an_alarm(monkeypatch):
+    _spec(monkeypatch, "lever", floor=0, note="roster deliberately empty")
+    assert sr.classify("lever", 0) == sr.EMPTY_BY_DESIGN
+
+
+def test_zero_floor_WITHOUT_a_note_is_still_loud(monkeypatch):
+    """floor: 0 is a claim that zero is correct. Unjustified, it is just a zero.
+
+    Without this, `floor: 0` becomes a one-line way to silence any broken
+    source — the exact hole this module closes.
+    """
+    _spec(monkeypatch, "lever", floor=0, note="")
+    assert sr.classify("lever", 0) == sr.ZERO
+
+
+def test_undocumented_zero_is_loud(monkeypatch):
+    _spec(monkeypatch, "personio", floor=None)
+    assert sr.classify("personio", 0) == sr.ZERO
+
+
+def test_source_that_did_not_report_at_all_is_zero():
+    """Absence is the easiest failure to overlook, so it is treated as ZERO."""
+    assert sr.classify("personio", None) == sr.ZERO
+
+
+# --------------------------------------------------------------------------
+# Exclusion must be LOUD -- the point of the whole design
+# --------------------------------------------------------------------------
+
+
+def test_disabled_source_is_reported_not_hidden(monkeypatch):
+    """If a source could be switched off silently, this file would RECREATE the
+    bug it exists to prevent."""
+    _spec(monkeypatch, "jobicy", enabled=False, note="paused for X")
+    assert sr.classify("jobicy", 0) == sr.DISABLED
+    assert any("jobicy" in w and "DISABLED" in w for w in sr.check({"jobicy": 0}))
+
+
+def test_disabled_beats_a_healthy_count(monkeypatch):
+    """Even if a disabled source somehow returns jobs, say it is disabled."""
+    _spec(monkeypatch, "jobicy", enabled=False, note="paused")
+    assert sr.classify("jobicy", 500) == sr.DISABLED
+
+
+def test_unknown_source_defaults_to_enabled():
+    """A typo must not silently delete a source.
+
+    Defaulting an unregistered name to DISABLED would make a misspelling behave
+    exactly like a deliberate exclusion — the failure mode in miniature.
+    """
+    assert sr.is_enabled("a-source-nobody-registered") is True
+
+
+# --------------------------------------------------------------------------
+# check() over a whole run
+# --------------------------------------------------------------------------
+
+
+def test_a_vanished_source_is_caught():
+    counts = {n: 10 for n in sr.registered()}
+    counts.pop("greenhouse")
+    assert any(w.startswith("greenhouse: ZERO") for w in sr.check(counts))
+
+
+def test_a_healthy_uncalibrated_run_is_quiet():
+    """A fresh install with everything working must produce no noise."""
+    assert sr.check({n: 10 for n in sr.registered()}) == []
+
+
+def test_status_table_lists_every_registered_source():
+    """Nothing may be absent from the table — absence is how zeros hide."""
+    table = sr.status_table({n: 5 for n in sr.registered()})
+    for name in sr.registered():
+        assert name in table
+
+
+def test_status_table_shows_a_dash_for_a_source_that_did_not_run():
+    table = sr.status_table({})
+    assert "-" in table and "ZERO" in table
+
+
+# --------------------------------------------------------------------------
+# Calibration helper
+# --------------------------------------------------------------------------
+
+
+def test_suggested_floors_sit_below_the_observed_count():
+    """A floor at or above the measured value fires on ordinary variance."""
+    counts = {"greenhouse": 4042, "ashby": 2712, "remotive": 19}
+    for name, f in sr.suggest_floors(counts).items():
+        assert f < counts[name], f"{name}: floor {f} >= observed {counts[name]}"
+        assert f >= 1
+
+
+def test_calibration_refuses_to_guess_at_a_zero():
+    """One run cannot distinguish a correct zero from a broken source."""
+    assert sr.suggest_floors({"dead": 0, "live": 300}) == {"live": 99}
+
+
+def test_calibrate_cli_emits_pasteable_yaml(capsys):
+    sr._main(["--calibrate", json.dumps({"greenhouse": 4042})])
+    out = capsys.readouterr().out
+    assert "sources:" in out and "greenhouse:" in out and "floor: 1333" in out
+    parsed = yaml.safe_load(out)
+    assert parsed["sources"]["greenhouse"]["floor"] == 1333
+
+
+# --------------------------------------------------------------------------
+# The shipped example config must practise what the module preaches
+# --------------------------------------------------------------------------
+
+
+def test_example_config_parses():
+    assert EXAMPLE_CONFIG.exists(), "the example config must be tracked in git"
+    yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_example_config_ships_no_uncalibrated_floors():
+    """Shipping someone else's numbers guarantees false alarms elsewhere."""
+    raw = yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+    for name, cfg in (raw.get("sources") or {}).items():
+        assert (cfg or {}).get("floor") is None, (
+            f"{name}: the example config must not ship a floor — volumes are "
+            f"deployment-specific and a copied floor fires constantly"
+        )
+
+
+def test_example_config_zero_floors_carry_a_reason():
+    raw = yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+    for name, cfg in (raw.get("sources") or {}).items():
+        cfg = cfg or {}
+        if cfg.get("floor") == 0:
+            assert (cfg.get("note") or "").strip(), f"{name}: floor 0 with no reason"
+
+
+def test_removed_sources_record_why():
+    """So nobody restores TheHub without reading why it went."""
+    raw = yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+    removed = raw.get("removed") or {}
+    assert "thehub" in removed
+    for name, cfg in removed.items():
+        assert cfg.get("reason", "").strip(), f"{name}: removed with no reason"
+        assert cfg.get("ticket"), f"{name}: removed with no ticket"
+
+
+@pytest.mark.parametrize("name", sorted(sr.FLOOR_SOURCES))
+def test_every_shipped_source_appears_in_the_example_config(name):
+    """A source missing from the example is one a user never learns they have."""
+    raw = yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+    assert name in (raw.get("sources") or {}), f"{name} missing from the example config"
+
+
+# --------------------------------------------------------------------------
+# The registry must actually be WIRED IN. An unused module is documentation,
+# and documentation is precisely what failed here before.
+# --------------------------------------------------------------------------
+
+
+def _calls_in(func) -> set[str]:
+    """Names actually CALLED by `func`, via AST.
+
+    Deliberately not a substring search on the source. The first version of this
+    test did `"report_source_health(" in src` and passed happily when the call
+    was commented out — the comment still contains the substring. A guard that
+    a comment satisfies is not a guard.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return {
+        n.func.id if isinstance(n.func, ast.Name) else getattr(n.func, "attr", "")
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+    }
+
+
+def test_report_source_health_is_called_by_the_orchestrator():
+    """Guard the wiring, not just the logic.
+
+    A registry that exists but is never invoked leaves the original bug fully
+    intact while looking like it was fixed — the same "recorded state says fine"
+    failure, one level up.
+    """
+    import scrape_resilient
+
+    assert "report_source_health" in _calls_in(scrape_resilient.scrape_all_sources), (
+        "scrape_all_sources must CALL report_source_health — an unwired registry "
+        "protects nothing"
+    )
+
+
+def test_report_source_health_counts_from_emitted_source_values():
+    import scrape_resilient
+    from scrape_resilient import ScrapedJob
+
+    def job(source):
+        return ScrapedJob(title="t", company="c", location="l", url="u", source=source)
+
+    jobs = [job("greenhouse")] * 5 + [job("ashby")] * 2
+    warnings = scrape_resilient.report_source_health(jobs)
+    # greenhouse and ashby produced rows -> not warned about.
+    assert not any(w.startswith("greenhouse:") for w in warnings)
+    assert not any(w.startswith("ashby:") for w in warnings)
+    # Everything else registered produced nothing -> each is a loud ZERO.
+    assert any(w.startswith("personio: ZERO") for w in warnings)
+
+
+def test_a_source_that_returns_nothing_is_reported_not_omitted():
+    """The core thesis, end to end through the real entry point."""
+    import scrape_resilient
+
+    warnings = scrape_resilient.report_source_health([])
+    zeroed = {w.split(":")[0] for w in warnings if "ZERO" in w}
+    assert set(sr.FLOOR_SOURCES) <= zeroed, (
+        "every registered source must be accounted for when the scan returns nothing"
+    )
+
+
+def test_health_is_reported_before_dedup():
+    """Dedup removes cross-posted duplicates; counting after it would understate
+    a source's real contribution and make a healthy board look like it is fading."""
+    import inspect
+
+    import scrape_resilient
+
+    src = inspect.getsource(scrape_resilient.scrape_all_sources)
+    assert src.index("report_source_health(") < src.index("deduplicate(all_jobs)"), (
+        "source health must be measured on raw contributions, before dedup"
+    )


### PR DESCRIPTION
The machinery that would have caught **#508**'s two dead scrapers on their first run instead of months later.

A source returning nothing is indistinguishable from a source with nothing to return, when all you have is a total job count. Not hypothetical here: `scrape_thehub` GET an HTML page and called `.json()` on it, and `scrape_germantechjobs` parsed `.//item` against a `<jobs><job>` feed while the board served over a thousand postings. Neither was caught by a test, a log line, or a metric.

> **Stacked on #508.** Review that first; this branch contains it.

## What it adds

Every registered source now appears in every run's status table with exactly one of `ok · DISABLED · BLOCKED · ABANDONED · EMPTY-BY-DESIGN · BELOW-FLOOR · ZERO`. A source that returns nothing **cannot be absent** from the report — absence *is* the failure being guarded against.

```
Per-source health:
source                 jobs   state
greenhouse             4042   ok
germantechjobs         1011   ok
personio                  -   ZERO
...
WARNING SOURCE HEALTH — personio: ZERO jobs and no explanation — a blocked
source and an empty source must never look the same.
```

## Why `floor` is optional — the main design departure

Floors are deployment-specific: volumes depend entirely on your company lists, keywords and region. Shipping one install's numbers as defaults guarantees warnings that fire every run, and **a warning that always fires is one the reader learns to skip** — worse than none. So `floor` has three states:

| state | meaning |
|---|---|
| **absent** | NOT CALIBRATED. No below-floor check. A hard ZERO is still loud, so the protection that matters most works with **zero configuration**. |
| **`0` + a `note`** | DOCUMENTED ZERO. You assert empty is correct and say why. The note is **required** — otherwise `floor: 0` becomes a one-line way to silence any broken source, recreating the exact bug. |
| **`N`** | CALIBRATED. Below N shouts. |

```
python tools/source_registry.py --calibrate '{"greenhouse": 4042}'
```

Suggests ~1/3 of measured, and **refuses to suggest anything for a source observed at zero**: one run cannot tell a correct zero from a broken scraper, and guessing would either paper over a break or invent a false alarm.

## Registry names are what is EMITTED, not what functions are called

Verified against the emitting code rather than inferred from function names — which turned up two traps that would each have produced a permanent false ZERO:

- `scrape_remotely_de` emits `source="remotely.de"` — with a dot
- `scrape_jobspy` emits `row["site"]`, the **underlying board**, so a `"jobspy"` entry would never match anything. Its boards are documented but left unregistered by default, since which ones run is a caller argument.

## The wiring is guarded, not assumed

`scrape_all_sources` calls `report_source_health` **before dedup** (dedup removes cross-posted duplicates and would understate a source's real contribution, making a healthy board look like it is fading).

A test asserts the call exists — **via AST, not a substring search**. The first version used `"report_source_health(" in src` and passed happily with the call commented out, because the comment still contains the substring. A guard a comment can satisfy is not a guard.

Counts derive from `ScrapedJob.source`, so a source cannot report a number it did not produce.

## Verification

- **49 tests** in `tools/tests/test_source_registry.py`, each pinning a failure mode that actually occurred
- **Mutation-verified:** commenting out the wiring call turns the AST guard red; restoring it passes
- Full run: **422 tools tests**
- ruff on the touched file: **14 on main → 13 here**; both new files clean
- Personal-data and downstream-data scrubs clean

Config ships as `config/scan-sources.example.yaml` (real file gitignored), per the existing blocklist/companies convention. It deliberately ships **no floors**.
