### PR TITLE
docs(eval): say what the blind-set gate actually measures (judge, not hand labels)

### DIFF
--- a/docs/guides/geo-eligibility.md
+++ b/docs/guides/geo-eligibility.md
@@ -69,7 +69,7 @@ foreign country is still `foreign`.
 
 ## The two contract rules
 
-Both rules were measured on a human-judged blind set and survive verbatim:
+Both rules were measured on the 277-item blind set and survive verbatim:
 
 1. **Title region-tokens bind first.** "(AMER)" or ", Korea" in the *title*
    names the served market regardless of which office is listed — but an

--- a/src/career_os/discovery/prefilter.py
+++ b/src/career_os/discovery/prefilter.py
@@ -11,12 +11,14 @@ Three aggressiveness levels:
 Based on validated spike results in tools/spike_prefilter.py.
 
 The 99.5% recall figure describes the keyword filter above. The optional geo
-gate is a SEPARATE signal with its own measured recall of 93.6% (G-1474
-blind set, 47 human-judged GO roles, 3 classified ``foreign``), so it does not
-delete anything by default: it annotates and counts, leaving the cap/review
-decision to the scoring layer, exactly as the engine's own contract defines the
-``foreign`` class. Deletion is available behind ``geo_drop_foreign`` — turning
-it on trades the module's 99.5% recall claim for the geo gate's 93.6%.
+gate is a SEPARATE signal, measured at 93.6% recall against an AUTOMATED judge
+on the G-1474 blind set — and at 81.4% against that set's hand labels, which is
+the more honest figure (see ``tests/eval/geo/fixtures/README.md``). Either way
+it does not delete anything by default: it annotates and counts, leaving the
+cap/review decision to the scoring layer, exactly as the engine's own contract
+defines the ``foreign`` class. Deletion is available behind ``geo_drop_foreign``
+— turning it on trades the module's 99.5% recall claim for the geo gate's, and
+the hand-labelled number is the one to weigh that trade against.
 """
 
 from __future__ import annotations

--- a/src/career_os/services/geo/classifier.py
+++ b/src/career_os/services/geo/classifier.py
@@ -19,14 +19,15 @@ Public classes returned by :func:`geo_eligibility`:
                                  country-locked remote) => cap / review queue.
 - ``unknown``                 -> no geo signal => do NOT bury; let the AI score.
 
-Two contract rules (measured on a 277-item human-judged blind set) survive
+Two contract rules (measured on a 277-item blind set) survive
 verbatim from the source engine:
 
 1. Region tokens in the TITLE bind first — "(AMER)" or ", Korea" name the
    served market regardless of office; an eligible token alongside rescues.
 2. A bare "Remote" location consults the DESCRIPTION before defaulting
    eligible — skipping this consult admitted 10 junk roles (precision
-   74.6% -> 65.2%) before the blind-set regression caught it.
+   74.6% -> 65.2% against the automated judge in use at the time) before the
+   blind-set regression caught it.
 """
 
 from __future__ import annotations

--- a/src/career_os/services/geo/presets.py
+++ b/src/career_os/services/geo/presets.py
@@ -5,9 +5,11 @@ Everything in this module is geographic VOCABULARY, not code: the engine in
 profile swaps the geography.
 
 - ``FRANKFURT_PROFILE`` — the reference preset. Its pattern strings are copied
-  character-for-character from the measured source engine (93.6% recall /
-  74.6% precision on a 277-item human-judged blind set); they ARE the measured
-  artifact, so do not "clean them up".
+  character-for-character from the measured source engine; they ARE the measured
+  artifact, so do not "clean them up". The 93.6% / 74.6% figures previously
+  quoted here were measured against an AUTOMATED judge, not hand labels — see
+  ``tests/eval/geo/fixtures/README.md``. Against hand labels the same engine
+  measures 81.4% / 59.3% (79.1% / 53.1% on the production offices path).
 - ``US_REMOTE_PROFILE`` — an ILLUSTRATIVE contrast preset for a US-based
   remote worker. It exists to prove the engine is config-driven (same input,
   different profile, different verdict). It is demonstration data, not legal

--- a/tests/eval/geo/fixtures/README.md
+++ b/tests/eval/geo/fixtures/README.md
@@ -1,7 +1,12 @@
 # The Frankfurt-preset reference set
 
-A 277-posting sample of real scraped job postings, human-judged GO/SKIP by one
-contributor whose home base is the `FRANKFURT_PROFILE` preset. Its single
+A 277-posting sample of real scraped job postings, labelled GO/SKIP against one
+contributor's search, whose home base is the `FRANKFURT_PROFILE` preset.
+
+> **What produced these labels.** `judgements.json` holds an **automated
+> (LLM) judge's** verdicts, gated at 90% agreement on a control stratum — NOT
+> hand labels. That distinction was blurred in earlier versions of this file and
+> is worth stating plainly, because it changes what the numbers below mean. Its single
 purpose is to prove the geo engine did **not** change behaviour during the port
 from the source project: the committed reference freezes the source engine's
 class assignment for every item, and CI asserts the generic engine +
@@ -11,15 +16,26 @@ measured precision/recall floor.
 **These labels are NOT canonical ground truth for anyone else's job search.**
 GO/SKIP encodes one person's eligibility, commute tolerance and role taste.
 Likewise the thresholds in `reference_assignments.json` (`recall >= 0.93`,
-`precision >= 0.74`) are that set's measured numbers — not universal quality
-bars.
+`precision >= 0.74`) are that set's measured numbers against the automated
+judge — not universal quality bars, and **not the engine's accuracy against
+human labels**.
+
+That second caveat is not theoretical. In August 2026 the same contributor
+hand-labelled all 277 items himself. Scored against **his** labels rather than
+the judge's, the same engine on the same data measures **81.4% recall / 59.3%
+precision** — and **79.1% / 53.1%** on the full-description, authoritative-
+offices path that runs in production. The judge had been flattering the engine.
+
+The thresholds here are therefore a **regression floor against the judge**:
+useful for proving the port did not change behaviour, which is what this fixture
+exists for. They are not a quality claim, and should not be quoted as one.
 
 ## Files
 
 | File | What it is |
 |------|------------|
 | `blind_items.json` | 277 scrubbed postings: `{id, company, title, location, remote, desc}` |
-| `judgements.json` | Human GO/SKIP verdict + score + reason per item id |
+| `judgements.json` | **Automated-judge** GO/SKIP verdict + score + reason per item id (90% control-stratum agreement gate) |
 | `reference_assignments.json` | Frozen source-engine class (`eyas_class`), its generic rename (`generic_class`), and the frozen `role_keep` flag per item, plus the class map and thresholds |
 | `GENERATION_LOG.md` | The provenance record: scrub proof, behaviour-neutrality result, environment fingerprint |
 | `generate_reference.py` | One-shot regeneration script — requires a local Eyas checkout; **not run by CI** |
@@ -41,8 +57,10 @@ Your search is not this search. To gate the engine on your own data:
 
 1. **Export** your scraped postings to the same shape as `blind_items.json`:
    `{id, company, title, location, remote, desc}` (one JSON list).
-2. **Label** each posting yourself as GO or SKIP in a `judgements.json`-shaped
-   file: `{"<id>": {"id", "verdict": "GO"|"SKIP", "score", "reason"}}`.
+2. **Label** each posting as GO or SKIP in a `judgements.json`-shaped file:
+   `{"<id>": {"id", "verdict": "GO"|"SKIP", "score", "reason"}}`. If you use an
+   LLM to label, record that — and hand-label a sample to check it. The gap
+   between the two is itself a finding; here it was 14 points of precision.
 3. **Point** `../replay.py`'s loaders at your files (or drop your files in
    place of these) and classify with your own `GeoProfile` — see
    `career_os.services.geo.profile.GeoProfile.from_home_tokens`.

--- a/tests/eval/geo/fixtures/reference_assignments.json
+++ b/tests/eval/geo/fixtures/reference_assignments.json
@@ -1401,5 +1401,6 @@
       "generic_class": "foreign",
       "role_keep": true
     }
-  }
+  },
+  "thresholds_basis": "Measured against judgements.json — an AUTOMATED (LLM) judge gated at 90% agreement on a control stratum. NOT hand labels, and NOT the engine's accuracy. These are a regression floor proving the port did not change behaviour. Against the same contributor's hand labels the engine measures 81.4%/59.3%, and 79.1%/53.1% on the production offices path (2026-08-10)."
 }

--- a/tests/eval/geo/test_blindset_regression.py
+++ b/tests/eval/geo/test_blindset_regression.py
@@ -7,9 +7,26 @@ Three gates over the scrubbed 277-item Frankfurt-preset reference set
    the frozen Eyas class assignment on every item. This is the acceptance
    criterion for the port: byte-identical behaviour, not "close enough".
 2. **Precision/recall floor** — the joint role+geo KEEP decision must hold the
-   set's measured quality (thresholds read from the reference file, published
-   Eyas numbers: 93.6% recall / 74.6% precision). ``role_keep`` is frozen in
-   the reference because only the GEO engine was ported.
+   floor recorded in the reference file (``recall >= 0.93``, ``precision >=
+   0.74``). ``role_keep`` is frozen in the reference because only the GEO engine
+   was ported.
+
+   **Read this before quoting those numbers anywhere.** They are measured
+   against ``judgements.json``, which holds an **automated (LLM) judge's**
+   verdicts — not hand labels. They are a *regression floor for the port*, which
+   is what this fixture exists to prove, and they are **not** the engine's
+   accuracy.
+
+   Against the same contributor's own hand labels (August 2026, all 277 items)
+   the same engine measures **81.4% recall / 59.3% precision**, and **79.1% /
+   53.1%** on the full-description + authoritative-offices path that runs in
+   production. The judge had been flattering the engine by roughly 14 points of
+   precision.
+
+   An earlier version of this docstring described 93.6/74.6 as the "published"
+   numbers, which invited exactly the misreading this paragraph now prevents: a
+   green CI gate is the strongest available signal that something was checked,
+   so it must be unambiguous about *what* it checked.
 3. **Fixture integrity** — the scrub gate stays alive: the committed fixture
    must keep matching zero PII/tracking patterns, and the provenance log's
    ``SCRUB-PROOF: PASS`` line cannot be quietly dropped.
@@ -66,8 +83,14 @@ def test_differential_matches_frozen_eyas_reference():
 # ---------------------------------------------------------------------------
 
 
-def test_precision_recall_hold_published_floor():
-    """Recall/precision on the blind set must hold the thresholds frozen in the reference."""
+def test_precision_recall_hold_the_judge_regression_floor():
+    """Hold the thresholds frozen in the reference.
+
+    Named for what it measures: agreement with the AUTOMATED judge, which is the
+    port-regression signal. It is deliberately NOT called a "published floor" —
+    that phrasing is what let 93.6/74.6 travel onto a CV and a public site as if
+    it were the engine's accuracy.
+    """
     items = load_items()
     judgements = load_judgements()
     reference = load_reference()
@@ -88,11 +111,11 @@ def test_precision_recall_hold_published_floor():
 
     assert recall >= thresholds["recall"], (
         f"recall {recall:.1%} fell below the {thresholds['recall']:.0%} floor "
-        f"(Eyas published 93.6% on this set; kept {go_kept}/{total_go} GO items)"
+        f"(measured vs the AUTOMATED judge, not hand labels; kept {go_kept}/{total_go} GO items)"
     )
     assert precision >= thresholds["precision"], (
         f"precision {precision:.1%} fell below the {thresholds['precision']:.0%} floor "
-        f"(Eyas published 74.6% on this set; {go_kept} GO of {len(keep)} kept)"
+        f"(measured vs the AUTOMATED judge, not hand labels; {go_kept} GO of {len(keep)} kept)"
     )
 
 


### PR DESCRIPTION
**The gate scores against `judgements.json` — an automated (LLM) judge, gated at 90% agreement on a control stratum.** Seven places in this repo described that as *"human-judged"*, and the gate's own docstring called 93.6% / 74.6% the *"published Eyas numbers"* — presenting a judge-agreement floor as the engine's accuracy.

**That framing travelled.** It reached a CV and a public site before anyone noticed. A green CI gate is the strongest available signal that something was checked, so it has to be unambiguous about *what* it checked.

The numbers aren't wrong for what they measure. The description was.

| measured against | recall | precision |
|---|---|---|
| the automated judge (what this gate uses) | 93.6% | 74.6% |
| the same contributor's hand labels, all 277 items | 81.4% | 59.3% |
| hand labels, full-description + authoritative-offices (**production path**) | **79.1%** | **53.1%** |

The judge had been flattering the engine by roughly 14 points of precision.

## Thresholds unchanged, deliberately

`recall >= 0.93`, `precision >= 0.74` stay. They are a valid regression floor proving the port did not change behaviour — which is what this fixture exists for. Lowering them to the hand-labelled figures would be wrong twice over: **the hand labels are not in this repo**, and a threshold set to whatever the code currently scores is a rubber stamp, not a gate.

## Changed

- **`test_blindset_regression.py`** — docstring states the basis and the hand-labelled contrast; both assertion messages now say *"measured vs the AUTOMATED judge, not hand labels"*; test renamed from `test_precision_recall_hold_published_floor` → `..._hold_the_judge_regression_floor`, because *"published floor"* is the exact phrasing that let the number travel.
- **`fixtures/README.md`** — leads with what produced the labels; the file table now reads *"Automated-judge verdict"*; the caveat section carries the hand-labelled numbers; the build-your-own guide tells readers that if they label with an LLM they should hand-label a sample, since **the gap is itself a finding** — here, 14 points.
- **`fixtures/reference_assignments.json`** — new `thresholds_basis` field, so the meaning travels with the data rather than living only in prose.
- **`services/geo/presets.py`** — dropped "human-judged" from the public source.
- **`discovery/prefilter.py`** — the geo gate's recall named as judge-measured, with the hand-labelled figure beside it, since that is the number to weigh the `geo_drop_foreign` trade-off against.
- **`services/geo/classifier.py`**, **`docs/guides/geo-eligibility.md`** — same descriptor fix. The 74.6% → 65.2% incident stays (it is true) with its basis anchored so it isn't read as current accuracy.

## Verified

- full-repo grep for `human-judged` returns **nothing** outside dated session logs (historical records, left alone)
- eval gate: **7 passed** · geo/prefilter: **282 passed, 3 skipped**
- PII scrub clean

Part of G-1557 / G-1560.
